### PR TITLE
add sonarcloud support for hedwig (#28)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
       SonarCloud: "SonarCloudConnection"
       organization: "speedcm"
       scannerMode: "MSBuild"
-      projectKey: "xExperiments"
+      projectKey: "xhedwig"
   #
   # Download dependencies
   # 

--- a/hedwig.csproj
+++ b/hedwig.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp2.2</TargetFramework>
-		<ProjectGuid>{688cf6c2-2ca0-40c0-91bb-89cab7280562}</ProjectGuid>
+		<ProjectGuid>{b2868f77-a23a-467e-8225-53ef3c053ee1}</ProjectGuid>
 		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
 		<TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
 		<IsPackable>false</IsPackable>


### PR DESCRIPTION
The driver file was changed to publish to the sonarcloud xhedwig project (temporary sonar project).  Each project in sonarcloud requires a unique GUID.  The GUID was changed for the hedwig project to be unique (not the same as the prototype project). 