### PR TITLE
170: Add family determination mutations

### DIFF
--- a/src/Hedwig/Repositories/FamilyDeterminationRepository.cs
+++ b/src/Hedwig/Repositories/FamilyDeterminationRepository.cs
@@ -20,10 +20,69 @@ namespace Hedwig.Repositories
 
 			return determinations.ToLookup(d => d.FamilyId);
 		}
+
+		public Task<FamilyDetermination> GetDeterminationByIdAsync(int id, DateTime? asOf = null)
+		{
+			return GetBaseQuery<FamilyDetermination>(asOf)
+				.FirstOrDefaultAsync(d => d.Id == id);
+		}
+
+		public FamilyDetermination CreateFamilyDetermination(
+			int numberOfPeople,
+			decimal income,
+			DateTime determined,
+			int familyId
+		)
+		{
+			var familyDetermination = new FamilyDetermination {
+				NumberOfPeople = numberOfPeople,
+				Income = income,
+				Determined = determined,
+				FamilyId = familyId
+			};
+			_context.Add(familyDetermination);
+			return familyDetermination;
+		}
+
+		public FamilyDetermination UpdateFamilyDetermination(
+			FamilyDetermination determination,
+			int? numberOfPeople,
+			decimal? income,
+			DateTime? determined
+		)
+		{
+			if(numberOfPeople.HasValue) {
+				determination.NumberOfPeople = numberOfPeople.Value;
+			}
+
+			if(income.HasValue) {
+				determination.Income = income.Value;
+			}
+
+			if(determined.HasValue) {
+				determination.Determined = determined.Value;
+			}
+
+			return determination;
+		}
 	}
 
 	public interface IFamilyDeterminationRepository
 	{
 		Task<ILookup<int, FamilyDetermination>> GetDeterminationsByFamilyIdsAsync(IEnumerable<int> familyIds, DateTime? asOf = null);
+		Task<FamilyDetermination> GetDeterminationByIdAsync(int id, DateTime? asOf = null);
+		FamilyDetermination CreateFamilyDetermination(
+			int numberOfPeople,
+			decimal income,
+			DateTime determined,
+			int familyId
+		);
+
+		FamilyDetermination UpdateFamilyDetermination(
+			FamilyDetermination determination,
+			int? numberOfPeople = null,
+			decimal? income = null,
+			DateTime? determined = null
+		);
 	}
 }

--- a/src/Hedwig/Repositories/FamilyRepository.cs
+++ b/src/Hedwig/Repositories/FamilyRepository.cs
@@ -20,6 +20,12 @@ namespace Hedwig.Repositories
 			return dict as IDictionary<int, Family>;
 		}
 
+		public async Task<Family> GetFamilyByIdAsync(int id, DateTime? asOf = null)
+		{
+			return await GetBaseQuery<Family>(asOf)
+				.FirstOrDefaultAsync(f => f.Id == id);
+		}
+
 		public Family CreateFamily(
 			string addressLine1 = null,
 			string addressLine2 = null,
@@ -45,6 +51,7 @@ namespace Hedwig.Repositories
 	public interface IFamilyRepository
 	{
 		Task<IDictionary<int, Family>> GetFamiliesByIdsAsync(IEnumerable<int> ids, DateTime? asOf = null);
+		Task<Family> GetFamilyByIdAsync(int id, DateTime? asOf = null);
 		Family CreateFamily(
 			string addressLine1 = null,
 			string addressLine2 = null,

--- a/src/Hedwig/Schema/Mutations/FamilyDeterminationMutation.cs
+++ b/src/Hedwig/Schema/Mutations/FamilyDeterminationMutation.cs
@@ -1,0 +1,77 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System;
+
+namespace Hedwig.Schema.Mutations
+{
+    public class FamilyDeterminationMutation : ObjectGraphType<FamilyDetermination>, IAppSubMutation
+    {
+        public FamilyDeterminationMutation(IFamilyDeterminationRepository familyDeterminations, IFamilyRepository families)
+        {
+            FieldAsync<FamilyDeterminationType>(
+                "createFamilyDetermination",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "familyId" },
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "numberOfPeople" },
+                    new QueryArgument<NonNullGraphType<DecimalGraphType>> { Name = "income" },
+                    new QueryArgument<NonNullGraphType<DateGraphType>> { Name = "determined" }
+                ),
+                resolve: async context => 
+                {
+                    var familyId = context.GetArgument<int>("familyId");
+                    var family = await families.GetFamilyByIdAsync(familyId);
+                    if ( family == null) {
+                        throw new ExecutionError(
+                            AppErrorMessages.NOT_FOUND("Family", familyId)
+                        );
+                    }
+
+                    var numberOfPeople = context.GetArgument<int>("numberOfPeople");
+                    var income = context.GetArgument<decimal>("income");
+                    var determined = context.GetArgument<DateTime>("determined");
+
+                    var determination = familyDeterminations.CreateFamilyDetermination(
+                        numberOfPeople: numberOfPeople,
+                        income: income,
+                        determined: determined,
+                        familyId: family.Id
+                    );
+                    return determination;
+                }
+            );
+            FieldAsync<FamilyDeterminationType>(
+                "updateFamilyDetermination",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "id" },
+                    new QueryArgument<IntGraphType> { Name = "numberOfPeople" },
+                    new QueryArgument<DecimalGraphType> { Name = "income" },
+                    new QueryArgument<DateGraphType> { Name = "determined" }
+                ),
+                resolve: async context => 
+                {
+                    var id = context.GetArgument<int>("id");
+                    var determination = await familyDeterminations.GetDeterminationByIdAsync(id);
+                    if (determination == null) {
+                        throw new ExecutionError(
+                            AppErrorMessages.NOT_FOUND("FamilyDetermination", id)
+                        );
+                    }
+
+                    var numberOfPeople = context.GetArgument<int?>("numberOfPeople");
+                    var income = context.GetArgument<decimal?>("income");
+                    var determined = context.GetArgument<DateTime?>("determined");
+
+                    return familyDeterminations.UpdateFamilyDetermination(
+                        determination,
+                        numberOfPeople: numberOfPeople,
+                        income: income,
+                        determined: determined
+                    );
+                }
+            );
+        }
+    }
+}

