### PR TITLE
Add enrollment mutation

### DIFF
--- a/src/Hedwig/Repositories/EnrollmentRepository.cs
+++ b/src/Hedwig/Repositories/EnrollmentRepository.cs
@@ -29,6 +29,12 @@ namespace Hedwig.Repositories
 			return GetBaseQuery<Enrollment>(asOf)
 				.SingleOrDefaultAsync(e => e.Id == id);
 		}
+
+		public Enrollment UpdateEnrollment(Enrollment enrollment)
+		{
+			_context.SaveChanges();
+			return enrollment;
+		}
 	}
 
 	public interface IEnrollmentRepository
@@ -40,6 +46,7 @@ namespace Hedwig.Repositories
 			DateTime? to = null
 		);
 		Task<Enrollment> GetEnrollmentByIdAsync(int id, DateTime? asOf = null);
+		Enrollment UpdateEnrollment(Enrollment enrollment);
 	}
 
 	public static class EnrollmentQueryExtensions

--- a/src/Hedwig/Schema/Mutations/EnrollmentMutation.cs
+++ b/src/Hedwig/Schema/Mutations/EnrollmentMutation.cs
@@ -1,0 +1,59 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System.Collections.Generic;
+using System;
+
+namespace Hedwig.Schema.Mutations
+{
+	public class EnrollmentMutation : ObjectGraphType<Enrollment>, IAppSubMutation
+	{
+		public EnrollmentMutation(IEnrollmentRepository repository)
+		{
+			FieldAsync<EnrollmentType>(
+				"updateEnrollment",
+				arguments: new QueryArguments(
+					new QueryArgument<NonNullGraphType<IntGraphType>>{ Name = "id" },
+					new QueryArgument<DateGraphType>{ Name = "entry" },
+					new QueryArgument<StringGraphType>{ Name = "exit" }
+				),
+				resolve: async context =>
+				{
+					var id = context.GetArgument<int>("id");
+					var enrollment = (Enrollment) await repository.GetEnrollmentByIdAsync(id);
+					if (enrollment == null)
+					{
+						throw new ExecutionError(
+							AppErrorMessages.NOT_FOUND("Enrollment", id)
+						);
+					}
+
+					var entry = context.GetArgument<DateTime?>("entry");
+					var exitStr = context.GetArgument<String>("exit");
+
+					if (entry != null)
+					{
+						enrollment.Entry = (DateTime) entry;
+					}
+
+					if (exitStr != null)
+					{
+						DateTime? exit;
+						try {
+							exit = ValueConverter.ConvertTo<DateTime>(exitStr);
+						}
+						catch (FormatException e)
+						{
+							exit = null;
+						}
+						enrollment.Exit = exit;
+					}
+
+					return repository.UpdateEnrollment(enrollment);
+				}
+			);
+		}
+	}
+}

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -81,6 +81,7 @@ namespace Hedwig
 
 			// Add Mutations
 			services.AddScoped<IAppSubMutation, ReportMutation>();
+			services.AddScoped<IAppSubMutation, EnrollmentMutation>();
 
 			services.AddScoped<IDependencyResolver>(s => new FuncDependencyResolver(s.GetRequiredService));
 			services.AddScoped<AppSchema>();

--- a/test/HedwigTests/Integration/GraphQLMutations/EnrollmentMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/EnrollmentMutationTests.cs
@@ -1,0 +1,180 @@
+using Xunit;
+using System.Threading.Tasks;
+using System;
+using Hedwig.Models;
+using Hedwig.Schema;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+	public class EnrollmentMutationTests
+	{
+		[Fact]
+		public async Task Update_Enrollment_With_Entry_And_Exit()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: "2000-1-1", exit: "2000-2-2");
+				var entry = new DateTime(2019, 10, 10, 0, 0, 0);
+				var exit = new DateTime(2020, 10, 10, 0, 0, 0);
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, entry: ""{entry.ToString()}"", exit: ""{exit.ToString()}"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Equal(exit, updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_With_Entry()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var exit = new DateTime(2020, 2, 2, 0, 0, 0);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: "2000-1-1", exit: exit.ToString());
+				var entry = new DateTime(2019, 10, 10, 0, 0, 0);
+				
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, entry: ""{entry.ToString()}"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Equal(exit, updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_With_Exit()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var entry = new DateTime(2020, 2, 2, 0, 0, 0);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: entry.ToString(), exit: "2020-06-06");
+				var exit = new DateTime(2020, 8, 8, 0, 0, 0);
+				
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, exit: ""{exit.ToString()}"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Equal(exit, updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_Clear_Exit()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var entry = new DateTime(2020, 2, 2, 0, 0, 0);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: entry.ToString(), exit: "2020-06-06");
+				
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, exit: ""null"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Null(updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_With_Entry_Clear_Exit()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: "2019-01-01", exit: "2020-06-06");
+				var entry = new DateTime(2020, 1, 1, 0, 0, 0);
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, entry: ""{entry.ToString()}"" exit: ""null"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Null(updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_Id_Not_Found()
+		{
+			using (var api = new TestApiProvider()) {
+				var invalidId = 0;
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {invalidId}, entry: ""2010-10-10"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+				var gqlResponse = await response.ParseGraphQLResponse();
+				Assert.NotEmpty(gqlResponse.Errors);
+				Assert.Equal(AppErrorMessages.NOT_FOUND("Enrollment", invalidId), gqlResponse.Errors[0].Message);
+			}
+		}
+	}
+}


### PR DESCRIPTION
I have a question about the process for clearing an exit date (i.e. setting it to null). I'm not sure if this is a supported use case but needed to check in. /cc @cmgiven 

Should resolve #7 