### PR TITLE
[WIP] Validation

### DIFF
--- a/src/Hedwig/Schema/Types/DataValidationIssueType.cs
+++ b/src/Hedwig/Schema/Types/DataValidationIssueType.cs
@@ -1,0 +1,14 @@
+using Hedwig.Validations;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+  public class DataValidationIssueType : HedwigGraphType<DataValidationIssue>
+  {
+    public DataValidationIssueType()
+    {
+      Field(i => i.property);
+      Field(i => i.message);
+    }
+  }
+}

--- a/src/Hedwig/Startup.cs
+++ b/src/Hedwig/Startup.cs
@@ -12,62 +12,63 @@ using Microsoft.IdentityModel.Logging;
 
 namespace Hedwig
 {
-    public class Startup
+  public class Startup
+  {
+    public Startup(IConfiguration configuration)
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
-
-        public IConfiguration Configuration { get; }
-
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public virtual void ConfigureServices(IServiceCollection services)
-        {
-            services.ConfigureSqlServer(Configuration.GetConnectionString("HEDWIG"));
-            services.ConfigureCors();
-            services.ConfigureSpa();
-            services.ConfigureRepositories();
-            services.ConfigureGraphQL();
-            services.ConfigureAuthentication();
-        }
-
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-                app.UseCors("AllowAll");
-                // Prints the URLs of endpoints and values of JWT claims when there is a mismatch in validation
-                IdentityModelEventSource.ShowPII = true; 
-            }
-            else
-            {
-                app.UseExceptionHandler("/Error");
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                app.UseHsts();
-            }
-
-            app.UseHttpsRedirection();
-            app.UseStaticFiles();
-            app.UseSpaStaticFiles();
-
-            app.UseAuthentication();
-
-            app.UseGraphQL<AppSchema>();
-            app.UseGraphQLPlayground(options: new GraphQLPlaygroundOptions());
-
-            app.UseSpa(spa =>
-            {
-                spa.Options.SourcePath = "ClientApp";
-
-                if (env.IsDevelopment())
-                {
-                    string CLIENT_HOST = Environment.GetEnvironmentVariable("CLIENT_HOST") ?? "http://localhost:3000";
-                    spa.UseProxyToSpaDevelopmentServer(CLIENT_HOST);
-                }
-            });
-        }
+      Configuration = configuration;
     }
+
+    public IConfiguration Configuration { get; }
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    public virtual void ConfigureServices(IServiceCollection services)
+    {
+      services.ConfigureSqlServer(Configuration.GetConnectionString("HEDWIG"));
+      services.ConfigureCors();
+      services.ConfigureSpa();
+      services.ConfigureRepositories();
+      services.ConfigureDataValidations();
+      services.ConfigureGraphQL();
+      services.ConfigureAuthentication();
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+    {
+      if (env.IsDevelopment())
+      {
+        app.UseDeveloperExceptionPage();
+        app.UseCors("AllowAll");
+        // Prints the URLs of endpoints and values of JWT claims when there is a mismatch in validation
+        IdentityModelEventSource.ShowPII = true;
+      }
+      else
+      {
+        app.UseExceptionHandler("/Error");
+        // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+        app.UseHsts();
+      }
+
+      app.UseHttpsRedirection();
+      app.UseStaticFiles();
+      app.UseSpaStaticFiles();
+
+      app.UseAuthentication();
+
+      app.UseGraphQL<AppSchema>();
+      app.UseGraphQLPlayground(options: new GraphQLPlaygroundOptions());
+
+      app.UseSpa(spa =>
+      {
+        spa.Options.SourcePath = "ClientApp";
+
+        if (env.IsDevelopment())
+        {
+          string CLIENT_HOST = Environment.GetEnvironmentVariable("CLIENT_HOST") ?? "http://localhost:3000";
+          spa.UseProxyToSpaDevelopmentServer(CLIENT_HOST);
+        }
+      });
+    }
+  }
 }

