### PR TITLE
Add API endpoint protection (106)

### DIFF
--- a/auth-dev/OpenIDProvider/Config.cs
+++ b/auth-dev/OpenIDProvider/Config.cs
@@ -24,7 +24,9 @@ namespace OpenIDProvider
 					Claims = new []
 					{
 						new Claim("name", "Voldemort"),
-						new Claim("allowed_apps", "hedwig")
+						new Claim("allowed_apps", "hedwig"),
+						new Claim("role", "developer"),
+						new Claim("role", "oec-admin"),
 					}
 				}
 			};
@@ -39,11 +41,30 @@ namespace OpenIDProvider
 			};
 	}
 
+	// http://docs.identityserver.io/en/latest/topics/resources.html#defining-api-resources
 	public static IEnumerable<ApiResource> GetApis()
 	{
 	  return new List<ApiResource>
 			{
-				new ApiResource("hedwig_backend", "Hedwig API")
+				new ApiResource
+            {
+                Name = "hedwig_backend",
+
+                Description = "Hedwig API",
+
+                // include the following using claims in access token (in addition to subject id)
+                UserClaims = { "role" },
+
+								Scopes =
+                {
+                    new Scope()
+                    {
+                        Name = "hedwig_backend",
+                        DisplayName = "Full access to Hedwig API",
+                        UserClaims = new [] { "role", "allowed_apps" }
+                    }
+                }
+            }
 			};
 	}
 

--- a/docs/graphql-authorization_10_24_2019.md
+++ b/docs/graphql-authorization_10_24_2019.md
@@ -1,0 +1,35 @@
+# Security and Permissions Flow
+
+## Context
+`Hedwig` uses GraphQL and Dotnet Core. There is one open-source library (`GraphQL.Authorization`) that provides Authorization to the Dotnet+GraphQL world. It currently is in preview mode for v3, which requires Dotnet Core 3.0. `Hedwig` uses Dotnet Core 2.2. `Hedwig` requires robust permissioning on API endpoints, and the developer desire authorization requirements to be semantically meaningful. `GraphQL.Authorization` only implements on conjunction requirements-base policies. Disjunction or heirarchial policies must be implemented within individual requirement classes.
+
+## Decision
+The team decided to pull down source code from `GraphQL.Authorization` to provide customization to the authorization flow.
+
+### Flow
+Authorization in GraphQL is implemented as a validation rule (see `AuthorizationValidationRule.cs`). This class walks the GraphQL AST and validates each node against the permissions registered on that node. `AuthorizationValidationRule` calls the `Authorize` method on the node type. This is an extension method provided by `AuthorizationMetadataExensions`.
+
+`AuthorizationMetadataExensions#Authorize` retrieves the permission rules registered on the node type and calls `AuthorizationEvaluator#Evalute`.
+
+Permission rules are retrieved by calling the `Permissions` method which is implemented by all types implementing the `IAuthorizedGraphType`. This method returns a `AuthorizationRules` object.
+
+`AuthorizationRules` is an enumerable collection of `AuthorizationRule` objects. An `AuthorizationRule` is a combination of an `AuthorizationAction` and an `IAuthorizationPolicy`.
+
+`AuthorizationEvaluator#Evalute` iterates over the rules in the `AuthorizationRules` object. For each rule, it iterates over the requirements. On each requirement, `Evaluate` determines whether an error occured. If any one of the requirements produced an error, the result for the policy is an error. Otherwise, the result of the policy is no error. The action corresponding to this `AuthorizationRule` is then used to determine whether to succeed, fail, or continue. `AuthorizationAction`s have an extension method defined `Assess` that takes in a single boolean corresponding to whether the result of the policy was an error. `Assess` returns an `AuthorizationRuleResult`.
+
+The first `AuthorizationRuleResult` that is not `Continue` (i.e. `Success` or `Failure`) reports to `Evaluate` accordingly. If the result is `Continue` the iteration over `AuthorizationRules` continues. (The final rule should be `Allow` or `Deny` to ensure that every request receives a final determination.)
+
+Control is returned to `AuthorizationValidationRule` where the request continues to the query or an error is reported and an early response is sent.
+
+## Status
+* Proposed
+* __Accepted__
+* Rejected
+* Superceded
+* Accepted (Partially superceded)
+
+## Consequences
+* Upstream changes to `GraphQL.Authorization` must be manually added.
+* `Hedwig` gets access to v3 features of `GraphQL.Authorization`.
+* More semantic permissions policy flow.
+* Greater customization possibilities for authorization flow.