--- a/src/Hedwig/Schema/Types/FamilyDeterminationType.cs
+++ b/src/Hedwig/Schema/Types/FamilyDeterminationType.cs
@@ -1,16 +1,30 @@
 using Hedwig.Models;
 using GraphQL.Types;
+using System;
+using GraphQL.DataLoader;
+using Hedwig.Repositories;
 
 namespace Hedwig.Schema.Types
 {
-	public class FamilyDeterminationType : HedwigGraphType<FamilyDetermination>
+	public class FamilyDeterminationType : TemporalGraphType<FamilyDetermination>
 	{
-		public FamilyDeterminationType()
+		public FamilyDeterminationType(IDataLoaderContextAccessor dataLoader, IFamilyRepository families)
 		{
 			Field(d => d.Id);
 			Field(d => d.NumberOfPeople);
 			Field(d => d.Income);
 			Field(d => d.Determined);
+			Field<NonNullGraphType<FamilyType>>(
+				"family",
+				resolve: context => {
+					DateTime? asOf = GetAsOfGlobal(context);
+					String loaderCacheKey = $"GetChildByIdsAsync{asOf.ToString()}";
+					var loader = dataLoader.Context.GetOrAddBatchLoader<int, Family>(
+						loaderCacheKey,
+						(ids) => families.GetFamiliesByIdsAsync(ids, asOf));
+					return loader.LoadAsync(context.Source.FamilyId);
+				}
+			);
 		}
 	}
 }

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -85,6 +85,7 @@ namespace Hedwig
 			services.AddScoped<IAppSubMutation, ReportMutation>();
 			services.AddScoped<IAppSubMutation, EnrollmentMutation>();
 			services.AddScoped<IAppSubMutation, FamilyMutation>();
+			services.AddScoped<IAppSubMutation, FamilyDeterminationMutation>();
 
 			// Add Middlewares
 			services.AddScoped<IFieldsMiddleware, CommitMutationFieldsMiddleware>();

