### PR TITLE
application logging (#51)

### DIFF
--- a/src/Hedwig/Program.cs
+++ b/src/Hedwig/Program.cs
@@ -39,7 +39,12 @@ namespace Hedwig
 				  logging.AddConfiguration(context.Configuration.GetSection("Logging"));
 				  logging.AddConsole();
 				  logging.AddDebug();
-				  logging.AddAWSProvider();
+
+				  if(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != EnvironmentName.Development)
+				  {
+  					logging.AddAWSProvider();
+				  }
+
 				})
 				.UseStartup<Startup>();
 	}

--- a/src/Hedwig/appsettings.json
+++ b/src/Hedwig/appsettings.json
@@ -14,3 +14,4 @@
 	"AllowedHosts": "*"
 }
 
+

--- a/src/Hedwig/appsettings.json
+++ b/src/Hedwig/appsettings.json
@@ -3,7 +3,7 @@
 		"HEDWIG": ""
 	},
 	"Logging": {
-		"Region": "us-east-2",
+		"Region": "",
 		"LogGroup":  "Hedwig",
 		"LogLevel": {
 			"Default": "Information",

--- a/src/Hedwig/appsettings.json
+++ b/src/Hedwig/appsettings.json
@@ -3,7 +3,7 @@
 		"HEDWIG": ""
 	},
 	"Logging": {
-		"Region": "",
+		"Region": "us-east-2",
 		"LogGroup":  "Hedwig",
 		"LogLevel": {
 			"Default": "Information",


### PR DESCRIPTION
This is for a future demo for application logging (with CloudWatch support) with team leaders for GitHub issue 51.  For more information on the suggested logging implementation, see:  https://github.com/ctoec/ecis-experimental/wiki/Paper:-Application-Logging.

This pull request is to ensure AWS logging does not occur in the development environment.  A conditional was added to the program.cs file. There is a hard code in the appsettings.json for Logging.Region.  If this appsettings value is empty (""), the CI build will fail. 

This issue will not be closed if the pull request gets merged.  