--- a/src/Hedwig/Schema/Types/ChildType.cs
+++ b/src/Hedwig/Schema/Types/ChildType.cs
@@ -1,12 +1,13 @@
 using System;
 using Hedwig.Models;
 using Hedwig.Repositories;
+using Hedwig.Security;
 using GraphQL.DataLoader;
 using GraphQL.Types;
 
 namespace Hedwig.Schema.Types
 {
-	public class ChildType : TemporalGraphType<Child>
+	public class ChildType : TemporalGraphType<Child>, IAuthorizedGraphType
 	{
 		public ChildType(IDataLoaderContextAccessor dataLoader, IFamilyRepository families)
 		{
@@ -40,6 +41,15 @@ namespace Hedwig.Schema.Types
 					return loader.LoadAsync(familyId);
 				}
 			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
 		}
 	}
 }

--- a/src/Hedwig/Schema/Types/EnrollmentType.cs
+++ b/src/Hedwig/Schema/Types/EnrollmentType.cs
@@ -1,12 +1,13 @@
 using System;
 using Hedwig.Models;
 using Hedwig.Repositories;
+using Hedwig.Security;
 using GraphQL.DataLoader;
 using GraphQL.Types;
 
 namespace Hedwig.Schema.Types
 {
-	public class EnrollmentType : TemporalGraphType<Enrollment>
+	public class EnrollmentType : TemporalGraphType<Enrollment>, IAuthorizedGraphType
 	{
 		public EnrollmentType(IDataLoaderContextAccessor dataLoader, IChildRepository children, IFundingRepository fundings)
 		{
@@ -39,6 +40,15 @@ namespace Hedwig.Schema.Types
 					return loader.LoadAsync(context.Source.Id);
 				}
 			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
 		}
 	}
 }

--- a/src/Hedwig/Schema/Types/UserType.cs
+++ b/src/Hedwig/Schema/Types/UserType.cs
@@ -1,10 +1,12 @@
 using Hedwig.Models;
 using Hedwig.Repositories;
+using Hedwig.Security;
 using GraphQL.Types;
+using GraphQL.Authorization;
 
 namespace Hedwig.Schema.Types
 {
-	public class UserType : HedwigGraphType<User>
+	public class UserType : HedwigGraphType<User>, IAuthorizedGraphType
 	{
 		public UserType(ISiteRepository sites, IReportRepository reports)
 		{
@@ -21,6 +23,16 @@ namespace Hedwig.Schema.Types
 				"reports",
 				resolve: context => reports.GetReportsByUserIdAsync(context.Source.Id)
 			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsCurrentUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
 		}
 	}
 }

--- a/src/Hedwig/Security/AuthorizationContext.cs
+++ b/src/Hedwig/Security/AuthorizationContext.cs
@@ -1,6 +1,5 @@
-/**
- * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthenticatedUserRequirement.cs
- * This file is released in v3 of GraphQL.Authorization but we use v2.1.
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationContext.cs
  */
 /**
  * The MIT License (MIT)
@@ -22,23 +21,38 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+/*
+ * Summary of Changes
+ * - Rename Arguments field to InputVariables.
+ * - Add Arguments field for query arguments.
+ */
 