--- a/test/HedwigTests/Integration/GraphQLMutations/FamilyDeterminationMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/FamilyDeterminationMutationTests.cs
@@ -1,0 +1,125 @@
+using Xunit;
+using Hedwig.Models;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+using Hedwig.Schema;
+using System;
+using System.Threading.Tasks;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+    public class FamilyDeterminationMutationTests
+    {
+        [Fact]
+        public async Task Create_Family_Determination()
+        {
+            using (var api = new TestApiProvider()) {
+                var numberOfPeople = 4;
+                var income = 20000M;
+                var determined = DateTime.Now.Date;
+                var family = FamilyHelper.CreateFamily(api.Context);
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        createFamilyDetermination(
+                            familyId: {family.Id},
+                            numberOfPeople: {numberOfPeople},
+                            income: ""{income}"",
+                            determined: ""{determined}""
+                        ) {{
+                            family {{ id }}
+                            numberOfPeople
+                            income
+                            determined
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                FamilyDetermination determination = await response.GetObjectFromGraphQLResponse<FamilyDetermination>("createFamilyDetermination");
+                Assert.Equal(family.Id, determination.Family.Id);
+                Assert.Equal(numberOfPeople, determination.NumberOfPeople);
+                Assert.Equal(income, determination.Income);
+                Assert.Equal(determined, determination.Determined);
+            }
+        }
+
+        [Fact]
+        public async Task Create_Family_Determination_Family_Id_Not_Found()
+        {
+            using (var api = new TestApiProvider()) {
+                var numberOfPeople = 4;
+                var income = 20000M;
+                var determined = DateTime.Now;
+                var invalidId = 0;
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        createFamilyDetermination(
+                            familyId: {invalidId},
+                            numberOfPeople: {numberOfPeople},
+                            income: {income},
+                            determined: ""{determined}""
+                        ) {{
+                            family {{ id }}
+                            numberOfPeople
+                            income
+                            determined
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                var gqlResponse = await response.ParseGraphQLResponse();
+                Assert.NotEmpty(gqlResponse.Errors);
+                Assert.Equal(AppErrorMessages.NOT_FOUND("Family", invalidId), gqlResponse.Errors[0].Message);
+            }
+        }
+
+        [Fact]
+        public async Task Update_Family_Determination()
+        {
+            using (var api = new TestApiProvider()) {
+                var determination = FamilyDeterminationHelper.CreateDetermination(api.Context);
+                var numberOfPeople = 10;
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        updateFamilyDetermination(
+                            id: {determination.Id},
+                            numberOfPeople: {numberOfPeople}
+                        ) {{
+                            numberOfPeople
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                FamilyDetermination updated = await response.GetObjectFromGraphQLResponse<FamilyDetermination>("updateFamilyDetermination");
+                Assert.Equal(numberOfPeople, updated.NumberOfPeople);
+            }
+        }
+
+        [Fact]
+        public async Task Update_Family_Determination_Not_Found()
+        {
+            using (var api = new TestApiProvider()) {
+                var invalidId = 0;
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        updateFamilyDetermination(
+                            id: {invalidId}
+                        ) {{
+                            id
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                var gqlResponse = await response.ParseGraphQLResponse();
+                Assert.NotEmpty(gqlResponse.Errors);
+                Assert.Equal(AppErrorMessages.NOT_FOUND("FamilyDetermination", invalidId), gqlResponse.Errors[0].Message);
+            }
+        }
+    }
+}

--- a/test/HedwigTests/Repositories/FamilyDeterminationRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/FamilyDeterminationRepositoryTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 using Hedwig.Repositories;
 using HedwigTests.Helpers;
 using HedwigTests.Fixtures;
+using System;
 
 namespace HedwigTests.Repositories
 {
@@ -32,6 +33,44 @@ namespace HedwigTests.Repositories
 
 				// And no other site Ids are returned
 				Assert.False(res.Contains(family1.Id));
+			}
+		}
+
+		[Fact]
+		public async Task Get_Determination_By_Id()
+		{
+			using (var context = new TestContextProvider().Context) {
+				var determination = FamilyDeterminationHelper.CreateDetermination(context);
+
+				var determinationRepo = new FamilyDeterminationRepository(context);
+				var res = await determinationRepo.GetDeterminationByIdAsync(determination.Id);
+
+				Assert.Equal(determination.Id, res.Id);
+			}
+		}
+
+		[Fact]
+		public void Create_Family_Determination()
+		{
+			using(var context = new TestContextProvider().Context)
+			{
+				var numberOfPeople = 4;
+				var income = 20000M;
+				var determined = DateTime.Now;
+				var family = FamilyHelper.CreateFamily(context);
+
+				var determinationRepo = new FamilyDeterminationRepository(context);
+				var determination = determinationRepo.CreateFamilyDetermination(
+					numberOfPeople,
+					income,
+					determined,
+					family.Id
+				);
+
+				Assert.Equal(numberOfPeople, determination.NumberOfPeople);
+				Assert.Equal(income, determination.Income);
+				Assert.Equal(determined, determination.Determined);
+				Assert.Equal(family.Id, determination.FamilyId);
 			}
 		}
 	}

--- a/test/HedwigTests/Repositories/FamilyRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/FamilyRepositoryTests.cs
@@ -56,5 +56,18 @@ namespace HedwigTests.Repositories
                 Assert.Null(resAsOf.First().Value.AddressLine1);
             }
         }
+
+        [Fact]
+        public async Task Get_Family_By_Id()
+        {
+            using (var context = new TestContextProvider().Context) {
+                var family = FamilyHelper.CreateFamily(context);
+
+                var familyRepo = new FamilyRepository(context);
+                var res = await familyRepo.GetFamilyByIdAsync(family.Id);
+
+                Assert.Equal(family.Id, res.Id);
+            }
+        }
     }
 }


### PR DESCRIPTION
I opted to put the null-checking logic into the repository `UpdateFamilyDetermination` function, as opposed to handling it in the mutation itself. This was easy enough to do because none of the familydetermination fields are nullable; if they have a value, use it to update, if not then nothing changes. Not sure it's what we want to do / should do / can do for objects with nullable fields, but it seemed the cleanest here. 

closes #170 #176 