### PR TITLE
233: Adds a mocked rest backend to the docker-compose project

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,18 @@ services:
     entrypoint:
       - sh
       - /entrypoint.sh
+  rest-backend:
+    image: clue/json-server
+    volumes:
+      - ./rest-backend/db.json:/db.json
+      - ./rest-backend/routes.json:/routes.json
+    ports:
+      - 6000:3000
+    entrypoint:
+      - json-server
+      - --routes
+      - /routes.json
+      - /db.json
   client:
     image: node:12
     volumes:

--- a/rest-backend/db.json
+++ b/rest-backend/db.json
@@ -1,0 +1,156 @@
+{
+  "organizations": [
+    { "id": 1 }
+  ],
+  "sites": [
+    { "id": 1 , "organizationId": 1}
+  ],
+  "children": [
+    {
+      "id": "f93b1e4c-98ee-426e-12dd-08d7639ce3fc",
+      "firstName": "Alan",
+      "middleName": null,
+      "lastName": "Rickman",
+      "suffix": null,
+      "birthCertificateId": null,
+      "birthdate": "2018-12-07",
+      "birthTown": null,
+      "birthState": null,
+      "gender": "MALE",
+      "americanIndianOrAlaskaNative": false,
+      "asian": false,
+      "blackOrAfricanAmerican": false,
+      "hispanicOrLatinxEthnicity": false,
+      "nativeHawaiianOrPacificIslander": false,
+      "white": false,
+      "foster": false
+    },
+    {
+      "id": "93769dbf-b424-48d2-12de-08d7639ce3fc",
+      "firstName": "David",
+      "middleName": null,
+      "lastName": "Thewlis",
+      "suffix": null,
+      "birthCertificateId": null,
+      "birthdate": "2016-07-29",
+      "birthTown": null,
+      "birthState": null,
+      "gender": "MALE",
+      "americanIndianOrAlaskaNative": false,
+      "asian": false,
+      "blackOrAfricanAmerican": false,
+      "hispanicOrLatinxEthnicity": false,
+      "nativeHawaiianOrPacificIslander": false,
+      "white": false,
+      "foster": false
+    },
+    {
+      "id": "2322ad0d-0808-409b-12df-08d7639ce3fc",
+      "firstName": "Helena",
+      "middleName": null,
+      "lastName": "Bonham Carter",
+      "suffix": null,
+      "birthCertificateId": null,
+      "birthdate": "2016-01-01",
+      "birthTown": null,
+      "birthState": null,
+      "gender": "FEMALE",
+      "americanIndianOrAlaskaNative": false,
+      "asian": false,
+      "blackOrAfricanAmerican": false,
+      "hispanicOrLatinxEthnicity": false,
+      "nativeHawaiianOrPacificIslander": false,
+      "white": false,
+      "foster": false
+    }
+  ],
+  "families": [
+    {
+      "id": 1,
+      "addressLine1": "1234 Street St",
+      "addressLine2": "Apt 1",
+      "town": "Townville",
+      "state": "NY",
+      "zip": "12345",
+      "homelessness": false
+    },
+    {
+      "id": 2,
+      "addressLine1": "1234 Road Rd",
+      "addressLine2": "",
+      "town": "Cityopolis",
+      "state": "NY",
+      "zip": "12345",
+      "homelessness": false
+    },
+    {
+      "id": 3,
+      "addressLine1": "1234 Avenue Ave",
+      "addressLine2": "",
+      "town": "Suburberg",
+      "state": "NY",
+      "zip": "12345",
+      "homelessness": true
+    }
+  ],
+  "determinations": [
+    {
+      "id": 1,
+      "familyId": 1,
+      "determined": "2019-01-01",
+      "numberOfPeople": 6,
+      "income": 60000
+    },
+    {
+      "id": 2,
+      "familyId": 2,
+      "determined": "2019-01-01",
+      "numberOfPeople": 4,
+      "income": 40000
+    },
+    {
+      "id": 3,
+      "familyId": 3,
+      "determined": "2019-01-01",
+      "numberOfPeople": 2,
+      "income": 20000
+    }
+
+  ],
+  "enrollments": [
+    {
+      "id": 1,
+      "siteId": 1,
+      "childId": "93769dbf-b424-48d2-12de-08d7639ce3fc"
+    },
+    {
+      "id": 2,
+      "siteId": 1,
+      "childId": "f93b1e4c-98ee-426e-12dd-08d7639ce3fc"
+    },
+    {
+      "id": 3,
+      "siteId": 1,
+      "childId": "f93b1e4c-98ee-426e-12dd-08d7639ce3fc"
+    }
+  ],
+  "fundings": [
+    {
+      "type": "CDC",
+      "time": "PART",
+      "enrollmentId": 1
+    },
+    {
+      "type": "CDC",
+      "time": "FULL",
+      "enrollmentId": 2
+    }
+  ],
+  "reports": [
+    {
+      "id": 1,
+      "siteId": 1,
+      "accredited": true
+    }
+  ]
+}

--- a/rest-backend/routes.json
+++ b/rest-backend/routes.json
@@ -1,0 +1,15 @@
+{
+  "/organizations/1/sites/1": "/sites/1",
+  "/organizations/1/sites/1/enrollments": "/enrollments",
+  "/organizations/1/sites/1/enrollments/:id": "/enrollments/:id",
+  "/organizations/1/sites/1/enrollments/:id/fundings": "/enrollments/:id/fundings",
+  "/organizations/1/sites/1/enrollments/:_/fundings/:id": "/fundings/:id",
+  "/organizations/1/sites/1/children": "/children",
+  "/organizations/1/sites/1/children/:id": "/children/:id",
+  "/organizations/1/sites/1/families": "/families",
+  "/organizations/1/sites/1/families/:id": "/families/:id",
+  "/organizations/1/sites/1/families/:id/determinations": "/families/:id/determinations",
+  "/organizations/1/sites/1/families/:_/determinations/:id": "/determinations/:id",
+  "/organizations/1/reports": "/reports",
+  "/organizations/1/reports/:id": "/reports/:id"
+}


### PR DESCRIPTION
adds a simple json server to docker-compose project that serves static data at localhost:6000

missing: family not accessible via child route. we did not determine in API v2 Spec (#230) if we want to expose family on the child via an optional `include=family` or `includeFamily=true` qs param

closes #233 