-using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
+using System.Security.Claims;
+using GraphQL.Language.AST;
 
 namespace Hedwig.Security
 {
-    public class AuthenticatedUserRequirement : IAuthorizationRequirement
+    public class AuthorizationContext
     {
-        public Task Authorize(AuthorizationContext context)
-        {
-            if (!context.User.Identities.Any(x => x.IsAuthenticated))
-            {
-                context.ReportError("An authenticated user is required.");
-            }
+        private readonly List<string> _errors = new List<string>();
 
-            return Task.CompletedTask;
+        public ClaimsPrincipal User { get; set; }
+
+        public object UserContext { get; set; }
+
+        public Dictionary<string, object> InputVariables { get; set; }
+
+        public Arguments Arguments { get; set; }
+
+        public IEnumerable<string> Errors => _errors;
+
+        public bool HasErrors => _errors.Any<string>();
+
+        public void ReportError(string error)
+        {
+            _errors.Add(error);
         }
     }
 }

--- a/src/Hedwig/Security/AuthorizationMetadataExtensions.cs
+++ b/src/Hedwig/Security/AuthorizationMetadataExtensions.cs
@@ -33,6 +33,7 @@ using System.Threading.Tasks;
 using GraphQL.Builders;
 using GraphQL.Types;
 using GraphQL.Authorization;
+using GraphQL.Language.AST;
 
 namespace Hedwig.Security
 {
@@ -48,12 +49,13 @@ namespace Hedwig.Security
             ClaimsPrincipal principal,
             object userContext,
             Dictionary<string, object> inputVariables,
-            IAuthorizationEvaluator evaluator)
+            IAuthorizationEvaluator evaluator,
+            Arguments arguments)
         {
             var authorizedType = type as IAuthorizedGraphType;
             var rules = new AuthorizationRules();
             rules = authorizedType.Permissions(rules);
-            return evaluator.Evaluate(principal, userContext, inputVariables, rules);
+            return evaluator.Evaluate(principal, userContext, inputVariables, rules, arguments);
         }
     }
 }

--- a/src/Hedwig/Security/AuthorizationPolicy.cs
+++ b/src/Hedwig/Security/AuthorizationPolicy.cs
@@ -1,6 +1,5 @@
-/**
- * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthenticatedUserRequirement.cs
- * This file is released in v3 of GraphQL.Authorization but we use v2.1.
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationPolicy.cs
  */
 /**
  * The MIT License (MIT)
@@ -23,22 +22,25 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-using System;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Hedwig.Security
 {
-    public class AuthenticatedUserRequirement : IAuthorizationRequirement
+    public interface IAuthorizationPolicy
     {
-        public Task Authorize(AuthorizationContext context)
-        {
-            if (!context.User.Identities.Any(x => x.IsAuthenticated))
-            {
-                context.ReportError("An authenticated user is required.");
-            }
+        IEnumerable<IAuthorizationRequirement> Requirements { get; }
+    }
 
-            return Task.CompletedTask;
+    public class AuthorizationPolicy : IAuthorizationPolicy
+    {
+        private readonly List<IAuthorizationRequirement> _requirements;
+
+        public AuthorizationPolicy(IEnumerable<IAuthorizationRequirement> requirements)
+        {
+            _requirements = new List<IAuthorizationRequirement>(
+                requirements ?? new List<IAuthorizationRequirement>());
         }
+
+        public IEnumerable<IAuthorizationRequirement> Requirements => _requirements;
     }
 }

--- a/src/Hedwig/Security/AuthorizationPolicyBuilder.cs
+++ b/src/Hedwig/Security/AuthorizationPolicyBuilder.cs
@@ -1,6 +1,5 @@
-/**
- * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthenticatedUserRequirement.cs
- * This file is released in v3 of GraphQL.Authorization but we use v2.1.
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationPolicyBuilder.cs
  */
 /**
  * The MIT License (MIT)
@@ -22,23 +21,35 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+/*
+ * Summary of Changes
+ * - Remove unused methods.
+ */
 
