### PR TITLE
Add graphql frontend auth (97)

### DIFF
--- a/src/Hedwig/ClientApp/package.json
+++ b/src/Hedwig/ClientApp/package.json
@@ -51,7 +51,7 @@
 		"eject": "react-scripts eject",
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
-		"apollo-generate": "NODE_TLS_REJECT_UNAUTHORIZED=0 apollo codegen:generate --excludes=node_modules/* --includes=**/*.tsx --endpoint https://localhost:5001/graphql --target typescript --tagName gql --outputFlat src/generated --passthroughCustomScalars --customScalarsPrefix OEC"
+		"apollo-generate": "NODE_TLS_REJECT_UNAUTHORIZED=0 npx apollo codegen:generate --excludes=node_modules/* --includes=**/*.tsx --endpoint https://backend:5001/graphql --target typescript --tagName gql --outputFlat src/generated --passthroughCustomScalars --customScalarsPrefix OEC"
 	},
 	"husky": {
 		"hooks": {

--- a/src/Hedwig/ClientApp/src/containers/Reports/Reports.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/Reports.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import { useQuery } from '@apollo/react-hooks';
+import useAuthQuery from '../../hooks/useAuthQuery';
 import { gql } from 'apollo-boost';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 import { Table, TableProps } from '../../components/Table/Table';
 import InlineIcon from '../../components/InlineIcon/InlineIcon';
-import { ReportsQuery, ReportsQuery_user_reports } from '../../generated/ReportsQuery';
+import { ReportsQuery, ReportsQuery_me_reports } from '../../generated/ReportsQuery';
 import monthFormatter from '../../utils/monthFormatter';
 import dateFormatter from '../../utils/dateFormatter';
 
 export const REPORTS_QUERY = gql`
 	query ReportsQuery {
-		user(id: 1) {
+		me {
 			reports {
 				... on CdcReportType {
 					id
@@ -30,17 +30,17 @@ export const REPORTS_QUERY = gql`
 `;
 
 export default function Reports() {
-	const { loading, error, data } = useQuery<ReportsQuery>(REPORTS_QUERY);
+	const { loading, error, data } = useAuthQuery<ReportsQuery>(REPORTS_QUERY);
 
-	if (loading || error || !data || !data.user) {
+	if (loading || error || !data || !data.me) {
 		return <div className="Reports"></div>;
 	}
 
-	const unsubmittedReportsCount = data.user.reports.filter(report => !report.submittedAt).length;
+	const unsubmittedReportsCount = data.me.reports.filter(report => !report.submittedAt).length;
 
-	const reportsTableProps: TableProps<ReportsQuery_user_reports> = {
+	const reportsTableProps: TableProps<ReportsQuery_me_reports> = {
 		id: 'reports-table',
-		data: data.user.reports,
+		data: data.me.reports,
 		rowKey: row => row.id,
 		columns: [
 			{

--- a/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import { useQuery } from '@apollo/react-hooks';
+import useAuthQuery from '../../hooks/useAuthQuery';
 import { gql } from 'apollo-boost';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 import { Table, TableProps } from '../../components/Table/Table';
-import { RosterQuery, RosterQuery_user_sites_enrollments } from '../../generated/RosterQuery';
+import { RosterQuery, RosterQuery_me_sites_enrollments } from '../../generated/RosterQuery';
 import nameFormatter from '../../utils/nameFormatter';
 import dateFormatter from '../../utils/dateFormatter';
 import Tag from '../../components/Tag/Tag';
 
 export default function Roster() {
-	const { loading, error, data } = useQuery<RosterQuery>(gql`
+	const { loading, error, data } = useAuthQuery<RosterQuery>(gql`
 		query RosterQuery {
-			user(id: 1) {
+			me {
 				sites {
 					id
 					name
@@ -38,14 +38,14 @@ export default function Roster() {
 		}
 	`);
 
-	if (loading || error || !data || !data.user) {
+	if (loading || error || !data || !data.me) {
 		return <div className="Roster"></div>;
 	}
 
-	const site = data.user.sites[0];
+	const site = data.me.sites[0];
 	const enrollments = site.enrollments;
 
-	const rosterTableProps: TableProps<RosterQuery_user_sites_enrollments> = {
+	const rosterTableProps: TableProps<RosterQuery_me_sites_enrollments> = {
 		id: 'roster-table',
 		data: enrollments,
 		rowKey: row => row.id,

--- a/src/Hedwig/ClientApp/src/generated/AppQuery.ts
+++ b/src/Hedwig/ClientApp/src/generated/AppQuery.ts
@@ -6,18 +6,18 @@
 // GraphQL query operation: AppQuery
 // ====================================================
 
-export interface AppQuery_user_reports {
-	__typename: 'CdcReportType';
-	id: number;
-	submittedAt: OECDate | null;
+export interface AppQuery_me_reports {
+  __typename: "CdcReportType";
+  id: number;
+  submittedAt: OECDate | null;
 }
 
-export interface AppQuery_user {
-	__typename: 'UserType';
-	firstName: string;
-	reports: AppQuery_user_reports[];
+export interface AppQuery_me {
+  __typename: "UserType";
+  firstName: string;
+  reports: AppQuery_me_reports[];
 }
 
 export interface AppQuery {
-	user: AppQuery_user | null;
+  me: AppQuery_me | null;
 }

--- a/src/Hedwig/ClientApp/src/generated/ReportsQuery.ts
+++ b/src/Hedwig/ClientApp/src/generated/ReportsQuery.ts
@@ -2,33 +2,33 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { FundingSource } from './globalTypes';
+import { FundingSource } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: ReportsQuery
 // ====================================================
 
-export interface ReportsQuery_user_reports_organization {
-	__typename: 'OrganizationType';
-	id: number;
-	name: string;
+export interface ReportsQuery_me_reports_organization {
+  __typename: "OrganizationType";
+  id: number;
+  name: string;
 }
 
-export interface ReportsQuery_user_reports {
-	__typename: 'CdcReportType';
-	id: number;
-	type: FundingSource;
-	period: OECDate;
-	dueAt: OECDate;
-	submittedAt: OECDate | null;
-	organization: ReportsQuery_user_reports_organization;
+export interface ReportsQuery_me_reports {
+  __typename: "CdcReportType";
+  id: number;
+  type: FundingSource;
+  period: OECDate;
+  dueAt: OECDate;
+  submittedAt: OECDate | null;
+  organization: ReportsQuery_me_reports_organization;
 }
 
-export interface ReportsQuery_user {
-	__typename: 'UserType';
-	reports: ReportsQuery_user_reports[];
+export interface ReportsQuery_me {
+  __typename: "UserType";
+  reports: ReportsQuery_me_reports[];
 }
 
 export interface ReportsQuery {
-	user: ReportsQuery_user | null;
+  me: ReportsQuery_me | null;
 }

--- a/src/Hedwig/ClientApp/src/generated/RosterQuery.ts
+++ b/src/Hedwig/ClientApp/src/generated/RosterQuery.ts
@@ -8,7 +8,7 @@ import { FundingSource } from "./globalTypes";
 // GraphQL query operation: RosterQuery
 // ====================================================
 
-export interface RosterQuery_user_sites_enrollments_child {
+export interface RosterQuery_me_sites_enrollments_child {
   __typename: "ChildType";
   firstName: string;
   middleName: string | null;
@@ -17,34 +17,34 @@ export interface RosterQuery_user_sites_enrollments_child {
   suffix: string | null;
 }
 
-export interface RosterQuery_user_sites_enrollments_fundings {
+export interface RosterQuery_me_sites_enrollments_fundings {
   __typename: "FundingType";
   entry: OECDate;
   exit: OECDate | null;
   source: FundingSource;
 }
 
-export interface RosterQuery_user_sites_enrollments {
+export interface RosterQuery_me_sites_enrollments {
   __typename: "EnrollmentType";
   id: number;
   entry: OECDate;
   exit: OECDate | null;
-  child: RosterQuery_user_sites_enrollments_child;
-  fundings: RosterQuery_user_sites_enrollments_fundings[];
+  child: RosterQuery_me_sites_enrollments_child;
+  fundings: RosterQuery_me_sites_enrollments_fundings[];
 }
 
-export interface RosterQuery_user_sites {
+export interface RosterQuery_me_sites {
   __typename: "SiteType";
   id: number;
   name: string;
-  enrollments: RosterQuery_user_sites_enrollments[];
+  enrollments: RosterQuery_me_sites_enrollments[];
 }
 
-export interface RosterQuery_user {
+export interface RosterQuery_me {
   __typename: "UserType";
-  sites: RosterQuery_user_sites[];
+  sites: RosterQuery_me_sites[];
 }
 
 export interface RosterQuery {
-  user: RosterQuery_user | null;
+  me: RosterQuery_me | null;
 }

--- a/src/Hedwig/ClientApp/src/hooks/useAuthQuery.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useAuthQuery.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+import { useQuery, QueryHookOptions } from '@apollo/react-hooks';
+import { DocumentNode } from 'graphql';
+import LoginContext from '../contexts/Login/LoginContext';
+import { QueryResult } from '@apollo/react-common';
+
+export default <T>(query: DocumentNode, options: QueryHookOptions = {}): QueryResult<T> => {
+  const { accessToken } = useContext(LoginContext);
+
+  return useQuery<T>(query, {
+    ...options,
+    context: {
+      headers: {
+        Authorization: accessToken ? `Bearer ${accessToken}` : ''
+      }
+    },
+    fetchPolicy: 'cache-and-network'
+  });
+}


### PR DESCRIPTION
Include access token as a Bearer Token in all graphql requests.

Create a wrapper around `useQuery` hook so queries requiring authentication will instead use `useAuthQuery` -- with the same API.

Update queries from `user(id: 1)` to `me`.

Initial page load will show no data and "Log in" in the header. Clicking on login will redirect user to IS and then redirect back to roster page. After some time (initial load is slow) the data will load and "Log in" will be replaced with "Hi, Chris". Currently, no loading sign exists for after redirect.