### PR TITLE
Modify GraphQL.Authorization to support iptables-like permissions

### DIFF
--- a/src/Hedwig/Security/AuthorizationEvaluator.cs
+++ b/src/Hedwig/Security/AuthorizationEvaluator.cs
@@ -1,0 +1,127 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationEvaluator.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Summary of Changes
+ * - Add AuthorizationRules parameter to Evaluate.
+ * - Reimplement Evaluate using AuthorizationRuleResult.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using GraphQL.Authorization;
+
+namespace Hedwig.Security
+{
+	public interface IAuthorizationEvaluator
+	{
+		Task<AuthorizationResult> Evaluate(
+				ClaimsPrincipal principal,
+				object userContext,
+				Dictionary<string, object> arguments,
+				AuthorizationRules rules);
+	}
+	public class AuthorizationEvaluator : IAuthorizationEvaluator
+	{
+		private readonly AuthorizationSettings _settings;
+
+		public AuthorizationEvaluator(AuthorizationSettings settings)
+		{
+				_settings = settings;
+		}
+
+		public async Task<AuthorizationResult> Evaluate(
+			ClaimsPrincipal principal,
+			object userContext,
+			Dictionary<string, object> arguments,
+			AuthorizationRules _rules)
+		{
+			var context = new AuthorizationContext();
+			context.User = principal ?? new ClaimsPrincipal(new ClaimsIdentity());
+			context.UserContext = userContext;
+			context.Arguments = arguments;
+			var rules = _rules as IEnumerable<AuthorizationRule>;
+			
+			foreach (var rule in rules)
+			{
+				var policy = rule.Policy;
+				var action = rule.Action;
+				var authorizationPolicy = _settings.GetPolicy(policy);
+				// Check if authorization rule was added without policy
+				// Should be the final rule in the permissions block
+				if (authorizationPolicy == null)
+				{
+					// Process final rule assuming no errors
+					// Implies final rule must be "Allow" or "Deny"
+					AuthorizationRuleResult result = action.Assess(false);
+					if (result == AuthorizationRuleResult.Success)
+					{
+						return AuthorizationResult.Success();
+					}
+					else if (result == AuthorizationRuleResult.Failure)
+					{
+						return AuthorizationResult.Fail(context.Errors);
+					}
+					else
+					{
+						// Final rule must succeed or fail
+						throw new Exception();
+					}
+				}
+				else
+				{
+					foreach (var requirement in authorizationPolicy.Requirements)
+					{
+						// Because we are allowing "DenyNot" and "AllowNot" rules
+						// but AuthorizationRequirement.Authorize only returns a
+						// completed task and adds an error if and only if there
+						// is an error, we need to check the number of errors to
+						// determine if the most recent requirement succeeded.
+						var startingCount = context.Errors.Count();
+						await requirement.Authorize(context);
+						var endingCount = context.Errors.Count();
+						var didError = startingCount != endingCount;
+						AuthorizationRuleResult result = action.Assess(didError);
+						if (result == AuthorizationRuleResult.Success)
+						{
+							return AuthorizationResult.Success();
+						}
+						else if (result == AuthorizationRuleResult.Failure)
+						{
+							return AuthorizationResult.Fail(context.Errors);
+						}
+						else // AuthorizationRuleResult.Continue
+						{
+							continue;
+						}
+					}
+				}
+			}
+			// there are no rules applied, so succeed
+			return AuthorizationResult.Success();
+		}
+	}
+}

--- a/src/Hedwig/Security/AuthorizationRule.cs
+++ b/src/Hedwig/Security/AuthorizationRule.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Hedwig.Security
+{
+  public class AuthorizationRule
+  {
+    public string Policy { get; private set; }
+
+    public AuthorizationAction Action { get; private set; }
+
+    public AuthorizationRule(string policy, AuthorizationAction action)
+    {
+      Policy = policy;
+      Action = action;
+    }
+  }
+
+  public enum AuthorizationAction
+  {
+    Deny,
+    DenyNot,
+    Allow,
+    AllowNot
+  }
+
+  public enum AuthorizationRuleResult
+  {
+    Success,
+    Failure,
+    Continue
+  }
+
+  public static class AuthorizationActionExtensions {
+    public static AuthorizationRuleResult Assess(this AuthorizationAction action, bool error)
+    {
+      switch (action)
+      {
+          case AuthorizationAction.Allow:
+            return error ? AuthorizationRuleResult.Continue : AuthorizationRuleResult.Success;
+          case AuthorizationAction.Deny:
+            return error ? AuthorizationRuleResult.Continue : AuthorizationRuleResult.Failure;
+          case AuthorizationAction.AllowNot:
+            return error ? AuthorizationRuleResult.Success : AuthorizationRuleResult.Continue;
+          case AuthorizationAction.DenyNot:
+            return error ? AuthorizationRuleResult.Failure : AuthorizationRuleResult.Continue;
+          default:
+            // Enum type not found
+            throw new Exception();
+      }
+    }
+  }
+}

