### PR TITLE
169 Add create family with child mutation

### DIFF
--- a/src/Hedwig/GraphQL/CommitMutationFieldsMiddleware.cs
+++ b/src/Hedwig/GraphQL/CommitMutationFieldsMiddleware.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using GraphQL.Instrumentation;
+using GraphQL.Types;
+using Hedwig.Data;
+
+namespace Hedwig.GraphQL
+{
+	public class CommitMutationFieldsMiddleware : IFieldsMiddleware
+	{
+		private readonly HedwigContext _context;
+		public CommitMutationFieldsMiddleware(HedwigContext context)
+		{
+			_context = context;
+		}
+
+		public Task<object> Resolve(ResolveFieldContext context, FieldMiddlewareDelegate next)
+		{
+			if ("IntrospectionQuery".Equals(context.Operation.Name)) {
+				return next(context);
+			}
+			
+			_context.SaveChanges();
+			return next(context);
+		}
+	}
+}

--- a/src/Hedwig/GraphQL/HedwigExecutor.cs
+++ b/src/Hedwig/GraphQL/HedwigExecutor.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Options;
+using Hedwig.Data;
+using Hedwig.Schema;
+using GraphQL;
+using GraphQL.Types;
+using GraphQL.Server;
+using GraphQL.Server.Internal;
+using GraphQL.Instrumentation;
+using GraphQL.Validation;
+using GraphQL.Execution;
+
+
+namespace Hedwig.GraphQL
+{
+	public class HedwigExecutor<TSchema> : DefaultGraphQLExecuter<TSchema>
+		where TSchema : ISchema
+	{
+		private readonly IEnumerable<IFieldsMiddleware> _middlewares;
+
+		public HedwigExecutor(
+			IEnumerable<IFieldsMiddleware> middlewares,
+			TSchema schema,
+			IDocumentExecuter documentExecuter,
+			IOptions<GraphQLOptions> options,
+			IEnumerable<IDocumentExecutionListener> listeners,
+			IEnumerable<IValidationRule> validationRules)
+			: base(schema, documentExecuter, options, listeners, validationRules)
+		{
+			_middlewares = middlewares;
+		}
+
+		protected override ExecutionOptions GetOptions(string operationName, string query, Inputs variables, object context, CancellationToken cancellationToken)
+		{
+			var opts = base.GetOptions(operationName, query, variables, context, cancellationToken);
+			foreach (var middleware in _middlewares)
+			{
+				opts.FieldMiddleware.Use(next =>
+				{
+					return _context =>
+					{
+						return middleware.Resolve(_context, next);
+					};
+				});
+			}
+			
+			return opts;
+		}
+	}
+}

--- a/src/Hedwig/GraphQL/IFieldsMiddleware.cs
+++ b/src/Hedwig/GraphQL/IFieldsMiddleware.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using GraphQL.Instrumentation;
+
+namespace Hedwig.GraphQL
+{
+	public interface IFieldsMiddleware
+	{
+		Task<object> Resolve(ResolveFieldContext context, FieldMiddlewareDelegate next);
+	}
+}

--- a/src/Hedwig/Repositories/ChildRepository.cs
+++ b/src/Hedwig/Repositories/ChildRepository.cs
@@ -21,9 +21,9 @@ namespace Hedwig.Repositories
 			return dict as IDictionary<Guid, Child>;
 		}
 
-		public Task<Child> GetChildByIdAsync(Guid id, DateTime? asOf = null)
+		public async Task<Child> GetChildByIdAsync(Guid id, DateTime? asOf = null)
 		{
-			return GetBaseQuery<Child>(asOf)
+			return await GetBaseQuery<Child>(asOf)
 				.Where(c => c.Id == id)
 				.SingleOrDefaultAsync();
 		}
@@ -36,6 +36,12 @@ namespace Hedwig.Repositories
 
 			return children.ToLookup(c => (int) c.FamilyId);
 		}
+
+		public Child UpdateFamily(Child child, Family family)
+		{
+			child.Family = family;
+			return child;
+		}
 	}
 
 	public interface IChildRepository
@@ -43,5 +49,6 @@ namespace Hedwig.Repositories
 		Task<IDictionary<Guid, Child>> GetChildrenByIdsAsync(IEnumerable<Guid> ids, DateTime? asOf = null);
 		Task<Child> GetChildByIdAsync(Guid id, DateTime? asOf = null);
 		Task<ILookup<int, Child>> GetChildrenByFamilyIdsAsync(IEnumerable<int> familyIds, DateTime? asOf = null);