--- a/src/Hedwig/Validation/DataValidationIssue.cs
+++ b/src/Hedwig/Validation/DataValidationIssue.cs
@@ -2,7 +2,7 @@ namespace Hedwig.Validations
 {
   public struct DataValidationIssue
   {
-    public string property, message;
+    public readonly string property, message;
 
     public DataValidationIssue(string p, string m)
     {

--- a/src/Hedwig/Validation/DataValidationIssue.cs
+++ b/src/Hedwig/Validation/DataValidationIssue.cs
@@ -1,0 +1,13 @@
+namespace Hedwig.Validations
+{
+  public struct DataValidationIssue
+  {
+    public string property, message;
+
+    public DataValidationIssue(string p, string m)
+    {
+      property = p;
+      message = m;
+    }
+  }
+}

--- a/src/Hedwig/Validation/DataValidator.cs
+++ b/src/Hedwig/Validation/DataValidator.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL;
+
+namespace Hedwig.Validations
+{
+  public class DataValidator<T> : IDataValidator<T>
+  {
+    private IEnumerable<IDataValidationRule<T>> _rules;
+    private ConcurrentDictionary<T, IEnumerable<DataValidationIssue>> _nonBlockingResults = new ConcurrentDictionary<T, IEnumerable<DataValidationIssue>>();
+    private ConcurrentDictionary<T, IEnumerable<DataValidationIssue>> _blockingResults = new ConcurrentDictionary<T, IEnumerable<DataValidationIssue>>();
+
+    public DataValidator(IEnumerable<IDataValidationRule<T>> rules) => _rules = rules;
+
+    public IEnumerable<DataValidationIssue> Validate(T obj)
+    {
+      return FetchBlockingResults(obj).Concat(FetchNonBlockingResults(obj));
+    }
+
+    public IEnumerable<ExecutionError> BlockingErrorsForProperties(T obj, IEnumerable<string> props)
+    {
+      return FetchBlockingResults(obj)
+        .Where(result => props.Contains(result.property))
+        .Select(result => new ExecutionError(message: $"{nameof(T)};{result.property};{result.message}"));
+    }
+
+    private IEnumerable<DataValidationIssue> FetchNonBlockingResults(T obj)
+    {
+      return _nonBlockingResults.GetOrAdd(obj,
+        o => _rules.Where(rule => !(rule is IDataValidationBlockingRule<T>)).SelectMany(rule => rule.Validate(o))
+      );
+    }
+
+    private IEnumerable<DataValidationIssue> FetchBlockingResults(T obj)
+    {
+      return _blockingResults.GetOrAdd(obj,
+        o => _rules.OfType<IDataValidationBlockingRule<T>>().SelectMany(rule => rule.Validate(o))
+      );
+    }
+  }
+
+  public interface IDataValidator<T>
+  {
+    IEnumerable<DataValidationIssue> Validate(T obj);
+    IEnumerable<ExecutionError> BlockingErrorsForProperties(T obj, IEnumerable<string> props);
+  }
+}

--- a/src/Hedwig/Validation/DataValidator.cs
+++ b/src/Hedwig/Validation/DataValidator.cs
@@ -7,9 +7,9 @@ namespace Hedwig.Validations
 {
   public class DataValidator<T> : IDataValidator<T>
   {
-    private IEnumerable<IDataValidationRule<T>> _rules;
-    private ConcurrentDictionary<T, IEnumerable<DataValidationIssue>> _nonBlockingResults = new ConcurrentDictionary<T, IEnumerable<DataValidationIssue>>();
-    private ConcurrentDictionary<T, IEnumerable<DataValidationIssue>> _blockingResults = new ConcurrentDictionary<T, IEnumerable<DataValidationIssue>>();
+    private readonly IEnumerable<IDataValidationRule<T>> _rules;
+    private const ConcurrentDictionary<T, IEnumerable<DataValidationIssue>> _nonBlockingResults = new ConcurrentDictionary<T, IEnumerable<DataValidationIssue>>();
+    private const ConcurrentDictionary<T, IEnumerable<DataValidationIssue>> _blockingResults = new ConcurrentDictionary<T, IEnumerable<DataValidationIssue>>();
 
     public DataValidator(IEnumerable<IDataValidationRule<T>> rules) => _rules = rules;
 

--- a/src/Hedwig/Validation/IDataValidationRule.cs
+++ b/src/Hedwig/Validation/IDataValidationRule.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Hedwig.Validations
+{
+  public interface IDataValidationRule<T>
+  {
+    IEnumerable<DataValidationIssue> Validate(T obj);
+  }
+
+  public interface IDataValidationBlockingRule<T> : IDataValidationRule<T> { }
+}

--- a/src/Hedwig/Validation/ResolveFieldContextExtensions.cs
+++ b/src/Hedwig/Validation/ResolveFieldContextExtensions.cs
@@ -1,0 +1,18 @@
+using GraphQL.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hedwig.Validations
+{
+  public static class ResolveFieldContextExtensions
+  {
+    public static bool AddDataValidationErrors<T>(this ResolveFieldContext<T> context, IDataValidator<T> validator, T obj, IEnumerable<string> props = null)
+    {
+      props = props ?? context.Arguments.Keys.Select(key => Char.ToUpperInvariant(key[0]) + key.Substring(1));
+      var errors = validator.BlockingErrorsForProperties(obj, props);
+      context.Errors.AddRange(errors);
+      return errors.Any();
+    }
+  }
+}

--- a/src/Hedwig/Validation/Rules/EnrollmentEntryCannotBeBeforeBirthdate.cs
+++ b/src/Hedwig/Validation/Rules/EnrollmentEntryCannotBeBeforeBirthdate.cs
@@ -7,11 +7,11 @@ namespace Hedwig.Validations
   {
     private const string _message = "Cannot be before the child's birthdate.";
 
-    public IEnumerable<DataValidationIssue> Validate(Enrollment enrollment)
+    public IEnumerable<DataValidationIssue> Validate(Enrollment obj)
     {
-      if (enrollment.Entry < enrollment.Child.Birthdate)
+      if (obj.Entry < obj.Child.Birthdate)
       {
-        return new DataValidationIssue[] { new DataValidationIssue(_message, nameof(enrollment.Entry)) };
+        return new DataValidationIssue[] { new DataValidationIssue(_message, nameof(obj.Entry)) };
       }
       return new DataValidationIssue[0];
     }

--- a/src/Hedwig/Validation/Rules/EnrollmentEntryCannotBeBeforeBirthdate.cs
+++ b/src/Hedwig/Validation/Rules/EnrollmentEntryCannotBeBeforeBirthdate.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Hedwig.Models;
+
+namespace Hedwig.Validations
+{
+  class EnrollmentEntryCannotBeBeforeBirthdate : IDataValidationBlockingRule<Enrollment>
+  {
+    private const string _message = "Cannot be before the child's birthdate.";
+
+    public IEnumerable<DataValidationIssue> Validate(Enrollment enrollment)
+    {
+      if (enrollment.Entry < enrollment.Child.Birthdate)
+      {
+        return new DataValidationIssue[] { new DataValidationIssue(_message, nameof(enrollment.Entry)) };
+      }
+      return new DataValidationIssue[0];
+    }
+  }
+}

--- a/src/Hedwig/Validation/Rules/EnrollmentExitCannotBeBeforeEntry.cs
+++ b/src/Hedwig/Validation/Rules/EnrollmentExitCannotBeBeforeEntry.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Hedwig.Models;
+
+namespace Hedwig.Validations
+{
+  class EnrollmentExitCannotBeBeforeEntry : IDataValidationBlockingRule<Enrollment>
+  {
+    private const string _message = "Cannot be before the start date.";
+
+    public IEnumerable<DataValidationIssue> Validate(Enrollment enrollment)
+    {
+      if (enrollment.Exit < enrollment.Entry)
+      {
+        return new DataValidationIssue[] { new DataValidationIssue(_message, nameof(enrollment.Exit)) };
+      }
+      return new DataValidationIssue[0];
+    }
+  }
+}

--- a/src/Hedwig/Validation/Rules/EnrollmentExitCannotBeBeforeEntry.cs
+++ b/src/Hedwig/Validation/Rules/EnrollmentExitCannotBeBeforeEntry.cs
@@ -7,11 +7,11 @@ namespace Hedwig.Validations
   {
     private const string _message = "Cannot be before the start date.";
 
-    public IEnumerable<DataValidationIssue> Validate(Enrollment enrollment)
+    public IEnumerable<DataValidationIssue> Validate(Enrollment obj)
     {
-      if (enrollment.Exit < enrollment.Entry)
+      if (obj.Exit < obj.Entry)
       {
-        return new DataValidationIssue[] { new DataValidationIssue(_message, nameof(enrollment.Exit)) };
+        return new DataValidationIssue[] { new DataValidationIssue(_message, nameof(obj.Exit)) };
       }
       return new DataValidationIssue[0];
     }


### PR DESCRIPTION
Two ways this is used.

From any schema type, I can add the following to create a field with an array of validation issues for the record:

```C#
Field<NonNullGraphType<ListGraphType<NonNullGraphType<DataValidationIssueType>>>>(
  "validations",
  resolve: context => validator.Validate(context.Source)
);
```

Or, from a mutation resolver, I can run the following after I update the record to add errors for any blocking validations to the context. It returns a `bool` that I can use to determine whether or not to save the record. If I don't specify which properties I would like it to check, it will use the context's `Arguments` and only validate properties with the same name as an argument (imagine we add a new blocking mutation, making a whole bunch of records retroactively invalid; a screen that touches the same model but doesn't update or display the problematic field would be broken and there'd be no way to display to the user what to fix).

```C#
context.AddDataValidationErrors(validator, record);
```