### PR TITLE
209: reconcile frontend with backend changes

### DIFF
--- a/src/Hedwig/ClientApp/src/generated/ChildQuery.ts
+++ b/src/Hedwig/ClientApp/src/generated/ChildQuery.ts
@@ -76,9 +76,9 @@ export interface ChildQuery_child {
 }
 
 export interface ChildQuery {
-  child: ChildQuery_child | null;
+	child: ChildQuery_child | null;
 }
 
 export interface ChildQueryVariables {
-  id: string;
+	id: string;
 }

--- a/src/Hedwig/ClientApp/src/generated/RosterQuery.ts
+++ b/src/Hedwig/ClientApp/src/generated/RosterQuery.ts
@@ -35,22 +35,22 @@ export interface RosterQuery_me_sites_enrollments {
 }
 
 export interface RosterQuery_me_sites {
-  __typename: "SiteType";
-  id: number;
-  name: string;
-  enrollments: RosterQuery_me_sites_enrollments[];
+	__typename: 'SiteType';
+	id: number;
+	name: string;
+	enrollments: RosterQuery_me_sites_enrollments[];
 }
 
 export interface RosterQuery_me {
-  __typename: "UserType";
-  sites: RosterQuery_me_sites[];
+	__typename: 'UserType';
+	sites: RosterQuery_me_sites[];
 }
 
 export interface RosterQuery {
-  me: RosterQuery_me | null;
+	me: RosterQuery_me | null;
 }
 
 export interface RosterQueryVariables {
-  from?: OECDate | null;
-  to?: OECDate | null;
+	from?: OECDate | null;
+	to?: OECDate | null;
 }


### PR DESCRIPTION
Remove fields from queries/generated types that have been removed from backend:
- funding: entry, exit,
- family: casenumber