--- a/src/Hedwig/Security/AuthorizationRules.cs
+++ b/src/Hedwig/Security/AuthorizationRules.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Hedwig.Security
+{
+  public class AuthorizationRules : IEnumerable<AuthorizationRule>
+  {
+    private readonly List<AuthorizationRule> _rulesSet = new List<AuthorizationRule>();
+
+    public AuthorizationRules Allow(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.Allow));
+      return this;
+    }
+
+    public AuthorizationRules Deny(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.Deny));
+      return this;
+    }
+
+    public AuthorizationRules AllowNot(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.AllowNot));
+      return this;
+    }
+
+    public AuthorizationRules DenyNot(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.DenyNot));
+      return this;
+    }
+
+    public IEnumerator<AuthorizationRule> GetEnumerator()
+    {
+        return _rulesSet.GetEnumerator();
+    }
+
+    private IEnumerator _GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return _GetEnumerator();
+    }
+  }
+}

--- a/src/Hedwig/Security/AuthorizationValidationRule.cs
+++ b/src/Hedwig/Security/AuthorizationValidationRule.cs
@@ -1,0 +1,116 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationValidationRule.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+ /*
+  * Summary of Changes
+  * - Display only last error.
+  */
+
+using System.Linq;
+using GraphQL;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Authorization;
+
+namespace Hedwig.Security
+{
+    public class AuthorizationValidationRule : IValidationRule
+    {
+        private readonly IAuthorizationEvaluator _evaluator;
+
+        public AuthorizationValidationRule(IAuthorizationEvaluator evaluator)
+        {
+            _evaluator = evaluator;
+        }
+
+        public INodeVisitor Validate(ValidationContext context)
+        {
+            var userContext = context.UserContext as IProvideClaimsPrincipal;
+
+            return new EnterLeaveListener(_ =>
+            {
+                var operationType = OperationType.Query;
+
+                // this could leak info about hidden fields or types in error messages
+                // it would be better to implement a filter on the Schema so it
+                // acts as if they just don't exist vs. an auth denied error
+                // - filtering the Schema is not currently supported
+
+                _.Match<Operation>(astType =>
+                {
+                    operationType = astType.OperationType;
+
+                    var type = context.TypeInfo.GetLastType();
+                    CheckAuth(astType, type, userContext, context, operationType);
+                });
+
+                _.Match<ObjectField>(objectFieldAst =>
+                {
+                    var argumentType = context.TypeInfo.GetArgument().ResolvedType.GetNamedType() as IComplexGraphType;
+                    if (argumentType == null)
+                        return;
+
+                    var fieldType = argumentType.GetField(objectFieldAst.Name);
+                    CheckAuth(objectFieldAst, fieldType, userContext, context, operationType);
+                });
+
+                _.Match<Field>(fieldAst =>
+                {
+                    var fieldDef = context.TypeInfo.GetFieldDef();
+
+                    if (fieldDef == null) return;
+
+                    // check target field
+                    CheckAuth(fieldAst, fieldDef, userContext, context, operationType);
+                    // check returned graph type
+                    CheckAuth(fieldAst, fieldDef.ResolvedType.GetNamedType(), userContext, context, operationType);
+                });
+            });
+        }
+
+        private void CheckAuth(
+            INode node,
+            IProvideMetadata type,
+            IProvideClaimsPrincipal userContext,
+            ValidationContext context,
+            OperationType operationType)
+        {
+            if (type == null || !type.RequiresAuthorization()) return;
+            var result = type
+                .Authorize(userContext?.User, context.UserContext, context.Inputs, _evaluator)
+                .GetAwaiter()
+                .GetResult();
+
+            if (result.Succeeded) return;
+
+            var error = string.Join("\n", result.Errors.LastOrDefault());
+
+            context.ReportError(new ValidationError(
+                context.OriginalQuery,
+                "authorization",
+                $"You are not authorized to run this {operationType.ToString().ToLower()}.\n{error}",
+                node));
+        }
+    }
+}

--- a/src/Hedwig/Security/IAuthorizedGraphType.cs
+++ b/src/Hedwig/Security/IAuthorizedGraphType.cs
@@ -1,0 +1,7 @@
+namespace Hedwig.Security
+{
+  public interface IAuthorizedGraphType
+  {
+      AuthorizationRules Permissions(AuthorizationRules rules);
+  }
+}

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -104,8 +104,8 @@ namespace Hedwig
 							ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
 						};
 					});
-			services.AddSingleton<IAuthorizationEvaluator, AuthorizationEvaluator>();
-			services.AddTransient<IValidationRule, AuthorizationValidationRule>();
+			services.AddSingleton<Hedwig.Security.IAuthorizationEvaluator, Hedwig.Security.AuthorizationEvaluator>();
+			services.AddTransient<IValidationRule, Hedwig.Security.AuthorizationValidationRule>();
 			services.AddSingleton(s => Permissions.GetAuthorizationSettings());
 		}
 	}


### PR DESCRIPTION
Due to the limitations of GraphQL.Authorization, this PR pulls several key files into our code base and modifies them to support an authorization flow similar to iptables.

Files that are pulled in are denoted with the GraphQL.Authorization's license at the start of the file with a link to the fixed Github file.

This needs tests, but I wanted to get it out there to see if the permissions flow makes sense.

How it would work in practice:

In a `HedwigGraphType` class, such as `UserType` is must implement the `IAuthorizedGraphType` interface and implement the `Permissions` method like so
```cs
public AuthorizationRules Permissions(AuthorizationRules rules)
{
	rules.DenyNot("IsAuthenticatedUserPolicy");
	rules.Allow();
	return rules;
}
```