+		Child UpdateFamily(Child child, Family family);
 	}
 }

--- a/src/Hedwig/Repositories/EnrollmentRepository.cs
+++ b/src/Hedwig/Repositories/EnrollmentRepository.cs
@@ -25,15 +25,9 @@ namespace Hedwig.Repositories
 			return enrollments.ToLookup(x => x.SiteId);
 		}
 
-		public Task<Enrollment> GetEnrollmentByIdAsync(int id, DateTime? asOf = null) {
-			return GetBaseQuery<Enrollment>(asOf)
+		public async Task<Enrollment> GetEnrollmentByIdAsync(int id, DateTime? asOf = null) {
+			return await GetBaseQuery<Enrollment>(asOf)
 				.SingleOrDefaultAsync(e => e.Id == id);
-		}
-
-		public Enrollment UpdateEnrollment(Enrollment enrollment)
-		{
-			_context.SaveChanges();
-			return enrollment;
 		}
 	}
 
@@ -46,7 +40,6 @@ namespace Hedwig.Repositories
 			DateTime? to = null
 		);
 		Task<Enrollment> GetEnrollmentByIdAsync(int id, DateTime? asOf = null);
-		Enrollment UpdateEnrollment(Enrollment enrollment);
 	}
 
 	public static class EnrollmentQueryExtensions

--- a/src/Hedwig/Repositories/FamilyRepository.cs
+++ b/src/Hedwig/Repositories/FamilyRepository.cs
@@ -19,10 +19,39 @@ namespace Hedwig.Repositories
 				.ToDictionaryAsync(x => x.Id);
 			return dict as IDictionary<int, Family>;
 		}
+
+		public Family CreateFamily(
+			string addressLine1 = null,
+			string addressLine2 = null,
+			string town = null,
+			string state = null,
+			string zip = null,
+			bool homelessness = false)
+		{
+			var family = new Family {
+				AddressLine1 = addressLine1,
+				AddressLine2 = addressLine2,
+				Town = town,
+				State = state,
+				Zip = zip,
+				Homelessness = homelessness
+			};
+
+			_context.Add<Family>(family);
+			return family;
+		}
 	}
 
 	public interface IFamilyRepository
 	{
 		Task<IDictionary<int, Family>> GetFamiliesByIdsAsync(IEnumerable<int> ids, DateTime? asOf = null);
+		Family CreateFamily(
+			string addressLine1 = null,
+			string addressLine2 = null,
+			string town = null,
+			string state = null,
+			string zip = null,
+			bool homelessness = false
+		);
 	}
 }

--- a/src/Hedwig/Repositories/ReportRepository.cs
+++ b/src/Hedwig/Repositories/ReportRepository.cs
@@ -40,22 +40,14 @@ namespace Hedwig.Repositories
 			return reports;
 		}
 
-		public Task<Report> GetReportByIdAsync(int id) => _context.Reports
+		public async Task<Report> GetReportByIdAsync(int id) => await _context.Reports
 			.Include(r => r.ReportingPeriod)
 			.FirstOrDefaultAsync(r => r.Id == id);
-
-		public Report UpdateReport(Report report)
-		{
-			_context.Update(report);
-			_context.SaveChanges();
-			return report;
-		}
 	}
 
 	public interface IReportRepository
 	{
 		Task<IEnumerable<Report>> GetReportsByUserIdAsync(int userId);
 		Task<Report> GetReportByIdAsync(int id);
-		Report UpdateReport(Report report);
 	}
 }

--- a/src/Hedwig/Repositories/UserRepository.cs
+++ b/src/Hedwig/Repositories/UserRepository.cs
@@ -11,7 +11,7 @@ namespace Hedwig.Repositories
 
 		public UserRepository(HedwigContext context) => _context = context;
 
-		public Task<User> GetUserByIdAsync(int id) => _context.Users.SingleOrDefaultAsync(u => u.Id == id);
+		public async Task<User> GetUserByIdAsync(int id) => await _context.Users.SingleOrDefaultAsync(u => u.Id == id);
 	}
 
 	public interface IUserRepository

--- a/src/Hedwig/Schema/AppErrorMessages.cs
+++ b/src/Hedwig/Schema/AppErrorMessages.cs
@@ -6,5 +6,8 @@ namespace Hedwig.Schema
         public static string NOT_FOUND(string type, int id) {
             return string.Format(NOT_FOUND_TMPL, type, id);
         }
+        public static string NOT_FOUND(string type, string id) {
+            return string.Format(NOT_FOUND_TMPL, type, id);
+        }
     }
 }

