### PR TITLE
Add print stylesheet

### DIFF
--- a/src/Hedwig/ClientApp/src/assets/styles/index.scss
+++ b/src/Hedwig/ClientApp/src/assets/styles/index.scss
@@ -34,3 +34,4 @@
 // Import theme custom styles
 
 @import 'uswds-theme-custom-styles';
+@import 'print';

--- a/src/Hedwig/ClientApp/src/assets/styles/print.scss
+++ b/src/Hedwig/ClientApp/src/assets/styles/print.scss
@@ -1,0 +1,27 @@
+@media print {
+  @page { size:8.5in 11in; margin: 2cm }
+  
+  header {
+    @include u-display('none');
+  }
+
+  // <Tag />
+  .usa-tag {
+    background-color: #ffffff;
+    @include u-text($theme-color-base-ink);
+  }
+
+  // <Link />
+  .usa-link {
+    &, &:visited, &:link {
+      @include u-text('no-underline');
+      @include u-text($theme-color-base-ink);
+    }
+  }
+
+  .print-cancel {
+    float: right;
+    position: relative;
+    top: 15px;
+  }
+}


### PR DESCRIPTION
Simplify implementation for User story #3. This PR adds a print style sheet with the use of CSS media queries.

This implementation has a known limitation on being able to render a display on Firefox in the browser. This is due to how Firefox implements printing (versus Chrome-based browsers). For an implementation that provides a potential solution, see #34 (on branch 3-print-roster-with-context).