-using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Hedwig.Security
 {
-    public class AuthenticatedUserRequirement : IAuthorizationRequirement
+    public class AuthorizationPolicyBuilder
     {
-        public Task Authorize(AuthorizationContext context)
-        {
-            if (!context.User.Identities.Any(x => x.IsAuthenticated))
-            {
-                context.ReportError("An authenticated user is required.");
-            }
+        private readonly List<IAuthorizationRequirement> _requirements;
 
-            return Task.CompletedTask;
+        public AuthorizationPolicyBuilder()
+        {
+            _requirements = new List<IAuthorizationRequirement>();
+        }
+
+        public AuthorizationPolicy Build()
+        {
+            var policy = new AuthorizationPolicy(_requirements);
+            return policy;
+        }
+
+        public AuthorizationPolicyBuilder AddRequirement(IAuthorizationRequirement requirement)
+        {
+            _requirements.Add(requirement);
+            return this;
         }
     }
 }

--- a/src/Hedwig/Security/AuthorizationSettings.cs
+++ b/src/Hedwig/Security/AuthorizationSettings.cs
@@ -1,0 +1,77 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationSettings.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace Hedwig.Security
+{
+    public class AuthorizationSettings
+    {
+        private readonly IDictionary<string, IAuthorizationPolicy> _policies;
+
+        public AuthorizationSettings()
+        {
+            _policies = new Dictionary<string, IAuthorizationPolicy>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public IEnumerable<IAuthorizationPolicy> Policies => _policies.Values;
+
+        public IEnumerable<IAuthorizationPolicy> GetPolicies(IEnumerable<string> policies)
+        {
+            var found = new List<IAuthorizationPolicy>();
+
+            if (policies == null) { return found; }
+
+            foreach (var name in policies)
+            {
+              if (_policies.ContainsKey(name))
+              {
+                found.Add(_policies[name]);
+              }
+            }
+
+            return found;
+        }
+
+        public IAuthorizationPolicy GetPolicy(string name)
+        {
+            return _policies.ContainsKey(name) ? _policies[name] : null;
+        }
+
+        public void AddPolicy(string name, IAuthorizationPolicy policy)
+        {
+            _policies[name] = policy;
+        }
+
+        public void AddPolicy(string name, Action<AuthorizationPolicyBuilder> configure)
+        {
+            var builder = new AuthorizationPolicyBuilder();
+            configure(builder);
+
+            var policy = builder.Build();
+            _policies[name] = policy;
+        }
+    }
+}

--- a/src/Hedwig/Security/IAuthorizationRequirement.cs
+++ b/src/Hedwig/Security/IAuthorizationRequirement.cs
@@ -1,6 +1,5 @@
-/**
- * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthenticatedUserRequirement.cs
- * This file is released in v3 of GraphQL.Authorization but we use v2.1.
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/IAuthorizationRequirement.cs
  */
 /**
  * The MIT License (MIT)
@@ -23,22 +22,12 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Hedwig.Security
 {
-    public class AuthenticatedUserRequirement : IAuthorizationRequirement
+    public interface IAuthorizationRequirement
     {
-        public Task Authorize(AuthorizationContext context)
-        {
-            if (!context.User.Identities.Any(x => x.IsAuthenticated))
-            {
-                context.ReportError("An authenticated user is required.");
-            }
-
-            return Task.CompletedTask;
-        }
+        Task Authorize(AuthorizationContext context);
     }
 }

--- a/src/Hedwig/Security/Permissions.cs
+++ b/src/Hedwig/Security/Permissions.cs
@@ -1,16 +1,36 @@
-using GraphQL.Authorization;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Hedwig.Security
 {
-    public static class Permissions
+    public class Permissions
     {
-      public static AuthorizationSettings GetAuthorizationSettings()
+      // DevelopmentRequirement needs DI access to IHostingEnvironment
+      private readonly DevelopmentRequirement _developmentRequirement;
+
+      public Permissions(
+        DevelopmentRequirement developmentRequirement
+      )
+      {
+        _developmentRequirement = developmentRequirement;
+      }
+
+      public AuthorizationSettings GetAuthorizationSettings()
       {
         var authSettings = new AuthorizationSettings();
 
         authSettings.AddPolicy("IsAuthenticatedUserPolicy", policy =>
           policy.AddRequirement(new AuthenticatedUserRequirement()));
+
+        authSettings.AddPolicy("IsCurrentUserPolicy", policy =>
+          policy.AddRequirement(new CurrentUserRequirement()));
+
+        authSettings.AddPolicy("IsDeveloperInDevPolicy", policy =>
+          policy.AddRequirement(new DeveloperUserRequirement())
+            .AddRequirement(_developmentRequirement));
+
+        authSettings.AddPolicy("IsTestMode", policy =>
+          policy.AddRequirement(new TestModeRequirement())
+            .AddRequirement(_developmentRequirement));
 
         return authSettings;
       }

--- a/src/Hedwig/Security/Policies/CurrentUserRequirement.cs
+++ b/src/Hedwig/Security/Policies/CurrentUserRequirement.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Language.AST;
+using Hedwig.Data;
+
+namespace Hedwig.Security
+{
+    public class CurrentUserRequirement : IAuthorizationRequirement
+    {
+        public Task Authorize(AuthorizationContext context)
+        {
+            var queryId = context.Arguments.ValueFor("id")?.Value;
+            var authenticatedId = context.User.FindFirst("sub")?.Value;
+            if (queryId == null || authenticatedId == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!queryId.Equals(Int32.Parse(authenticatedId)))
+            {
+                context.ReportError("The current user is required.");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Hedwig/Security/Policies/DeveloperUserRequirement.cs
+++ b/src/Hedwig/Security/Policies/DeveloperUserRequirement.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using System;
+
+namespace Hedwig.Security
+{
+  public class DeveloperUserRequirement : IAuthorizationRequirement
+  {
+    public Task Authorize(AuthorizationContext context)
+    {
+      var user = context.User;
+      if (user == null || !user.HasClaim("role", "developer"))
+      {
+        context.ReportError("A developer account is required");
+      }
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Hedwig/Security/Policies/DevelopmentRequirement.cs
+++ b/src/Hedwig/Security/Policies/DevelopmentRequirement.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Hosting;
+using System.Threading.Tasks;
+using Hedwig.Schema;
+
+namespace Hedwig.Security
+{
+  public class DevelopmentRequirement : IAuthorizationRequirement
+  {
+    private readonly IHostingEnvironment _env;
+    public DevelopmentRequirement(IHostingEnvironment env)
+    {
+      _env = env;
+    }
+    public Task Authorize(AuthorizationContext context)
+    {
+      if (!(_env.IsDevelopment()))
+      {
+        context.ReportError("Development environment is required");
+      }
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Hedwig/Security/Policies/TestModeRequirement.cs
+++ b/src/Hedwig/Security/Policies/TestModeRequirement.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Hosting;
+using System.Threading.Tasks;
+using System;
+
+namespace Hedwig.Security
+{
+  public class TestModeRequirement : IAuthorizationRequirement
+  {
+    public Task Authorize(AuthorizationContext context)
+    {
+      var user = context.User;
+      if (user == null || !user.HasClaim("test_mode", "true"))
+      {
+        context.ReportError("Test mode is required");
+      }
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -104,9 +104,18 @@ namespace Hedwig
 							ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
 						};
 					});
-			services.AddSingleton<Hedwig.Security.IAuthorizationEvaluator, Hedwig.Security.AuthorizationEvaluator>();
+		}
+
+		public static void ConfigureGraphQLAuthorization(this IServiceCollection services)
+		{
+			services.AddScoped<Hedwig.Security.IAuthorizationEvaluator, Hedwig.Security.AuthorizationEvaluator>();
 			services.AddTransient<IValidationRule, Hedwig.Security.AuthorizationValidationRule>();
-			services.AddSingleton(s => Permissions.GetAuthorizationSettings());
+			services.AddScoped<Permissions>();
+			services.AddScoped<DevelopmentRequirement>();
+			services.AddScoped(s => {
+				Permissions permissions = s.GetRequiredService<Permissions>();
+				return permissions.GetAuthorizationSettings();
+			});
 		}
 	}
 }

--- a/src/Hedwig/Startup.cs
+++ b/src/Hedwig/Startup.cs
@@ -30,6 +30,7 @@ namespace Hedwig
             services.ConfigureRepositories();
             services.ConfigureGraphQL();
             services.ConfigureAuthentication();
+            services.ConfigureGraphQLAuthorization();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/HedwigTests/Fixtures/TestAuthenticationHandler.cs
+++ b/test/HedwigTests/Fixtures/TestAuthenticationHandler.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authentication;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using System.Text.Encodings.Web;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Security.Claims;
+
+namespace HedwigTests.Fixtures
+{
+  public class TestAuthenticationHandler : AuthenticationHandler<TestAuthenticationOptions>
+  {
+    public TestAuthenticationHandler(
+      IOptionsMonitor<TestAuthenticationOptions> options,
+      ILoggerFactory logger,
+      UrlEncoder encoder,
+      ISystemClock clock) : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+      var authenticationTicket = new AuthenticationTicket(
+        new ClaimsPrincipal(Options.Identity),
+        new AuthenticationProperties(),
+        "Test Scheme"
+      );
+      return Task.FromResult(AuthenticateResult.Success(authenticationTicket));
+    }
+  }
+
+  public static class TestAuthenticationExtensions {
+    public static AuthenticationBuilder AddTestAuth(this AuthenticationBuilder builder, Action<TestAuthenticationOptions> configureOptions)
+    {
+      return builder.AddScheme<TestAuthenticationOptions, TestAuthenticationHandler>("Test Scheme", "Test Auth", configureOptions);
+    }
+  }
+
+  public class TestAuthenticationOptions : AuthenticationSchemeOptions
+  {
+    public virtual ClaimsIdentity Identity { get; } = new ClaimsIdentity(
+      new Claim[] {
+        new Claim("test_mode", "true")
+      },
+      "test"
+    );
+  }
+}

--- a/test/HedwigTests/Fixtures/TestClientProvider.cs
+++ b/test/HedwigTests/Fixtures/TestClientProvider.cs
@@ -24,7 +24,7 @@ namespace HedwigTests.Fixtures
 					.UseStartup<TestStartup>()
 			);
 			var scope = _server.Host.Services.CreateScope();
-            Context = scope.ServiceProvider.GetRequiredService<TestHedwigContext>();
+			Context = scope.ServiceProvider.GetRequiredService<TestHedwigContext>();
 			Client = _server.CreateClient();
 		}
 

--- a/test/HedwigTests/Fixtures/TestServiceExtensions.cs
+++ b/test/HedwigTests/Fixtures/TestServiceExtensions.cs
@@ -1,16 +1,28 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using GraphQL.Authorization;
+using GraphQL.Validation;
+using Hedwig.Security;
 
 namespace HedwigTests.Fixtures
 {
-    public static class TestServiceExtensions
-    {
-        public static void ConfigureSqlServer(this IServiceCollection services, string connectionString)
-        {
-            services.AddDbContext<TestHedwigContext>(options =>
-                options.UseSqlServer(connectionString)
-        			.EnableSensitiveDataLogging()
-            );
-        }
-    }
+	public static class TestServiceExtensions
+	{
+		public static void ConfigureSqlServer(this IServiceCollection services, string connectionString)
+		{
+			services.AddDbContext<TestHedwigContext>(options =>
+					options.UseSqlServer(connectionString)
+						.EnableSensitiveDataLogging()
+			);
+		}
+
+		public static void ConfigureAuthentication(this IServiceCollection services)
+		{
+			services.AddAuthentication(options =>
+				{
+					options.DefaultAuthenticateScheme = "Test Scheme";
+					options.DefaultChallengeScheme = "Test Scheme";
+				}).AddTestAuth(o => {});
+		}
+	}
 }

--- a/test/HedwigTests/Fixtures/TestStartup.cs
+++ b/test/HedwigTests/Fixtures/TestStartup.cs
@@ -16,6 +16,7 @@ namespace HedwigTests.Fixtures
             if(TestEnvironmentFlags.ShouldLogSQL()) {
                 services.AddLogging(configure => configure.AddConsole());
             }
+            services.ConfigureAuthentication();
         }
     }
 }


### PR DESCRIPTION
Add initial protection to API endpoints.

Several new requirements are added:
* `CurrentUserRequirement` --> the user query id is the authenticated user id
* `DeveloperUserRequirement` --> the user has the "developer" role claim
* `DevelopmentRequirement` --> the current environment is development

Pulls down more of the `GraphQL.Authorization` library; needed to allow requirements to inspect the arguments in queries.

Relies on more DI to support injecting `HedwigContext` and `IHostingEnvironment` objects into specific requirements, instead of carrying them along on the `RequestContext` object.

Should resolve #106