--- a/src/Hedwig/Schema/AppSchema.cs
+++ b/src/Hedwig/Schema/AppSchema.cs
@@ -1,11 +1,11 @@
-using GraphQL;
+using graphQL = GraphQL;
 using Hedwig.Schema.Mutations;
 
 namespace Hedwig.Schema
 {
-	public class AppSchema : GraphQL.Types.Schema
+	public class AppSchema : graphQL::Types.Schema
 	{
-		public AppSchema(IDependencyResolver resolver)
+		public AppSchema(graphQL::IDependencyResolver resolver)
 			: base(resolver)
 		{
 			Query = resolver.Resolve<AppQuery>();

--- a/src/Hedwig/Schema/Mutations/EnrollmentMutation.cs
+++ b/src/Hedwig/Schema/Mutations/EnrollmentMutation.cs
@@ -51,7 +51,7 @@ namespace Hedwig.Schema.Mutations
 						enrollment.Exit = exit;
 					}
 
-					return repository.UpdateEnrollment(enrollment);
+					return enrollment;
 				}
 			);
 		}

--- a/src/Hedwig/Schema/Mutations/FamilyMutation.cs
+++ b/src/Hedwig/Schema/Mutations/FamilyMutation.cs
@@ -1,0 +1,75 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using Hedwig.Security;
+
+namespace Hedwig.Schema.Mutations
+{
+	public class FamilyMutation : ObjectGraphType<Family>, IAppSubMutation, IAuthorizedGraphType
+	{
+		public FamilyMutation(
+			IFamilyRepository repository,
+			IChildRepository childRepo)
+		{
+			FieldAsync<FamilyType>(
+				"createFamilyWithChild",
+				arguments: new QueryArguments(
+					new QueryArgument<StringGraphType>{ Name = "addressLine1" },
+					new QueryArgument<StringGraphType>{ Name = "addressLine2" },
+					new QueryArgument<StringGraphType>{ Name = "town" },
+					new QueryArgument<StringGraphType>{ Name = "state" },
+					new QueryArgument<StringGraphType>{ Name = "zip" },
+					new QueryArgument<BooleanGraphType>{ Name = "homelessness" },
+					new QueryArgument<NonNullGraphType<StringGraphType>>{ Name = "childId" }
+				),
+				resolve: async context =>
+				{
+					var childStringId = context.GetArgument<string>("childId");
+					var childId = Guid.Parse(childStringId);
+
+					var child = (Child) await childRepo.GetChildByIdAsync(childId);
+					if (child == null)
+					{
+						throw new ExecutionError(
+							AppErrorMessages.NOT_FOUND("Child", childId.ToString())
+						);
+					}
+
+					var addressLine1 = context.GetArgument<string>("addressLine1");
+					var addressLine2 = context.GetArgument<string>("addressLine2");
+					var town = context.GetArgument<string>("town");
+					var state = context.GetArgument<string>("state");
+					var zip = context.GetArgument<string>("zip");
+					var homelessness = context.GetArgument<bool>("homelessness");
+
+					var family = repository.CreateFamily(
+						addressLine1: addressLine1,
+						addressLine2: addressLine2,
+						town: town,
+						state: state,
+						zip: zip,
+						homelessness: homelessness
+					);
+
+					childRepo.UpdateFamily(child, family);
+
+					return family;
+				}
+			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedPolicy");
+			rules.Allow("IsDeveloperPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Schema/Mutations/ReportMutation.cs
+++ b/src/Hedwig/Schema/Mutations/ReportMutation.cs
@@ -29,8 +29,8 @@ namespace Hedwig.Schema.Mutations
                     }
 
                     report.SubmittedAt = DateTime.Now.ToUniversalTime();
-                    report.Accredited =context.GetArgument<bool>("accredited");
-                    return repository.UpdateReport(report);
+                    report.Accredited = context.GetArgument<bool>("accredited");
+                    return report;
                 }
             );
         }

--- a/src/Hedwig/Schema/Queries/ChildQuery.cs
+++ b/src/Hedwig/Schema/Queries/ChildQuery.cs
@@ -9,18 +9,18 @@ namespace Hedwig.Schema.Queries
 	{
 		public ChildQuery(IChildRepository repository)
 		{
-			Field<ChildType>(
+			FieldAsync<ChildType>(
 				"child",
 				arguments: new QueryArguments(
 					new QueryArgument<NonNullGraphType<IdGraphType>>{ Name = "id" },
 					new QueryArgument<DateGraphType>{ Name = "asOf" }
 				),
-				resolve: context => 
+				resolve: async context => 
 				{
 					var id = context.GetArgument<Guid>("id");
 					var asOf = context.GetArgument<DateTime?>("asOf");
 					SetAsOfGlobal(context, asOf);
-					return repository.GetChildByIdAsync(id, asOf);
+					return await repository.GetChildByIdAsync(id, asOf);
 				}
 			);
 		}

--- a/src/Hedwig/Schema/Queries/EnrollmentQuery.cs
+++ b/src/Hedwig/Schema/Queries/EnrollmentQuery.cs
@@ -9,18 +9,18 @@ namespace Hedwig.Schema.Queries
 	{
 		public EnrollmentQuery(IEnrollmentRepository repository)
 		{
-            Field<EnrollmentType>(
+            FieldAsync<EnrollmentType>(
                 "enrollment",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "id" },
                     new QueryArgument<DateGraphType> { Name = "asOf" }
                 ),
-                resolve: context => 
+                resolve: async context => 
                 {
                     var id = context.GetArgument<int>("id");
                     DateTime? asOf = context.GetArgument<DateTime?>("asOf");
                     SetAsOfGlobal(context, asOf);
-                    return repository.GetEnrollmentByIdAsync(id, asOf);
+                    return await repository.GetEnrollmentByIdAsync(id, asOf);
                 }
             );
 		}

--- a/src/Hedwig/Schema/Queries/ReportQuery.cs
+++ b/src/Hedwig/Schema/Queries/ReportQuery.cs
@@ -8,15 +8,15 @@ namespace Hedwig.Schema.Queries
     {
         public ReportQuery(IReportRepository repository)
         {
-            Field<ReportType>(
+            FieldAsync<ReportType>(
                 "report",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "id" }
                 ),
-                resolve: context => 
+                resolve: async context => 
                 {
                     var id = context.GetArgument<int>("id");
-                    return repository.GetReportByIdAsync(id);
+                    return await repository.GetReportByIdAsync(id);
                 }
             );
         }

--- a/src/Hedwig/Schema/Queries/UserQuery.cs
+++ b/src/Hedwig/Schema/Queries/UserQuery.cs
@@ -11,26 +11,26 @@ namespace Hedwig.Schema.Queries
 	{
 		public UserQuery(IUserRepository repository)
 		{
-			Field<UserType>(
+			FieldAsync<UserType>(
 				"user",
 				arguments: new QueryArguments(
 					new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "id" }
 					),
-				resolve: context =>
+				resolve: async context =>
 				{
 					var id = context.GetArgument<int>("id");
-					return repository.GetUserByIdAsync(id);
+					return await repository.GetUserByIdAsync(id);
 				}
 			);
-			Field<UserType>(
+			FieldAsync<UserType>(
 				"me",
 				arguments: new QueryArguments(),
-				resolve: context =>
+				resolve: async context =>
 				{
 					var user = GetRequestContext(context).User;
 					var subClaim = user.FindFirst("sub");
 					var id = Int32.Parse(subClaim?.Value ?? "");
-					return repository.GetUserByIdAsync(id);
+					return await repository.GetUserByIdAsync(id);
 				}
 			);
 		}

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -7,8 +7,10 @@ using Hedwig.Schema.Queries;
 using Hedwig.Schema.Mutations;
 using Hedwig.Schema;
 using Hedwig.Security;
+using Hedwig.GraphQL;
 using GraphQL;
 using GraphQL.Server;
+using GraphQL.Server.Internal;
 using GraphQL.Authorization;
 using GraphQL.Validation;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -82,14 +84,25 @@ namespace Hedwig
 			// Add Mutations
 			services.AddScoped<IAppSubMutation, ReportMutation>();
 			services.AddScoped<IAppSubMutation, EnrollmentMutation>();
+			services.AddScoped<IAppSubMutation, FamilyMutation>();
+
+			// Add Middlewares
+			services.AddScoped<IFieldsMiddleware, CommitMutationFieldsMiddleware>();
 
 			services.AddScoped<IDependencyResolver>(s => new FuncDependencyResolver(s.GetRequiredService));
 			services.AddScoped<AppSchema>();
 
-			services.AddGraphQL(o => { o.ExposeExceptions = false; })
+			services.AddGraphQL(o =>
+				{
+					o.ExposeExceptions = false;
+				})
 				.AddGraphTypes(ServiceLifetime.Scoped)
 				.AddDataLoader()
 				.AddUserContextBuilder<RequestContext>(RequestContext.RequestContextCreator);
+
+			// Add Executer
+			// NOTE: This must come after services.AddGraphQL
+			services.AddScoped(typeof(IGraphQLExecuter<>), typeof(HedwigExecutor<>));
 		}
 
 		public static void ConfigureAuthentication(this IServiceCollection services)

--- a/test/HedwigTests/Helpers/FamilyHelper.cs
+++ b/test/HedwigTests/Helpers/FamilyHelper.cs
@@ -11,7 +11,7 @@ namespace HedwigTests.Helpers
 		public static Family CreateFamily(HedwigContext context)
 		{
 			var family = new Family();
-			context.Families.Add(family);
+			context.Add<Family>(family);
 			context.SaveChanges();
 			return family;
 		}

--- a/test/HedwigTests/Integration/GraphQLMutations/FamilyMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/FamilyMutationTests.cs
@@ -1,0 +1,127 @@
+using Xunit;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using Hedwig.Models;
+using Hedwig.Schema;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+	public class FamilyMutationTests
+	{
+		[Fact]
+		public async Task Create_Family_With_All_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var child = ChildHelper.CreateChild(api.Context);
+				var addressLine1 = "123 Home St";
+				var addressLine2 = "Apt 1";
+				var town = "Hometown";
+				var state = "Homestate";
+				var zip = "12345";
+				var homelessness = false;
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createFamilyWithChild (
+							addressLine1: ""{addressLine1}"",
+							addressLine2: ""{addressLine2}"",
+							town: ""{town}"",
+							state: ""{state}"",
+							zip: ""{zip}"",
+							homelessness: false,
+							childId: ""{child.Id}""
+						) {{
+							children {{
+								id
+							}}
+							addressLine1
+							addressLine2
+							town
+							state
+							zip
+							homelessness
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Family family = await response.GetObjectFromGraphQLResponse<Family>("createFamilyWithChild");
+				Assert.Equal(addressLine1, family.AddressLine1);
+				Assert.Equal(addressLine2, family.AddressLine2);
+				Assert.Equal(town, family.Town);
+				Assert.Equal(state, family.State);
+				Assert.Equal(zip, family.Zip);
+				Assert.Equal(homelessness, family.Homelessness);
+				Assert.Equal(child.Id, family.Children.Single().Id);
+			}
+		}
+
+		[Fact]
+		public async Task Create_Family_With_Partial_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var child = ChildHelper.CreateChild(api.Context);
+				var addressLine1 = "123 Home St";
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createFamilyWithChild (
+							addressLine1: ""{addressLine1}"",
+							childId: ""{child.Id}""
+						) {{
+							children {{
+								id
+							}}
+							addressLine1
+							homelessness
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Family family = await response.GetObjectFromGraphQLResponse<Family>("createFamilyWithChild");
+				Assert.Equal(addressLine1, family.AddressLine1);
+				Assert.False(family.Homelessness);
+				Assert.Equal(child.Id, family.Children.Single().Id);
+			}
+		}
+
+		[Fact]
+		public async Task Create_Family_Child_Id_Not_Found()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var invalidId = Guid.Empty;
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createFamilyWithChild (
+							childId: ""{invalidId}""
+						) {{
+							children {{
+								id
+							}}
+						}}
+					}}"
+				);
+
+				// Then
+				var gqlResponse = await response.ParseGraphQLResponse();
+				Assert.NotEmpty(gqlResponse.Errors);
+				Assert.Equal(AppErrorMessages.NOT_FOUND("Child", invalidId.ToString()), gqlResponse.Errors[0].Message);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Repositories/ReportRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/ReportRepositoryTests.cs
@@ -39,24 +39,5 @@ namespace HedwigTests.Repositories
 				Assert.DoesNotContain(otherReport.Id, reportIds);
 			}
 		}
-
-		[Fact]
-		public void Update_Report()
-		{
-			using (var context = new TestContextProvider(retainObjects: true).Context)
-			{
-				// If a report exists in the DB
-				var report = ReportHelper.CreateCdcReport(context);
-
-				// When the report is updated
-				var submittedAt = DateTime.Now.ToUniversalTime();
-				report.SubmittedAt = submittedAt;
-				var reportRepo = new ReportRepository(context);
-				var updated = reportRepo.UpdateReport(report);
-
-				// Then the updated report is returned
-				Assert.Equal(submittedAt, updated.SubmittedAt);
-			}
-		}
 	}
 }


### PR DESCRIPTION
This adds the create family method to family and the update family method to child.

Removes saving changes to db context from repositories to a commit mutation middleware.

Cleans up async/await code.

Should resolve #169 