### PR TITLE
Integrate rest and graphql

### DIFF
--- a/src/Hedwig/GraphQL/CommitMutationFieldsMiddleware.cs
+++ b/src/Hedwig/GraphQL/CommitMutationFieldsMiddleware.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using GraphQL.Instrumentation;
+using GraphQL.Types;
+using Hedwig.Data;
+
+namespace Hedwig.GraphQL
+{
+	public class CommitMutationFieldsMiddleware : IFieldsMiddleware
+	{
+		private readonly HedwigContext _context;
+		public CommitMutationFieldsMiddleware(HedwigContext context)
+		{
+			_context = context;
+		}
+
+		public Task<object> Resolve(ResolveFieldContext context, FieldMiddlewareDelegate next)
+		{
+			if ("IntrospectionQuery".Equals(context.Operation.Name)) {
+				return next(context);
+			}
+			
+			_context.SaveChanges();
+			return next(context);
+		}
+	}
+}

--- a/src/Hedwig/GraphQL/EfDocumentExecutor.cs
+++ b/src/Hedwig/GraphQL/EfDocumentExecutor.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Execution;
+using GraphQL.Instrumentation;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
+using static GraphQL.Execution.ExecutionHelper;
+using ExecutionContext = GraphQL.Execution.ExecutionContext;
+
+namespace Hedwig.GraphQL
+{
+    public class EfDocumentExecuter : DocumentExecuter
+    {
+        public EfDocumentExecuter() : base()
+        {
+        }
+
+        public EfDocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IComplexityAnalyzer complexityAnalyzer)
+          : base(documentBuilder, documentValidator, complexityAnalyzer)
+        {
+        }
+
+        protected override IExecutionStrategy SelectExecutionStrategy(ExecutionContext context)
+        {
+            switch (context.Operation.OperationType)
+            {
+                case OperationType.Query:
+                    return new SerialExecutionStrategy();
+
+                case OperationType.Mutation:
+                    return new SerialExecutionStrategy();
+
+                case OperationType.Subscription:
+                    return new SubscriptionExecutionStrategy();
+
+                default:
+                    throw new InvalidOperationException($"Unexpected OperationType {context.Operation.OperationType}");
+            }
+        }
+    }
+}

--- a/src/Hedwig/GraphQL/HedwigExecutor.cs
+++ b/src/Hedwig/GraphQL/HedwigExecutor.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Options;
+using Hedwig.Data;
+using Hedwig.Schema;
+using GraphQL;
+using GraphQL.Types;
+using GraphQL.Server;
+using GraphQL.Server.Internal;
+using GraphQL.Instrumentation;
+using GraphQL.Validation;
+using GraphQL.Execution;
+
+
+namespace Hedwig.GraphQL
+{
+	public class HedwigExecutor<TSchema> : DefaultGraphQLExecuter<TSchema>
+		where TSchema : ISchema
+	{
+		private readonly IEnumerable<IFieldsMiddleware> _middlewares;
+
+		public HedwigExecutor(
+			IEnumerable<IFieldsMiddleware> middlewares,
+			TSchema schema,
+			IDocumentExecuter documentExecuter,
+			IOptions<GraphQLOptions> options,
+			IEnumerable<IDocumentExecutionListener> listeners,
+			IEnumerable<IValidationRule> validationRules)
+			: base(schema, documentExecuter, options, listeners, validationRules)
+		{
+			_middlewares = middlewares;
+		}
+
+		protected override ExecutionOptions GetOptions(string operationName, string query, Inputs variables, IDictionary<string, object> context, CancellationToken cancellationToken)
+		{
+			var opts = base.GetOptions(operationName, query, variables, context, cancellationToken);
+			foreach (var middleware in _middlewares)
+			{
+				opts.FieldMiddleware.Use(next =>
+				{
+					return _context =>
+					{
+						return middleware.Resolve(_context, next);
+					};
+				});
+			}
+			
+			return opts;
+		}
+	}
+}

--- a/src/Hedwig/GraphQL/IFieldsMiddleware.cs
+++ b/src/Hedwig/GraphQL/IFieldsMiddleware.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using GraphQL.Instrumentation;
+
+namespace Hedwig.GraphQL
+{
+	public interface IFieldsMiddleware
+	{
+		Task<object> Resolve(ResolveFieldContext context, FieldMiddlewareDelegate next);
+	}
+}

--- a/src/Hedwig/Hedwig.csproj
+++ b/src/Hedwig/Hedwig.csproj
@@ -16,6 +16,12 @@
 
   <ItemGroup>
     <PackageReference Include="AWS.Logger.AspNetCore" Version="2.1.1" />
+    <!-- GraphQL Support -->
+    <PackageReference Include="GraphQL" Version="3.0.0-preview-1271" />
+    <PackageReference Include="GraphQL.Authorization" Version="2.1.29" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.5.0-alpha0027 " />
+    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.5.0-alpha0027" />
+    <!-- End GraphQL Support -->
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.0.0" />

--- a/src/Hedwig/Repositories/FundingRepository.cs
+++ b/src/Hedwig/Repositories/FundingRepository.cs
@@ -21,9 +21,9 @@ namespace Hedwig.Repositories
 			return fundings.ToLookup(x => x.EnrollmentId);
 		}
 
-		public Task<Funding> GetFundingByIdAsync(int id, DateTime? asOf = null)
+		public async Task<Funding> GetFundingByIdAsync(int id, DateTime? asOf = null)
 		{
-			return GetBaseQuery<Funding>(asOf)
+			return await GetBaseQuery<Funding>(asOf)
 				.FirstOrDefaultAsync(f => f.Id == id);
 		}
 

--- a/src/Hedwig/Schema/AppErrorMessages.cs
+++ b/src/Hedwig/Schema/AppErrorMessages.cs
@@ -1,0 +1,20 @@
+namespace Hedwig.Schema
+{
+    public static class AppErrorMessages
+    {
+        private static string NOT_FOUND_TMPL = "{0} with id {1} not found";
+        private static string BAD_REQUEST_TMPL = "Bad request for {0}";
+
+        public static string NOT_FOUND(string type, string id) {
+            return string.Format(NOT_FOUND_TMPL, type, id);
+        }
+
+        public static string NOT_FOUND(string type, int id) {
+            return string.Format(NOT_FOUND_TMPL, type, id);
+        }
+
+        public static string BAD_REQUEST(string type) {
+            return string.Format(BAD_REQUEST_TMPL, type);
+        }
+    }
+}

--- a/src/Hedwig/Schema/AppMutation.cs
+++ b/src/Hedwig/Schema/AppMutation.cs
@@ -1,0 +1,19 @@
+using GraphQL.Types;
+using Hedwig.Schema.Mutations;
+using System.Collections.Generic;
+
+namespace Hedwig.Schema
+{
+    public class AppMutation : ObjectGraphType<object>
+    {
+        public AppMutation(IEnumerable<IAppSubMutation> appSubMutations)
+        {
+            foreach(var mutation in appSubMutations) {
+                foreach (var field in mutation.Fields) {
+                    AddField(field);
+                }
+            }
+            
+        }
+    }
+}

--- a/src/Hedwig/Schema/AppQuery.cs
+++ b/src/Hedwig/Schema/AppQuery.cs
@@ -1,0 +1,19 @@
+using Hedwig.Schema.Queries;
+using GraphQL.Types;
+using System.Collections.Generic;
+
+namespace Hedwig.Schema
+{
+	public class AppQuery : ObjectGraphType<object>
+	{
+		public AppQuery(IEnumerable<IAppSubQuery> appSubQueries)
+		{
+			foreach(var subquery in appSubQueries) {
+				foreach(var field in subquery.Fields) {
+					AddField(field);
+				}
+			}
+		}
+	}
+
+}

--- a/src/Hedwig/Schema/AppSchema.cs
+++ b/src/Hedwig/Schema/AppSchema.cs
@@ -1,0 +1,16 @@
+using graphQL = GraphQL;
+using Hedwig.Schema.Mutations;
+using System;
+
+namespace Hedwig.Schema
+{
+	public class AppSchema : graphQL::Types.Schema
+	{
+		public AppSchema(IServiceProvider resolver)
+			: base(resolver)
+		{
+			Query = (AppQuery) resolver.GetService(typeof(AppQuery));
+			Mutation = (AppMutation) resolver.GetService(typeof(AppMutation));
+		}
+	}
+}

--- a/src/Hedwig/Schema/HedwigGraphType.cs
+++ b/src/Hedwig/Schema/HedwigGraphType.cs
@@ -1,0 +1,12 @@
+using GraphQL.Types;
+
+namespace Hedwig.Schema
+{
+    public class HedwigGraphType<T> : ObjectGraphType<T>
+    {
+        public static RequestContext GetRequestContext(ResolveFieldContext<T> context)
+        {
+            return context.UserContext as RequestContext;
+        }
+    }
+}

--- a/src/Hedwig/Schema/Mutations/ChildMutation.cs
+++ b/src/Hedwig/Schema/Mutations/ChildMutation.cs
@@ -1,0 +1,251 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using Hedwig.Security;
+
+namespace Hedwig.Schema.Mutations
+{
+	public class ChildMutation : ObjectGraphType<Child>, IAppSubMutation, IAuthorizedGraphType
+	{
+		public ChildMutation(
+			IChildRepository repository,
+			IEnrollmentRepository enrollmentRepo,
+			ISiteRepository siteRepo)
+		{
+			FieldAsync<ChildType>(
+				"createChildWithSiteEnrollment",
+				arguments: new QueryArguments(
+				  new QueryArgument<StringGraphType>{ Name = "sasid" },
+					new QueryArgument<NonNullGraphType<StringGraphType>>{ Name = "firstName" },
+					new QueryArgument<StringGraphType>{ Name = "middleName" },
+					new QueryArgument<NonNullGraphType<StringGraphType>>{ Name = "lastName" },
+					new QueryArgument<StringGraphType>{ Name = "suffix" },
+					new QueryArgument<StringGraphType>{ Name = "birthdate" },
+					new QueryArgument<StringGraphType>{ Name = "birthCertificateId" },
+					new QueryArgument<StringGraphType>{ Name = "birthTown" },
+					new QueryArgument<StringGraphType>{ Name = "birthState" },
+					new QueryArgument<GenderEnumType>{ Name = "gender" },
+					new QueryArgument<BooleanGraphType>{ Name = "americanIndianOrAlaskaNative" },
+					new QueryArgument<BooleanGraphType>{ Name = "asian" },
+					new QueryArgument<BooleanGraphType>{ Name = "blackOrAfricanAmerican" },
+					new QueryArgument<BooleanGraphType>{ Name = "nativeHawaiianOrPacificIslander" },
+					new QueryArgument<BooleanGraphType>{ Name = "white" },
+					new QueryArgument<BooleanGraphType>{ Name = "hispanicOrLatinxEthnicity" },
+					new QueryArgument<BooleanGraphType>{ Name = "foster" },
+					new QueryArgument<NonNullGraphType<IntGraphType>>{ Name = "siteId" }
+				),
+				resolve: async context =>
+				{
+					var sasid = context.GetArgument<string>("sasid");
+					var firstName = context.GetArgument<string>("firstName");
+					var middleName = context.GetArgument<string>("middleName");
+					var lastName = context.GetArgument<string>("lastName");
+					var suffix = context.GetArgument<string>("suffix");
+					var birthdateStr = context.GetArgument<string>("birthdate");
+					var birthCertificateId = context.GetArgument<string>("birthCertificateId");
+					var birthTown = context.GetArgument<string>("birthTown");
+					var birthState = context.GetArgument<string>("birthState");
+					var gender = (Gender) (context.GetArgument<Gender?>("gender") ?? Gender.Unspecified);
+					var americanIndianOrAlaskaNative = context.GetArgument<bool?>("americanIndianOrAlaskaNative") ?? false;
+					var asian = context.GetArgument<bool?>("asian") ?? false;
+					var blackOrAfricanAmerican = context.GetArgument<bool?>("blackOrAfricanAmerican") ?? false;
+					var nativeHawaiianOrPacificIslander = context.GetArgument<bool?>("nativeHawaiianOrPacificIslander") ?? false;
+					var white = context.GetArgument<bool?>("white") ?? false;
+					var hispanicOrLatinxEthnicity = context.GetArgument<bool?>("hispanicOrLatinxEthnicity") ?? false;
+					var foster = context.GetArgument<bool?>("foster") ?? false;
+					var siteId = context.GetArgument<int>("siteId");
+
+					var site = await siteRepo.GetSiteByIdAsync(siteId);
+					if (site == null)
+					{
+						throw new ExecutionError(
+							AppErrorMessages.NOT_FOUND("Site", siteId.ToString())
+						);
+					}
+
+					DateTime? birthdate = null;
+
+					if (birthdateStr != null)
+					{
+						try {
+							birthdate = ValueConverter.ConvertTo<DateTime>(birthdateStr);
+						}
+						catch (FormatException)
+						{
+						}
+					}
+
+					var child = repository.CreateChild(
+					  sasid: sasid,
+						firstName: firstName,
+						middleName: middleName,
+						lastName: lastName,
+						suffix: suffix,
+						birthdate: birthdate,
+						birthCertificateId: birthCertificateId,
+						birthTown: birthTown,
+						birthState: birthState,
+						americanIndianOrAlaskaNative: americanIndianOrAlaskaNative,
+						asian: asian,
+						blackOrAfricanAmerican: blackOrAfricanAmerican,
+						nativeHawaiianOrPacificIslander: nativeHawaiianOrPacificIslander,
+						white: white,
+						hispanicOrLatinxEthnicity: hispanicOrLatinxEthnicity,
+						gender: gender,
+						foster: foster
+					);
+
+					enrollmentRepo.CreateEnrollment(child.Id, site.Id);
+
+					return child;
+				}
+			);
+			FieldAsync<ChildType>(
+				"updateChild",
+				arguments: new QueryArguments(
+					new QueryArgument<NonNullGraphType<StringGraphType>>{ Name = "id" },
+				  new QueryArgument<StringGraphType>{ Name = "sasid" },
+					new QueryArgument<StringGraphType>{ Name = "firstName" },
+					new QueryArgument<StringGraphType>{ Name = "middleName" },
+					new QueryArgument<StringGraphType>{ Name = "lastName" },
+					new QueryArgument<StringGraphType>{ Name = "suffix" },
+					new QueryArgument<StringGraphType>{ Name = "birthdate" },
+					new QueryArgument<StringGraphType>{ Name = "birthCertificateId" },
+					new QueryArgument<StringGraphType>{ Name = "birthTown" },
+					new QueryArgument<StringGraphType>{ Name = "birthState" },
+					new QueryArgument<GenderEnumType>{ Name = "gender" },
+					new QueryArgument<BooleanGraphType>{ Name = "americanIndianOrAlaskaNative" },
+					new QueryArgument<BooleanGraphType>{ Name = "asian" },
+					new QueryArgument<BooleanGraphType>{ Name = "blackOrAfricanAmerican" },
+					new QueryArgument<BooleanGraphType>{ Name = "nativeHawaiianOrPacificIslander" },
+					new QueryArgument<BooleanGraphType>{ Name = "white" },
+					new QueryArgument<BooleanGraphType>{ Name = "hispanicOrLatinxEthnicity" },
+					new QueryArgument<BooleanGraphType>{ Name = "foster" }
+				),
+				resolve: async context =>
+				{
+					var idStr = context.GetArgument<string>("id");
+					var id = Guid.Parse(idStr);
+					var child = await repository.GetChildByIdAsync(id);
+					if (child == null)
+					{
+						throw new ExecutionError(
+							AppErrorMessages.NOT_FOUND("Child", id.ToString())
+						);
+					}
+
+					var sasid = context.GetArgument<string>("sasid");
+					var firstName = context.GetArgument<string>("firstName");
+					var middleName = context.GetArgument<string>("middleName");
+					var lastName = context.GetArgument<string>("lastName");
+					var suffix = context.GetArgument<string>("suffix");
+					var birthdateStr = context.GetArgument<string>("birthdate");
+					var birthCertificateId = context.GetArgument<string>("birthCertificateId");
+					var birthTown = context.GetArgument<string>("birthTown");
+					var birthState = context.GetArgument<string>("birthState");
+					var gender = context.GetArgument<Gender?>("gender");
+					var americanIndianOrAlaskaNative = context.GetArgument<bool?>("americanIndianOrAlaskaNative");
+					var asian = context.GetArgument<bool?>("asian");
+					var blackOrAfricanAmerican = context.GetArgument<bool?>("blackOrAfricanAmerican");
+					var nativeHawaiianOrPacificIslander = context.GetArgument<bool?>("nativeHawaiianOrPacificIslander");
+					var white = context.GetArgument<bool?>("white");
+					var hispanicOrLatinxEthnicity = context.GetArgument<bool?>("hispanicOrLatinxEthnicity");
+					var foster = context.GetArgument<bool?>("foster");
+
+					if (sasid != null)
+					{
+						child.Sasid = sasid;
+					}
+					if (firstName != null)
+					{
+						child.FirstName = firstName;
+					}
+					if (middleName != null)
+					{
+						child.MiddleName = middleName;
+					}
+					if (lastName != null)
+					{
+						child.LastName = lastName;
+					}
+					if (suffix != null)
+					{
+						child.Suffix = suffix;
+					}
+					if (birthdateStr != null)
+					{
+						DateTime? birthdate;
+						try {
+							birthdate = ValueConverter.ConvertTo<DateTime>(birthdateStr);
+						}
+						catch (FormatException)
+						{
+							birthdate = null;
+						}
+						child.Birthdate = birthdate;
+					}
+					if (birthCertificateId != null)
+					{
+						child.BirthCertificateId = birthCertificateId;
+					}
+					if (birthTown != null)
+					{
+						child.BirthTown = birthTown;
+					}
+					if (birthState != null)
+					{
+						child.BirthState = birthState;
+					}
+					if (gender is Gender _gender)
+					{
+						child.Gender = _gender;
+					}
+					if (americanIndianOrAlaskaNative is bool _americanIndianOrAlaskaNative)
+					{
+						child.AmericanIndianOrAlaskaNative = _americanIndianOrAlaskaNative;
+					}
+					if (asian is bool _asian)
+					{
+						child.Asian = _asian;
+					}
+					if (blackOrAfricanAmerican is bool _blackOrAfricanAmerican)
+					{
+						child.BlackOrAfricanAmerican = _blackOrAfricanAmerican;
+					}
+					if (nativeHawaiianOrPacificIslander is bool _nativeHawaiianOrPacificIslander)
+					{
+						child.NativeHawaiianOrPacificIslander = _nativeHawaiianOrPacificIslander;
+					}
+					if (white is bool _white)
+					{
+						child.White = _white;
+					}
+					if (hispanicOrLatinxEthnicity is bool _hispanicOrLatinxEthnicity)
+					{
+						child.HispanicOrLatinxEthnicity = _hispanicOrLatinxEthnicity;
+					}
+					if (foster is bool _foster)
+					{
+						child.Foster = _foster;
+					}
+
+					return child;
+				}
+			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedPolicy");
+			rules.Allow("IsDeveloperPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Schema/Mutations/EnrollmentMutation.cs
+++ b/src/Hedwig/Schema/Mutations/EnrollmentMutation.cs
@@ -1,0 +1,73 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System.Collections.Generic;
+using System;
+
+namespace Hedwig.Schema.Mutations
+{
+	public class EnrollmentMutation : ObjectGraphType<Enrollment>, IAppSubMutation
+	{
+		public EnrollmentMutation(IEnrollmentRepository repository)
+		{
+			FieldAsync<EnrollmentType>(
+				"updateEnrollment",
+				arguments: new QueryArguments(
+					new QueryArgument<NonNullGraphType<IntGraphType>>{ Name = "id" },
+					new QueryArgument<StringGraphType>{ Name = "entry" },
+					new QueryArgument<StringGraphType>{ Name = "exit" },
+					new QueryArgument<AgeEnumType> {Name = "age" }
+				),
+				resolve: async context =>
+				{
+					var id = context.GetArgument<int>("id");
+					var enrollment = await repository.GetEnrollmentByIdAsync(id);
+					if (enrollment == null)
+					{
+						throw new ExecutionError(
+							AppErrorMessages.NOT_FOUND("Enrollment", id)
+						);
+					}
+
+					var age = context.GetArgument<Age?>("age");
+					var entryStr = context.GetArgument<String>("entry");
+					var exitStr = context.GetArgument<String>("exit");
+
+					if(age != null) {
+						enrollment.Age = age;
+					}
+
+					if (entryStr != null)
+					{
+						DateTime? entry;
+						try {
+							entry = ValueConverter.ConvertTo<DateTime>(entryStr);
+						}
+						catch (FormatException)
+						{
+							entry = null;
+						}
+						enrollment.Entry = entry;
+					}
+
+					if (exitStr != null)
+					{
+						DateTime? exit;
+						try {
+							exit = ValueConverter.ConvertTo<DateTime>(exitStr);
+						}
+						catch (FormatException)
+						{
+							exit = null;
+						}
+						enrollment.Exit = exit;
+					}
+
+					return enrollment;
+				}
+			);
+		}
+	}
+}

--- a/src/Hedwig/Schema/Mutations/FamilyDeterminationMutation.cs
+++ b/src/Hedwig/Schema/Mutations/FamilyDeterminationMutation.cs
@@ -1,0 +1,97 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System;
+
+namespace Hedwig.Schema.Mutations
+{
+    public class FamilyDeterminationMutation : ObjectGraphType<FamilyDetermination>, IAppSubMutation
+    {
+        public FamilyDeterminationMutation(IFamilyDeterminationRepository familyDeterminations, IFamilyRepository families)
+        {
+            FieldAsync<FamilyDeterminationType>(
+                "createFamilyDetermination",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "familyId" },
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "numberOfPeople" },
+                    new QueryArgument<NonNullGraphType<DecimalGraphType>> { Name = "income" },
+                    new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "determined" }
+                ),
+                resolve: async context =>
+                {
+                    var familyId = context.GetArgument<int>("familyId");
+                    var family = await families.GetFamilyByIdAsync(familyId);
+                    if ( family == null) {
+                        throw new ExecutionError(
+                            AppErrorMessages.NOT_FOUND("Family", familyId)
+                        );
+                    }
+
+                    var numberOfPeople = context.GetArgument<int>("numberOfPeople");
+                    var income = context.GetArgument<decimal>("income");
+                    var determinedStr = context.GetArgument<DateTime>("determined");
+
+										try {
+											var determined = ValueConverter.ConvertTo<DateTime>(determinedStr);
+
+	                    var determination = familyDeterminations.CreateFamilyDetermination(
+	                        numberOfPeople: numberOfPeople,
+	                        income: income,
+	                        determined: determined,
+	                        familyId: family.Id
+	                    );
+	                    return determination;
+										}
+										catch (FormatException)
+										{
+                      throw new ExecutionError(
+                          AppErrorMessages.BAD_REQUEST("FamilyDetermination")
+                      );
+										}
+                }
+            );
+            FieldAsync<FamilyDeterminationType>(
+                "updateFamilyDetermination",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "id" },
+                    new QueryArgument<IntGraphType> { Name = "numberOfPeople" },
+                    new QueryArgument<DecimalGraphType> { Name = "income" },
+                    new QueryArgument<StringGraphType> { Name = "determined" }
+                ),
+                resolve: async context =>
+                {
+                    var id = context.GetArgument<int>("id");
+                    var determination = await familyDeterminations.GetDeterminationByIdAsync(id);
+                    if (determination == null) {
+                        throw new ExecutionError(
+                            AppErrorMessages.NOT_FOUND("FamilyDetermination", id)
+                        );
+                    }
+
+                    var numberOfPeople = context.GetArgument<int?>("numberOfPeople");
+                    var income = context.GetArgument<decimal?>("income");
+                    var determinedStr = context.GetArgument<String>("determined");
+
+										try {
+											var determined = ValueConverter.ConvertTo<DateTime>(determinedStr);
+
+	                    return familyDeterminations.UpdateFamilyDetermination(
+	                        determination,
+	                        numberOfPeople: numberOfPeople,
+	                        income: income,
+	                        determined: determined
+	                    );
+										}
+										catch (FormatException)
+										{
+                      throw new ExecutionError(
+                          AppErrorMessages.BAD_REQUEST("FamilyDetermination")
+                      );
+										}
+                }
+            );
+        }
+    }
+}

--- a/src/Hedwig/Schema/Mutations/FamilyMutation.cs
+++ b/src/Hedwig/Schema/Mutations/FamilyMutation.cs
@@ -1,0 +1,133 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using Hedwig.Security;
+
+namespace Hedwig.Schema.Mutations
+{
+	public class FamilyMutation : ObjectGraphType<Family>, IAppSubMutation, IAuthorizedGraphType
+	{
+		public FamilyMutation(
+			IFamilyRepository repository,
+			IChildRepository childRepo)
+		{
+			FieldAsync<FamilyType>(
+				"createFamilyWithChild",
+				arguments: new QueryArguments(
+					new QueryArgument<StringGraphType>{ Name = "addressLine1" },
+					new QueryArgument<StringGraphType>{ Name = "addressLine2" },
+					new QueryArgument<StringGraphType>{ Name = "town" },
+					new QueryArgument<StringGraphType>{ Name = "state" },
+					new QueryArgument<StringGraphType>{ Name = "zip" },
+					new QueryArgument<BooleanGraphType>{ Name = "homelessness" },
+					new QueryArgument<NonNullGraphType<StringGraphType>>{ Name = "childId" }
+				),
+				resolve: async context =>
+				{
+					var childStringId = context.GetArgument<string>("childId");
+					var childId = Guid.Parse(childStringId);
+
+					var child = await childRepo.GetChildByIdAsync(childId);
+					if (child == null)
+					{
+						throw new ExecutionError(
+							AppErrorMessages.NOT_FOUND("Child", childId.ToString())
+						);
+					}
+
+					var addressLine1 = context.GetArgument<string>("addressLine1");
+					var addressLine2 = context.GetArgument<string>("addressLine2");
+					var town = context.GetArgument<string>("town");
+					var state = context.GetArgument<string>("state");
+					var zip = context.GetArgument<string>("zip");
+					var homelessness = context.GetArgument<bool>("homelessness");
+
+					var family = repository.CreateFamily(
+						addressLine1: addressLine1,
+						addressLine2: addressLine2,
+						town: town,
+						state: state,
+						zip: zip,
+						homelessness: homelessness
+					);
+
+					childRepo.UpdateFamily(child, family);
+
+					return family;
+				}
+			);
+			FieldAsync<FamilyType>(
+				"updateFamily",
+				arguments: new QueryArguments(
+					new QueryArgument<NonNullGraphType<IntGraphType>>{ Name = "id" },
+					new QueryArgument<StringGraphType>{ Name = "addressLine1" },
+					new QueryArgument<StringGraphType>{ Name = "addressLine2" },
+					new QueryArgument<StringGraphType>{ Name = "town" },
+					new QueryArgument<StringGraphType>{ Name = "state" },
+					new QueryArgument<StringGraphType>{ Name = "zip" },
+					new QueryArgument<BooleanGraphType>{ Name = "homelessness" }				
+				),
+				resolve: async context =>
+				{
+					var id = context.GetArgument<int>("id");
+
+					var family = await repository.GetFamilyByIdAsync(id);
+					if (family == null)
+					{
+						throw new ExecutionError(
+							AppErrorMessages.NOT_FOUND("Family", id)
+						);
+					}
+
+					var addressLine1 = context.GetArgument<string>("addressLine1");
+					var addressLine2 = context.GetArgument<string>("addressLine2");
+					var town = context.GetArgument<string>("town");
+					var state = context.GetArgument<string>("state");
+					var zip = context.GetArgument<string>("zip");
+					var homelessness = context.GetArgument<bool?>("homelessness");
+
+					if (addressLine1 != null)
+					{
+						family.AddressLine1 = addressLine1;
+					}
+					if (addressLine2 != null)
+					{
+						family.AddressLine2 = addressLine2;
+					}
+					if (town != null)
+					{
+						family.Town = town;
+					}
+					if (state != null)
+					{
+						family.State = state;
+					}
+					if (zip != null)
+					{
+						family.Zip = zip;
+					}
+					if (homelessness is bool _homelessness)
+					{
+						family.Homelessness = _homelessness;
+					}
+
+					return family;
+				}
+			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedPolicy");
+			rules.Allow("IsDeveloperPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Schema/Mutations/FundingMutation.cs
+++ b/src/Hedwig/Schema/Mutations/FundingMutation.cs
@@ -1,0 +1,66 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using Hedwig.Repositories;
+
+namespace Hedwig.Schema.Mutations
+{
+    public class FundingMutation : ObjectGraphType<Funding>, IAppSubMutation
+    {
+        public FundingMutation(IFundingRepository fundings, IEnrollmentRepository enrollments)
+        {
+            FieldAsync<FundingType>(
+                "createFunding",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "enrollmentId" },
+                    new QueryArgument<NonNullGraphType<FundingSourceEnumType>> { Name = "source" },
+                    new QueryArgument<NonNullGraphType<FundingTimeEnumType>> { Name = "time" }
+    
+                ),
+                resolve: async context => 
+                {
+                    var enrollmentId = context.GetArgument<int>("enrollmentId");
+                    var enrollment = await enrollments.GetEnrollmentByIdAsync(enrollmentId);
+                    if (enrollment == null) {
+                        throw new ExecutionError(
+                            AppErrorMessages.NOT_FOUND("Enrollment", enrollmentId)
+                        );
+                    }
+
+                    var source = context.GetArgument<FundingSource>("source");
+                    var time = context.GetArgument<FundingTime>("time");
+
+                    return fundings.CreateFunding(
+                        enrollmentId,
+                        source,
+                        time
+                    );
+                }
+            );
+            FieldAsync<FundingType>(
+                "updateFunding",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "id" },
+                    new QueryArgument<FundingSourceEnumType> { Name = "source" },
+                    new QueryArgument<FundingTimeEnumType> { Name = "time" }
+                ),
+                resolve: async context =>
+                {
+                    var id = context.GetArgument<int>("id");
+                    var funding = await fundings.GetFundingByIdAsync(id);
+                    if (funding == null) {
+                        throw new ExecutionError(
+                            AppErrorMessages.NOT_FOUND("Funding", id)
+                        );
+                    }
+
+                    var source = context.GetArgument<FundingSource?>("source");
+                    var time = context.GetArgument<FundingTime?>("time");
+
+                    return fundings.UpdateFunding(funding, source, time);
+                }
+            );
+        }
+    }
+}

--- a/src/Hedwig/Schema/Mutations/IAppSubMutation.cs
+++ b/src/Hedwig/Schema/Mutations/IAppSubMutation.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Mutations
+{
+    public interface IAppSubMutation
+    {
+        IEnumerable<FieldType> Fields { get; }
+    }
+}

--- a/src/Hedwig/Schema/Mutations/ReportMutation.cs
+++ b/src/Hedwig/Schema/Mutations/ReportMutation.cs
@@ -1,0 +1,38 @@
+using GraphQL.Types;
+using GraphQL;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using Hedwig.Models;
+using System.Collections.Generic;
+using System;
+
+namespace Hedwig.Schema.Mutations
+{
+    public class ReportMutation : ObjectGraphType<Report>, IAppSubMutation
+    {
+        public ReportMutation(IReportRepository repository)
+        {
+            FieldAsync<ReportType>(
+                "submitCdcReport",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>>{ Name = "id" },
+                    new QueryArgument<NonNullGraphType<BooleanGraphType>>{ Name = "accredited" }
+                ),
+                resolve: async context =>
+                {
+                    var id = context.GetArgument<int>("id");
+                    var report = (CdcReport) await repository.GetReportByIdAsync(id);
+                    if (report == null) {
+                        throw new ExecutionError(
+                            AppErrorMessages.NOT_FOUND("Report", id)
+                        );
+                    }
+
+                    report.SubmittedAt = DateTime.Now.ToUniversalTime();
+                    report.Accredited = context.GetArgument<bool>("accredited");
+                    return report;
+                }
+            );
+        }
+    }
+}

--- a/src/Hedwig/Schema/Queries/ChildQuery.cs
+++ b/src/Hedwig/Schema/Queries/ChildQuery.cs
@@ -1,0 +1,28 @@
+using System;
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Queries
+{
+	public class ChildQuery : TemporalGraphType<object>, IAppSubQuery
+	{
+		public ChildQuery(IChildRepository repository)
+		{
+			FieldAsync<ChildType>(
+				"child",
+				arguments: new QueryArguments(
+					new QueryArgument<NonNullGraphType<IdGraphType>>{ Name = "id" },
+					new QueryArgument<DateGraphType>{ Name = "asOf" }
+				),
+				resolve: async context => 
+				{
+					var id = context.GetArgument<Guid>("id");
+					var asOf = context.GetArgument<DateTime?>("asOf");
+					SetAsOfGlobal(context, asOf);
+					return await repository.GetChildByIdAsync(id, asOf);
+				}
+			);
+		}
+	}
+}

--- a/src/Hedwig/Schema/Queries/EnrollmentQuery.cs
+++ b/src/Hedwig/Schema/Queries/EnrollmentQuery.cs
@@ -1,0 +1,28 @@
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using GraphQL.Types;
+using System;
+
+namespace Hedwig.Schema.Queries
+{
+	public class EnrollmentQuery : TemporalGraphType<object>, IAppSubQuery
+	{
+		public EnrollmentQuery(IEnrollmentRepository repository)
+		{
+            FieldAsync<EnrollmentType>(
+                "enrollment",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "id" },
+                    new QueryArgument<DateGraphType> { Name = "asOf" }
+                ),
+                resolve: async context => 
+                {
+                    var id = context.GetArgument<int>("id");
+                    DateTime? asOf = context.GetArgument<DateTime?>("asOf");
+                    SetAsOfGlobal(context, asOf);
+                    return await repository.GetEnrollmentByIdAsync(id, asOf);
+                }
+            );
+		}
+	}
+}

--- a/src/Hedwig/Schema/Queries/IAppSubQuery.cs
+++ b/src/Hedwig/Schema/Queries/IAppSubQuery.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Queries
+{
+	public interface IAppSubQuery
+	{
+		IEnumerable<FieldType> Fields { get; }
+	}
+}

--- a/src/Hedwig/Schema/Queries/ReportQuery.cs
+++ b/src/Hedwig/Schema/Queries/ReportQuery.cs
@@ -1,0 +1,24 @@
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Queries
+{
+    public class ReportQuery : ObjectGraphType<object>, IAppSubQuery
+    {
+        public ReportQuery(IReportRepository repository)
+        {
+            FieldAsync<ReportType>(
+                "report",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "id" }
+                ),
+                resolve: async context => 
+                {
+                    var id = context.GetArgument<int>("id");
+                    return await repository.GetReportByIdAsync(id);
+                }
+            );
+        }
+    }
+}

--- a/src/Hedwig/Schema/Queries/UserQuery.cs
+++ b/src/Hedwig/Schema/Queries/UserQuery.cs
@@ -1,0 +1,38 @@
+using Hedwig.Repositories;
+using Hedwig.Schema.Types;
+using GraphQL.Types;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Hedwig.Schema.Queries
+{
+	public class UserQuery : HedwigGraphType<object>, IAppSubQuery
+	{
+		public UserQuery(IUserRepository repository)
+		{
+			FieldAsync<UserType>(
+				"user",
+				arguments: new QueryArguments(
+					new QueryArgument<NonNullGraphType<IdGraphType>> { Name = "id" }
+					),
+				resolve: async context =>
+				{
+					var id = context.GetArgument<int>("id");
+					return await repository.GetUserByIdAsync(id);
+				}
+			);
+			FieldAsync<UserType>(
+				"me",
+				arguments: new QueryArguments(),
+				resolve: async context =>
+				{
+					var user = GetRequestContext(context).User;
+					var subClaim = user.FindFirst("sub");
+					var id = Int32.Parse(subClaim?.Value ?? "");
+					return await repository.GetUserByIdAsync(id);
+				}
+			);
+		}
+	}
+}

--- a/src/Hedwig/Schema/RequestContext.cs
+++ b/src/Hedwig/Schema/RequestContext.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Security.Claims;
+using GraphQL.Authorization;
+using System.Threading.Tasks;
+
+namespace Hedwig.Schema
+{
+    /// <summary>
+    /// "UserContext" is an extensible, user-created and defined abstract property that can be accessed by all
+    /// resolvers in a request  (https://graphql-dotnet.github.io/docs/getting-started/user-context/). In conjunction 
+    /// with graphql-dotnet/server GraphQLHttpMiddleware, a user context will be created if an appropriate user context
+    /// builder exists in the http context (https://github.com/graphql-dotnet/server/blob/3.4/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs#L81).
+    /// To easily implement an IUserContextBuilder, we take advantage of a graphQL builder function that takes a "creator"
+    /// function and wraps it in a base UserContextBuilderClass.
+    /// (https://github.com/graphql-dotnet/server/blob/3.4/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs#L81)
+    ///
+    /// RequestContext is the concrete class this API implements to act as a UserContext, and RequestContextCreator
+    /// is the creator function passed to the graphQL builder <see cref="ServiceExtensions.ConfigureGraphQL" />
+    /// </summary>
+    public class RequestContext : Dictionary<string, object>, IProvideClaimsPrincipal
+    {
+        /// <summary>
+        /// The creator function to pass to GraphQLBuilder.AddUserContextBuilder()
+        /// </summary>
+        /// <returns>an instantiated RequestContext</returns>
+        public static readonly Func<HttpContext, RequestContext> RequestContextCreator = httpCtx => 
+            new RequestContext(httpCtx.User);
+
+        /// <summary>
+        /// A dictionary of arguments to make globally available to an entire query execution context
+        /// </summary>
+        public IDictionary<string, object> GlobalArguments { get; set; }
+
+        private ClaimsPrincipal _user { get; set; }
+
+        public ClaimsPrincipal User {
+            get { return _user; }
+        }
+
+        public RequestContext(ClaimsPrincipal user = null)
+        {
+            GlobalArguments = new Dictionary<string, object>();
+            _user = user;
+        }
+    }
+}

--- a/src/Hedwig/Schema/TemporalGraphType.cs
+++ b/src/Hedwig/Schema/TemporalGraphType.cs
@@ -1,0 +1,28 @@
+using GraphQL.Types;
+using System;
+
+namespace Hedwig.Schema
+{
+    /// <summary>
+    /// A generic ObjectGraphType with helper functions to get and set temporal query param `asOf`
+    /// on the UserContext object
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class TemporalGraphType<T> : HedwigGraphType<T>
+    {
+        private const String AS_OF_KEY = "asOf";
+        public static void SetAsOfGlobal(ResolveFieldContext<T> context, DateTime? asOf)
+        {
+            var requestContext = GetRequestContext(context);
+            requestContext.GlobalArguments.Add(AS_OF_KEY, asOf);
+        }
+
+        public static DateTime? GetAsOfGlobal(ResolveFieldContext<T> context)
+        {
+            var requestContext = GetRequestContext(context);
+            return requestContext.GlobalArguments.ContainsKey(AS_OF_KEY)
+                ? (DateTime?) requestContext.GlobalArguments["asOf"]
+                : null;
+        }
+    }
+}

--- a/src/Hedwig/Schema/Types/AgeEnumType.cs
+++ b/src/Hedwig/Schema/Types/AgeEnumType.cs
@@ -1,0 +1,13 @@
+using Hedwig.Models;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+    public class AgeEnumType : EnumerationGraphType<Age>
+    {
+        public AgeEnumType()
+        {
+            Name = "Age";
+        }
+    }
+}

--- a/src/Hedwig/Schema/Types/CdcReportType.cs
+++ b/src/Hedwig/Schema/Types/CdcReportType.cs
@@ -1,0 +1,33 @@
+using Hedwig.Models;
+using Hedwig.Repositories;
+using GraphQL.DataLoader;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+	public class CdcReportType : ObjectGraphType<CdcReport>
+	{
+		public CdcReportType(IDataLoaderContextAccessor dataLoader, IOrganizationRepository organizations)
+		{
+			Field(r => r.Id);
+			Field(r => r.Type, type: typeof(NonNullGraphType<FundingSourceEnumType>));
+			Field(r => r.ReportingPeriod.Period);
+			Field(r => r.ReportingPeriod.PeriodStart);
+			Field(r => r.ReportingPeriod.PeriodEnd);
+			Field(r => r.ReportingPeriod.DueAt);
+			Field(r => r.SubmittedAt, nullable: true);
+			Field(r => r.Accredited);
+			Field<NonNullGraphType<OrganizationType>>(
+				"organization",
+				resolve: context =>
+				{
+					var loader = dataLoader.Context.GetOrAddBatchLoader<int, Organization>(
+						"GetOrganizationsByIdsAsync",
+						(ids) => organizations.GetOrganizationsByIdsAsync(ids));
+
+					return loader.LoadAsync(context.Source.OrganizationId);
+				}
+			);
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/ChildType.cs
+++ b/src/Hedwig/Schema/Types/ChildType.cs
@@ -1,0 +1,73 @@
+using System;
+using Hedwig.Models;
+using Hedwig.Repositories;
+using Hedwig.Security;
+using GraphQL.DataLoader;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+	public class ChildType : TemporalGraphType<Child>, IAuthorizedGraphType
+	{
+		public ChildType(IDataLoaderContextAccessor dataLoader, IFamilyRepository families, IEnrollmentRepository enrollments)
+		{
+			Field(c => c.Id, type: typeof(NonNullGraphType<IdGraphType>));
+			Field(c => c.Sasid, nullable: true);
+			Field(c => c.FirstName);
+			Field(c => c.MiddleName, nullable: true);
+			Field(c => c.LastName);
+			Field(c => c.Suffix, nullable: true);
+			Field(c => c.Birthdate, type: typeof(DateGraphType), nullable: true);
+			Field(c => c.BirthCertificateId, nullable: true);
+			Field(c => c.BirthTown, nullable: true);
+			Field(c => c.BirthState, nullable: true);
+			Field(c => c.Gender, type: typeof(GenderEnumType), nullable: true);
+			Field(c => c.AmericanIndianOrAlaskaNative);
+			Field(c => c.Asian);
+			Field(c => c.BlackOrAfricanAmerican);
+			Field(c => c.NativeHawaiianOrPacificIslander);
+			Field(c => c.White);
+			Field(c => c.HispanicOrLatinxEthnicity);
+			Field(c => c.Foster);
+			Field<FamilyType>(
+				"family",
+				resolve: context =>
+				{
+					if (!context.Source.FamilyId.HasValue) { return null; }
+
+					var familyId = context.Source.FamilyId.Value;
+	 				var asOf = GetAsOfGlobal(context);
+					String loaderCacheKey = $"GetFamiliesByIdsAsync{asOf.ToString()}";
+
+					var loader = dataLoader.Context.GetOrAddBatchLoader<int, Family>(
+						loaderCacheKey,
+						(ids) => families.GetFamiliesByIdsAsync(ids, asOf));
+
+					return loader.LoadAsync(familyId);
+				}
+			);
+			Field<NonNullGraphType<ListGraphType<NonNullGraphType<EnrollmentType>>>>(
+				"enrollments",
+				resolve: context =>
+				{
+	 				var asOf = GetAsOfGlobal(context);
+					String loaderCacheKey = $"GetEnrollmentsByChildIdsAsync{asOf.ToString()}";
+
+					var loader = dataLoader.Context.GetOrAddCollectionBatchLoader<Guid, Enrollment>(
+						loaderCacheKey,
+						(ids) => enrollments.GetEnrollmentsByChildIdsAsync(ids, asOf));
+					return loader.LoadAsync(context.Source.Id);
+				}
+			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/EnrollmentType.cs
+++ b/src/Hedwig/Schema/Types/EnrollmentType.cs
@@ -1,0 +1,66 @@
+using System;
+using Hedwig.Models;
+using Hedwig.Repositories;
+using Hedwig.Security;
+using GraphQL.DataLoader;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+    public class EnrollmentType : TemporalGraphType<Enrollment>, IAuthorizedGraphType
+    {
+        public EnrollmentType(IDataLoaderContextAccessor dataLoader, IChildRepository children, IFundingRepository fundings, ISiteRepository sites)
+        {
+            Field(e => e.Id);
+            Field<DateTime?>(e => e.Entry, type: typeof(DateGraphType), nullable: true);
+            Field<DateTime?>(e => e.Exit, type: typeof(DateGraphType), nullable: true);
+            Field(e => e.Age, type: typeof(AgeEnumType));
+            Field<NonNullGraphType<ChildType>>(
+                "child",
+                resolve: context =>
+                {
+                    DateTime? asOf = GetAsOfGlobal(context);
+                    String loaderCacheKey = $"GetChildByIdsAsync{asOf.ToString()}";
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<Guid, Child>(
+                        loaderCacheKey,
+                        (ids) => children.GetChildrenByIdsAsync(ids, asOf));
+
+                    return loader.LoadAsync(context.Source.ChildId);
+                }
+            );
+            Field<NonNullGraphType<SiteType>>(
+                "site",
+                resolve: context =>
+                {
+                    var loader = dataLoader.Context.GetOrAddBatchLoader<int, Site>(
+                        "GetSitesByIdsAsync",
+                        (ids) => sites.GetSitesByIdsAsync(ids));
+
+                    return loader.LoadAsync(context.Source.SiteId);
+                }
+            );
+            FieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<FundingType>>>>(
+                "fundings",
+                resolve: async context =>
+                {
+                    DateTime? asOf = GetAsOfGlobal(context);
+                    String loaderCacheKey = $"GetFundingsByEnrollmentIdsAsync{asOf.ToString()}";
+                    var loader = dataLoader.Context.GetOrAddCollectionBatchLoader<int, Funding>(
+                        loaderCacheKey,
+                        async (ids) => await fundings.GetFundingsByEnrollmentIdsAsync(ids, asOf));
+
+                    return await loader.LoadAsync(context.Source.Id);
+                }
+            );
+        }
+
+        public AuthorizationRules Permissions(AuthorizationRules rules)
+        {
+            rules.DenyNot("IsAuthenticatedUserPolicy");
+            rules.Allow("IsDeveloperInDevPolicy");
+            rules.Allow("IsTestModePolicy");
+            rules.Deny();
+            return rules;
+        }
+    }
+}

--- a/src/Hedwig/Schema/Types/FamilyDeterminationType.cs
+++ b/src/Hedwig/Schema/Types/FamilyDeterminationType.cs
@@ -1,0 +1,39 @@
+using Hedwig.Models;
+using GraphQL.Types;
+using System;
+using GraphQL.DataLoader;
+using Hedwig.Repositories;
+using Hedwig.Security;
+
+namespace Hedwig.Schema.Types
+{
+	public class FamilyDeterminationType : TemporalGraphType<FamilyDetermination>
+	{
+		public FamilyDeterminationType(IDataLoaderContextAccessor dataLoader, IFamilyRepository families)
+		{
+			Field(d => d.Id);
+			Field(d => d.NumberOfPeople);
+			Field(d => d.Income);
+			Field(d => d.Determined);
+			Field<NonNullGraphType<FamilyType>>(
+				"family",
+				resolve: context => {
+					DateTime? asOf = GetAsOfGlobal(context);
+					String loaderCacheKey = $"GetChildByIdsAsync{asOf.ToString()}";
+					var loader = dataLoader.Context.GetOrAddBatchLoader<int, Family>(
+						loaderCacheKey,
+						(ids) => families.GetFamiliesByIdsAsync(ids, asOf));
+					return loader.LoadAsync(context.Source.FamilyId);
+				}
+			);
+		}
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/FamilyType.cs
+++ b/src/Hedwig/Schema/Types/FamilyType.cs
@@ -1,0 +1,52 @@
+using Hedwig.Models;
+using Hedwig.Repositories;
+using GraphQL.DataLoader;
+using GraphQL.Types;
+using System;
+
+namespace Hedwig.Schema.Types
+{
+	public class FamilyType : TemporalGraphType<Family>
+	{
+		public FamilyType(IDataLoaderContextAccessor dataLoader, IChildRepository children, IFamilyDeterminationRepository determinations)
+		{
+			Field(f => f.Id);
+			Field<NonNullGraphType<ListGraphType<NonNullGraphType<ChildType>>>>(
+				"children",
+				resolve: context =>
+				{
+					DateTime? asOf = GetAsOfGlobal(context);
+					String loaderCacheKey = $"GetChildrenByFamilyIdsAsync{asOf.ToString()}";
+
+					var loader = dataLoader.Context.GetOrAddCollectionBatchLoader<int, Child>(
+						loaderCacheKey,
+						(ids) => children.GetChildrenByFamilyIdsAsync(ids, asOf)
+					);
+
+					return loader.LoadAsync(context.Source.Id);
+				}
+			);
+			Field(f => f.AddressLine1, type: typeof(StringGraphType));
+			Field(f => f.AddressLine2, type: typeof(StringGraphType));
+			Field(f => f.Town, type: typeof(StringGraphType));
+			Field(f => f.State, type: typeof(StringGraphType));
+			Field(f => f.Zip, type: typeof(StringGraphType));
+			Field(f => f.Homelessness);
+			Field<NonNullGraphType<ListGraphType<NonNullGraphType<FamilyDeterminationType>>>>(
+				"determinations",
+				resolve: context =>
+				{
+					DateTime? asOf = GetAsOfGlobal(context);
+					String loaderCacheKey = $"GetDeterminationsByFamilyIdsAsync{asOf.ToString()}";
+
+					var loader = dataLoader.Context.GetOrAddCollectionBatchLoader<int, FamilyDetermination>(
+						loaderCacheKey,
+						(ids) => determinations.GetDeterminationsByFamilyIdsAsync(ids, asOf)
+					);
+
+					return loader.LoadAsync(context.Source.Id);
+				}
+			);
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/FundingSourceEnumType.cs
+++ b/src/Hedwig/Schema/Types/FundingSourceEnumType.cs
@@ -1,0 +1,13 @@
+using Hedwig.Models;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+	public class FundingSourceEnumType : EnumerationGraphType<FundingSource>
+	{
+		public FundingSourceEnumType()
+		{
+			Name = "FundingSource";
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/FundingTimeEnumType.cs
+++ b/src/Hedwig/Schema/Types/FundingTimeEnumType.cs
@@ -1,0 +1,13 @@
+using Hedwig.Models;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+    public class FundingTimeEnumType : EnumerationGraphType<FundingTime>
+    {
+        public FundingTimeEnumType()
+        {
+            Name = "FundingTime";
+        }
+    }
+}

--- a/src/Hedwig/Schema/Types/FundingType.cs
+++ b/src/Hedwig/Schema/Types/FundingType.cs
@@ -1,0 +1,42 @@
+using Hedwig.Models;
+using GraphQL.Types;
+using GraphQL.DataLoader;
+using Hedwig.Repositories;
+using Hedwig.Security;
+
+namespace Hedwig.Schema.Types
+{
+	public class FundingType : TemporalGraphType<Funding>
+	{
+		public FundingType(IDataLoaderContextAccessor dataLoader, IEnrollmentRepository enrollments)
+		{
+			Field(f => f.Id);
+			Field(f => f.Source, type: typeof(NonNullGraphType<FundingSourceEnumType>));
+			Field(f => f.Time, type: typeof(NonNullGraphType<FundingTimeEnumType>));
+			Field<EnrollmentType>(
+				"enrollment",
+				resolve: context => 
+				{
+					var enrollmentId = context.Source.EnrollmentId;
+					var asOf = GetAsOfGlobal(context);
+					var loaderCacheKey = $"GetEnrollmentsByIdsAsync{asOf.ToString()}";
+
+					var loader = dataLoader.Context.GetOrAddBatchLoader<int,Enrollment>(
+						loaderCacheKey,
+						(ids) => enrollments.GetEnrollmentsByIdsAsync(ids, asOf)
+					);
+					return loader.LoadAsync(enrollmentId);
+				}
+			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/GenderEnumType.cs
+++ b/src/Hedwig/Schema/Types/GenderEnumType.cs
@@ -1,0 +1,13 @@
+using Hedwig.Models;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+	public class GenderEnumType : EnumerationGraphType<Gender>
+	{
+		public GenderEnumType()
+		{
+			Name = "Gender";
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/OrganizationType.cs
+++ b/src/Hedwig/Schema/Types/OrganizationType.cs
@@ -1,0 +1,29 @@
+using System;
+using Hedwig.Models;
+using Hedwig.Repositories;
+using GraphQL;
+using GraphQL.DataLoader;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+	public class OrganizationType : ObjectGraphType<Organization>
+	{
+		public OrganizationType(IDataLoaderContextAccessor dataLoader, ISiteRepository sites)
+		{
+			Field(o => o.Id);
+			Field(o => o.Name);
+			Field<NonNullGraphType<ListGraphType<NonNullGraphType<SiteType>>>>(
+				"sites",
+				resolve: context =>
+				{
+					var loader = dataLoader.Context.GetOrAddCollectionBatchLoader<int, Site>(
+						"GetSitesByOrganizationIdsAsync",
+						(ids) => sites.GetSitesByOrganizationIdsAsync(ids));
+
+					return loader.LoadAsync(context.Source.Id);
+				}
+			);
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/ReportType.cs
+++ b/src/Hedwig/Schema/Types/ReportType.cs
@@ -1,0 +1,22 @@
+using GraphQL.Types;
+using Hedwig.Security;
+
+namespace Hedwig.Schema.Types
+{
+	public class ReportType : UnionGraphType, IAuthorizedGraphType
+	{
+		public ReportType()
+		{
+			Type<CdcReportType>();
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/SiteType.cs
+++ b/src/Hedwig/Schema/Types/SiteType.cs
@@ -1,0 +1,44 @@
+using System;
+using Hedwig.Models;
+using Hedwig.Repositories;
+using GraphQL;
+using GraphQL.DataLoader;
+using GraphQL.Types;
+
+namespace Hedwig.Schema.Types
+{
+	public class SiteType : TemporalGraphType<Site>
+	{
+		public SiteType(IDataLoaderContextAccessor dataLoader, IEnrollmentRepository enrollments)
+		{
+			Field(s => s.Id);
+			Field(s => s.Name);
+			Field<NonNullGraphType<ListGraphType<NonNullGraphType<EnrollmentType>>>>(
+				"enrollments",
+				arguments: new QueryArguments(
+					new QueryArgument<DateGraphType> { Name = "from" },
+					new QueryArgument<DateGraphType> { Name = "to" }
+				),
+				resolve: context =>
+				{
+					var from = context.GetArgument<DateTime?>("from");
+					var to = context.GetArgument<DateTime?>("to");
+					ValidateDateRangeArguments(from, to);
+					 
+					DateTime? asOf = GetAsOfGlobal(context);
+					String loaderCacheKey = $"GetEnrollmentsBySiteIdsAsync{asOf.ToString()}{from.ToString()}{to.ToString()}";
+					var loader = dataLoader.Context.GetOrAddCollectionBatchLoader<int, Enrollment>(
+						loaderCacheKey,
+						(ids) => enrollments.GetEnrollmentsBySiteIdsAsync(ids, asOf, from, to));
+					return loader.LoadAsync(context.Source.Id);
+				}
+			);
+		}
+        private static void ValidateDateRangeArguments(DateTime? from, DateTime? to)
+		{
+			if(from.HasValue != to.HasValue) {
+            	throw new ExecutionError("Both from and to must be supplied");
+			}	
+		}
+	}
+}

--- a/src/Hedwig/Schema/Types/UserType.cs
+++ b/src/Hedwig/Schema/Types/UserType.cs
@@ -1,0 +1,38 @@
+using Hedwig.Models;
+using Hedwig.Repositories;
+using Hedwig.Security;
+using GraphQL.Types;
+using GraphQL.Authorization;
+
+namespace Hedwig.Schema.Types
+{
+	public class UserType : HedwigGraphType<User>, IAuthorizedGraphType
+	{
+		public UserType(ISiteRepository sites, IReportRepository reports)
+		{
+			Field(u => u.Id);
+			Field(u => u.FirstName);
+			Field(u => u.MiddleName, nullable: true);
+			Field(u => u.LastName);
+			Field(u => u.Suffix, nullable: true);
+			Field<NonNullGraphType<ListGraphType<NonNullGraphType<SiteType>>>>(
+				"sites",
+				resolve: context => sites.GetSitesByUserIdAsync(context.Source.Id)
+			);
+			Field<NonNullGraphType<ListGraphType<NonNullGraphType<ReportType>>>>(
+				"reports",
+				resolve: context => reports.GetReportsByUserIdAsync(context.Source.Id)
+			);
+		}
+
+		public AuthorizationRules Permissions(AuthorizationRules rules)
+		{
+			rules.DenyNot("IsAuthenticatedUserPolicy");
+			rules.Allow("IsCurrentUserPolicy");
+			rules.Allow("IsDeveloperInDevPolicy");
+			rules.Allow("IsTestModePolicy");
+			rules.Deny();
+			return rules;
+		}
+	}
+}

--- a/src/Hedwig/Security/AuthorizationContext.cs
+++ b/src/Hedwig/Security/AuthorizationContext.cs
@@ -1,0 +1,58 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationContext.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Summary of Changes
+ * - Rename Arguments field to InputVariables.
+ * - Add Arguments field for query arguments.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using GraphQL.Language.AST;
+
+namespace Hedwig.Security
+{
+    public class AuthorizationContext
+    {
+        private readonly List<string> _errors = new List<string>();
+
+        public ClaimsPrincipal User { get; set; }
+
+        public object UserContext { get; set; }
+
+        public Dictionary<string, object> InputVariables { get; set; }
+
+        public Arguments Arguments { get; set; }
+
+        public IEnumerable<string> Errors => _errors;
+
+        public bool HasErrors => _errors.Any<string>();
+
+        public void ReportError(string error)
+        {
+            _errors.Add(error);
+        }
+    }
+}

--- a/src/Hedwig/Security/AuthorizationEvaluator.cs
+++ b/src/Hedwig/Security/AuthorizationEvaluator.cs
@@ -1,0 +1,135 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationEvaluator.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Summary of Changes
+ * - Change type of rules parameter in Evaluate to AuthorizationRules.
+ * - Add Arguments parameter.
+ * - Reimplement Evaluate using AuthorizationRuleResult.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using GraphQL.Authorization;
+using GraphQL.Language.AST;
+
+namespace Hedwig.Security
+{
+	public interface IAuthorizationEvaluator
+	{
+		Task<AuthorizationResult> Evaluate(
+				ClaimsPrincipal principal,
+				object userContext,
+				Dictionary<string, object> inputVariables,
+				AuthorizationRules rules,
+				Arguments arguments);
+	}
+	public class AuthorizationEvaluator : IAuthorizationEvaluator
+	{
+		private readonly AuthorizationSettings _settings;
+
+		public AuthorizationEvaluator(AuthorizationSettings settings)
+		{
+				_settings = settings;
+		}
+
+		public async Task<AuthorizationResult> Evaluate(
+			ClaimsPrincipal principal,
+			object userContext,
+			Dictionary<string, object> inputVariables,
+			AuthorizationRules _rules,
+			Arguments arguments)
+		{
+			var context = new Hedwig.Security.AuthorizationContext();
+			context.User = principal ?? new ClaimsPrincipal(new ClaimsIdentity());
+			context.UserContext = userContext;
+			context.InputVariables = inputVariables;
+			context.Arguments = arguments;
+			var rules = _rules as IEnumerable<AuthorizationRule>;
+			
+			foreach (var rule in rules)
+			{
+				var policy = rule.Policy;
+				var action = rule.Action;
+				var authorizationPolicy = _settings.GetPolicy(policy);
+				// Check if authorization rule was added without policy
+				// Should be the final rule in the permissions block
+				if (authorizationPolicy == null)
+				{
+					// Process final rule assuming no errors
+					// Implies final rule must be "Allow" or "Deny"
+					AuthorizationRuleResult result = action.Assess(false);
+					if (result == AuthorizationRuleResult.Success)
+					{
+						return AuthorizationResult.Success();
+					}
+					else if (result == AuthorizationRuleResult.Failure)
+					{
+						return AuthorizationResult.Fail(context.Errors);
+					}
+					else
+					{
+						// Final rule must succeed or fail
+						throw new Exception("Final rule must be Allow or Deny");
+					}
+				}
+				else
+				{
+					var didError = false;
+					foreach (var requirement in authorizationPolicy.Requirements)
+					{
+						// Because we are allowing "DenyNot" and "AllowNot" rules
+						// but AuthorizationRequirement.Authorize only returns a
+						// completed task and adds an error if and only if there
+						// is an error, we need to check the number of errors to
+						// determine if the most recent requirement succeeded.
+						var startingCount = context.Errors.Count();
+						await requirement.Authorize(context);
+						var endingCount = context.Errors.Count();
+						// Requirements are ANDed together, so we need to OR
+						// the didError boolean
+						didError = didError | (startingCount != endingCount);
+					}
+					AuthorizationRuleResult result = action.Assess(didError);
+					if (result == AuthorizationRuleResult.Success)
+					{
+						return AuthorizationResult.Success();
+					}
+					else if (result == AuthorizationRuleResult.Failure)
+					{
+						return AuthorizationResult.Fail(context.Errors);
+					}
+					else // AuthorizationRuleResult.Continue
+					{
+						continue;
+					}
+				}
+			}
+			// there are no rules applied, so succeed
+			return AuthorizationResult.Success();
+		}
+	}
+}

--- a/src/Hedwig/Security/AuthorizationMetadataExtensions.cs
+++ b/src/Hedwig/Security/AuthorizationMetadataExtensions.cs
@@ -1,0 +1,61 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationMetadataExtensions.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+ /*
+  * Summary of Changes
+  * - Different approach for retrieving permission rules.
+  */
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using GraphQL.Builders;
+using GraphQL.Types;
+using GraphQL.Authorization;
+using GraphQL.Language.AST;
+
+namespace Hedwig.Security
+{
+    public static class AuthorizationMetadataExtensions
+    {
+        public static bool RequiresAuthorization(this IProvideMetadata type)
+        {
+            return type is IAuthorizedGraphType;
+        }
+        
+        public static Task<AuthorizationResult> Authorize(
+            this IProvideMetadata type,
+            ClaimsPrincipal principal,
+            object userContext,
+            Dictionary<string, object> inputVariables,
+            IAuthorizationEvaluator evaluator,
+            Arguments arguments)
+        {
+            var authorizedType = type as IAuthorizedGraphType;
+            var rules = new AuthorizationRules();
+            rules = authorizedType.Permissions(rules);
+            return evaluator.Evaluate(principal, userContext, inputVariables, rules, arguments);
+        }
+    }
+}

--- a/src/Hedwig/Security/AuthorizationPolicy.cs
+++ b/src/Hedwig/Security/AuthorizationPolicy.cs
@@ -1,0 +1,46 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationPolicy.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System.Collections.Generic;
+
+namespace Hedwig.Security
+{
+    public interface IAuthorizationPolicy
+    {
+        IEnumerable<IAuthorizationRequirement> Requirements { get; }
+    }
+
+    public class AuthorizationPolicy : IAuthorizationPolicy
+    {
+        private readonly List<IAuthorizationRequirement> _requirements;
+
+        public AuthorizationPolicy(IEnumerable<IAuthorizationRequirement> requirements)
+        {
+            _requirements = new List<IAuthorizationRequirement>(
+                requirements ?? new List<IAuthorizationRequirement>());
+        }
+
+        public IEnumerable<IAuthorizationRequirement> Requirements => _requirements;
+    }
+}

--- a/src/Hedwig/Security/AuthorizationPolicyBuilder.cs
+++ b/src/Hedwig/Security/AuthorizationPolicyBuilder.cs
@@ -1,0 +1,55 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationPolicyBuilder.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Summary of Changes
+ * - Remove unused methods.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hedwig.Security
+{
+    public class AuthorizationPolicyBuilder
+    {
+        private readonly List<IAuthorizationRequirement> _requirements;
+
+        public AuthorizationPolicyBuilder()
+        {
+            _requirements = new List<IAuthorizationRequirement>();
+        }
+
+        public AuthorizationPolicy Build()
+        {
+            var policy = new AuthorizationPolicy(_requirements);
+            return policy;
+        }
+
+        public AuthorizationPolicyBuilder AddRequirement(IAuthorizationRequirement requirement)
+        {
+            _requirements.Add(requirement);
+            return this;
+        }
+    }
+}

--- a/src/Hedwig/Security/AuthorizationRule.cs
+++ b/src/Hedwig/Security/AuthorizationRule.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Hedwig.Security
+{
+  public class AuthorizationRule
+  {
+    public string Policy { get; private set; }
+
+    public AuthorizationAction Action { get; private set; }
+
+    public AuthorizationRule(string policy, AuthorizationAction action)
+    {
+      Policy = policy;
+      Action = action;
+    }
+  }
+
+  public enum AuthorizationAction
+  {
+    Deny,
+    DenyNot,
+    Allow,
+    AllowNot
+  }
+
+  public enum AuthorizationRuleResult
+  {
+    Success,
+    Failure,
+    Continue
+  }
+
+  public static class AuthorizationActionExtensions {
+    public static AuthorizationRuleResult Assess(this AuthorizationAction action, bool error)
+    {
+      switch (action)
+      {
+          case AuthorizationAction.Allow:
+            return error ? AuthorizationRuleResult.Continue : AuthorizationRuleResult.Success;
+          case AuthorizationAction.Deny:
+            return error ? AuthorizationRuleResult.Continue : AuthorizationRuleResult.Failure;
+          case AuthorizationAction.AllowNot:
+            return error ? AuthorizationRuleResult.Success : AuthorizationRuleResult.Continue;
+          case AuthorizationAction.DenyNot:
+            return error ? AuthorizationRuleResult.Failure : AuthorizationRuleResult.Continue;
+          default:
+            // Enum type not found
+            throw new Exception();
+      }
+    }
+  }
+}

--- a/src/Hedwig/Security/AuthorizationRules.cs
+++ b/src/Hedwig/Security/AuthorizationRules.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Hedwig.Security
+{
+  public class AuthorizationRules : IEnumerable<AuthorizationRule>
+  {
+    private readonly List<AuthorizationRule> _rulesSet = new List<AuthorizationRule>();
+
+    public AuthorizationRules Allow(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.Allow));
+      return this;
+    }
+
+    public AuthorizationRules Deny(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.Deny));
+      return this;
+    }
+
+    public AuthorizationRules AllowNot(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.AllowNot));
+      return this;
+    }
+
+    public AuthorizationRules DenyNot(string policy = "")
+    {
+      _rulesSet.Add(new AuthorizationRule(policy, AuthorizationAction.DenyNot));
+      return this;
+    }
+
+    public IEnumerator<AuthorizationRule> GetEnumerator()
+    {
+        return _rulesSet.GetEnumerator();
+    }
+
+    private IEnumerator _GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return _GetEnumerator();
+    }
+  }
+}

--- a/src/Hedwig/Security/AuthorizationSettings.cs
+++ b/src/Hedwig/Security/AuthorizationSettings.cs
@@ -1,0 +1,77 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationSettings.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace Hedwig.Security
+{
+    public class AuthorizationSettings
+    {
+        private readonly IDictionary<string, IAuthorizationPolicy> _policies;
+
+        public AuthorizationSettings()
+        {
+            _policies = new Dictionary<string, IAuthorizationPolicy>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public IEnumerable<IAuthorizationPolicy> Policies => _policies.Values;
+
+        public IEnumerable<IAuthorizationPolicy> GetPolicies(IEnumerable<string> policies)
+        {
+            var found = new List<IAuthorizationPolicy>();
+
+            if (policies == null) { return found; }
+
+            foreach (var name in policies)
+            {
+              if (_policies.ContainsKey(name))
+              {
+                found.Add(_policies[name]);
+              }
+            }
+
+            return found;
+        }
+
+        public IAuthorizationPolicy GetPolicy(string name)
+        {
+            return _policies.ContainsKey(name) ? _policies[name] : null;
+        }
+
+        public void AddPolicy(string name, IAuthorizationPolicy policy)
+        {
+            _policies[name] = policy;
+        }
+
+        public void AddPolicy(string name, Action<AuthorizationPolicyBuilder> configure)
+        {
+            var builder = new AuthorizationPolicyBuilder();
+            configure(builder);
+
+            var policy = builder.Build();
+            _policies[name] = policy;
+        }
+    }
+}

--- a/src/Hedwig/Security/AuthorizationValidationRule.cs
+++ b/src/Hedwig/Security/AuthorizationValidationRule.cs
@@ -1,0 +1,124 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthorizationValidationRule.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+ /*
+  * Summary of Changes
+  * - Add arguments parameter to CheckAuth.
+  */
+
+using System.Linq;
+using GraphQL;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Authorization;
+
+using System;
+
+namespace Hedwig.Security
+{
+    public class AuthorizationValidationRule : IValidationRule
+    {
+        private readonly IAuthorizationEvaluator _evaluator;
+
+        public AuthorizationValidationRule(IAuthorizationEvaluator evaluator)
+        {
+            _evaluator = evaluator;
+        }
+
+        public INodeVisitor Validate(ValidationContext context)
+        {
+            var userContext = context.UserContext as IProvideClaimsPrincipal;
+
+            return new EnterLeaveListener(_ =>
+            {
+                var operationType = OperationType.Query;
+
+                // this could leak info about hidden fields or types in error messages
+                // it would be better to implement a filter on the Schema so it
+                // acts as if they just don't exist vs. an auth denied error
+                // - filtering the Schema is not currently supported
+
+                _.Match<Operation>(astType =>
+                {
+                    operationType = astType.OperationType;
+
+                    var type = context.TypeInfo.GetLastType();
+                    CheckAuth(astType, type, userContext, context, operationType);
+                });
+
+                _.Match<ObjectField>(objectFieldAst =>
+                {
+                    var argumentType = context.TypeInfo.GetArgument().ResolvedType.GetNamedType() as IComplexGraphType;
+                    if (argumentType == null)
+                        return;
+
+                    var fieldType = argumentType.GetField(objectFieldAst.Name);
+                    CheckAuth(objectFieldAst, fieldType, userContext, context, operationType);
+                });
+
+                _.Match<Field>(fieldAst =>
+                {
+                    var fieldDef = context.TypeInfo.GetFieldDef();
+
+                    if (fieldDef == null) return;
+
+                    // check target field
+                    CheckAuth(fieldAst, fieldDef, userContext, context, operationType, fieldAst.Arguments);
+                    // check returned graph type
+                    CheckAuth(fieldAst, fieldDef.ResolvedType.GetNamedType(), userContext, context, operationType, fieldAst.Arguments);
+                });
+            });
+        }
+
+        private void CheckAuth(
+            INode node,
+            IProvideMetadata type,
+            IProvideClaimsPrincipal userContext,
+            ValidationContext context,
+            OperationType operationType,
+            Arguments arguments = null)
+        {
+            if (type == null || !type.RequiresAuthorization()) return;
+            if (arguments == null)
+            {
+                arguments = new Arguments();
+            }
+
+            var result = type
+                .Authorize(userContext?.User, context.UserContext, context.Inputs, _evaluator, arguments)
+                .GetAwaiter()
+                .GetResult();
+
+            if (result.Succeeded) return;
+
+            var error = string.Join("\n", result.Errors);
+
+            context.ReportError(new ValidationError(
+                context.OriginalQuery,
+                "authorization",
+                $"You are not authorized to run this {operationType.ToString().ToLower()}.\n{error}",
+                node));
+        }
+    }
+}

--- a/src/Hedwig/Security/ClaimsTransformer.cs
+++ b/src/Hedwig/Security/ClaimsTransformer.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Security.Claims;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Hedwig.Data;
+
+namespace Hedwig.Security {
+	public class ClaimsTransformer : IClaimsTransformation
+	{
+		private readonly HedwigContext _context;
+
+		public ClaimsTransformer(HedwigContext context)
+		{
+				_context = context;
+		}
+
+		public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+    {
+      return Task.FromResult(principal);
+		}
+	}
+}

--- a/src/Hedwig/Security/IAuthorizationRequirement.cs
+++ b/src/Hedwig/Security/IAuthorizationRequirement.cs
@@ -1,0 +1,33 @@
+/*
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/IAuthorizationRequirement.cs
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System.Threading.Tasks;
+
+namespace Hedwig.Security
+{
+    public interface IAuthorizationRequirement
+    {
+        Task Authorize(AuthorizationContext context);
+    }
+}

--- a/src/Hedwig/Security/IAuthorizedGraphType.cs
+++ b/src/Hedwig/Security/IAuthorizedGraphType.cs
@@ -1,0 +1,7 @@
+namespace Hedwig.Security
+{
+  public interface IAuthorizedGraphType
+  {
+      AuthorizationRules Permissions(AuthorizationRules rules);
+  }
+}

--- a/src/Hedwig/Security/Permissions.cs
+++ b/src/Hedwig/Security/Permissions.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Hedwig.Security
+{
+    public class Permissions
+    {
+      // DevelopmentRequirement needs DI access to IHostingEnvironment
+      private readonly DevelopmentRequirement _developmentRequirement;
+
+      public Permissions(
+        DevelopmentRequirement developmentRequirement
+      )
+      {
+        _developmentRequirement = developmentRequirement;
+      }
+
+      public AuthorizationSettings GetAuthorizationSettings()
+      {
+        var authSettings = new AuthorizationSettings();
+
+        authSettings.AddPolicy("IsAuthenticatedUserPolicy", policy =>
+          policy.AddRequirement(new AuthenticatedUserRequirement()));
+
+        authSettings.AddPolicy("IsCurrentUserPolicy", policy =>
+          policy.AddRequirement(new CurrentUserRequirement()));
+
+        authSettings.AddPolicy("IsDeveloperInDevPolicy", policy =>
+          policy.AddRequirement(new DeveloperUserRequirement())
+            .AddRequirement(_developmentRequirement));
+
+        authSettings.AddPolicy("IsTestModePolicy", policy =>
+          policy.AddRequirement(new TestModeRequirement())
+            .AddRequirement(_developmentRequirement));
+
+        return authSettings;
+      }
+    }
+}

--- a/src/Hedwig/Security/Policies/AuthenticatedUserRequirement.cs
+++ b/src/Hedwig/Security/Policies/AuthenticatedUserRequirement.cs
@@ -1,0 +1,44 @@
+/**
+ * Modified from https://github.com/graphql-dotnet/authorization/blob/8e7b3c70577c15ee45d16080eeba8273315b4e9c/src/GraphQL.Authorization/AuthenticatedUserRequirement.cs
+ * This file is released in v3 of GraphQL.Authorization but we use v2.1.
+ */
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Joseph T. McBride
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Hedwig.Security
+{
+    public class AuthenticatedUserRequirement : IAuthorizationRequirement
+    {
+        public Task Authorize(AuthorizationContext context)
+        {
+            if (!context.User.Identities.Any(x => x.IsAuthenticated))
+            {
+                context.ReportError("An authenticated user is required.");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Hedwig/Security/Policies/CurrentUserRequirement.cs
+++ b/src/Hedwig/Security/Policies/CurrentUserRequirement.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Language.AST;
+using Hedwig.Data;
+
+namespace Hedwig.Security
+{
+    public class CurrentUserRequirement : IAuthorizationRequirement
+    {
+        public Task Authorize(AuthorizationContext context)
+        {
+            var queryId = context.Arguments.ValueFor("id")?.Value;
+            var authenticatedId = context.User.FindFirst("sub")?.Value;
+            if (queryId == null || authenticatedId == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!queryId.Equals(Int32.Parse(authenticatedId)))
+            {
+                context.ReportError("The current user is required.");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Hedwig/Security/Policies/DeveloperUserRequirement.cs
+++ b/src/Hedwig/Security/Policies/DeveloperUserRequirement.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using System;
+
+namespace Hedwig.Security
+{
+  public class DeveloperUserRequirement : IAuthorizationRequirement
+  {
+    public Task Authorize(AuthorizationContext context)
+    {
+      var user = context.User;
+      if (user == null || !user.HasClaim("role", "developer"))
+      {
+        context.ReportError("A developer account is required");
+      }
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Hedwig/Security/Policies/DevelopmentRequirement.cs
+++ b/src/Hedwig/Security/Policies/DevelopmentRequirement.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Hosting;
+using System.Threading.Tasks;
+using Hedwig.Schema;
+
+namespace Hedwig.Security
+{
+  public class DevelopmentRequirement : IAuthorizationRequirement
+  {
+    private readonly IHostingEnvironment _env;
+    public DevelopmentRequirement(IHostingEnvironment env)
+    {
+      _env = env;
+    }
+    public Task Authorize(AuthorizationContext context)
+    {
+      if (!(_env.IsDevelopment()))
+      {
+        context.ReportError("Development environment is required");
+      }
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Hedwig/Security/Policies/TestModeRequirement.cs
+++ b/src/Hedwig/Security/Policies/TestModeRequirement.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Hosting;
+using System.Threading.Tasks;
+using System;
+
+namespace Hedwig.Security
+{
+  public class TestModeRequirement : IAuthorizationRequirement
+  {
+    public Task Authorize(AuthorizationContext context)
+    {
+      var user = context.User;
+      if (user == null || !user.HasClaim("test_mode", "true"))
+      {
+        context.ReportError("Test mode is required");
+      }
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -6,6 +6,21 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using System.Net.Http;
 using System.IdentityModel.Tokens.Jwt;
 
+// GraphQL Support
+using Hedwig.Schema.Types;
+using Hedwig.Schema.Queries;
+using Hedwig.Schema.Mutations;
+using Hedwig.Schema;
+using Hedwig.Security;
+using Hedwig.GraphQL;
+using GraphQL;
+using GraphQL.Server;
+using GraphQL.Server.Internal;
+using GraphQL.Authorization;
+using GraphQL.Validation;
+using System;
+// End GraphQL Support
+
 namespace Hedwig
 {
 	public static class ServiceExtensions
@@ -69,5 +84,69 @@ namespace Hedwig
 		{
 			services.AddControllers();
 		}
+
+// GraphQL Support
+		public static void ConfigureGraphQL(this IServiceCollection services)
+		{
+			// Add Types
+			services.AddScoped<CdcReportType>();
+			services.AddScoped<ChildType>();
+			services.AddScoped<EnrollmentType>();
+			services.AddScoped<FamilyDeterminationType>();
+			services.AddScoped<FamilyType>();
+			services.AddScoped<FundingType>();
+			services.AddScoped<OrganizationType>();
+			services.AddScoped<ReportType>();
+			services.AddScoped<SiteType>();
+			services.AddScoped<UserType>();
+			services.AddScoped<GenderEnumType>();
+			services.AddScoped<FundingSourceEnumType>();
+			services.AddScoped<FundingTimeEnumType>();
+
+			// Add Queries
+			services.AddScoped<IAppSubQuery, EnrollmentQuery>();
+			services.AddScoped<IAppSubQuery, UserQuery>();
+			services.AddScoped<IAppSubQuery, ChildQuery>();
+			services.AddScoped<IAppSubQuery, ReportQuery>();
+
+			// Add Mutations
+			services.AddScoped<IAppSubMutation, ReportMutation>();
+			services.AddScoped<IAppSubMutation, EnrollmentMutation>();
+			services.AddScoped<IAppSubMutation, FamilyMutation>();
+			services.AddScoped<IAppSubMutation, FamilyDeterminationMutation>();
+			services.AddScoped<IAppSubMutation, ChildMutation>();
+			services.AddScoped<IAppSubMutation, FundingMutation>();
+
+			// Add Middlewares
+			services.AddScoped<IFieldsMiddleware, CommitMutationFieldsMiddleware>();
+
+			services.AddScoped<IDocumentExecuter, EfDocumentExecuter>();
+			services.AddScoped<AppSchema>();
+
+			services.AddGraphQL(o =>
+				{
+					o.ExposeExceptions = false;
+				})
+				.AddGraphTypes(ServiceLifetime.Scoped)
+				.AddDataLoader()
+				.AddUserContextBuilder<RequestContext>(RequestContext.RequestContextCreator);
+
+			// Add Executer
+			// NOTE: This must come after services.AddGraphQL
+			services.AddScoped(typeof(IGraphQLExecuter<>), typeof(HedwigExecutor<>));
+		}
+
+		public static void ConfigureGraphQLAuthorization(this IServiceCollection services)
+		{
+			services.AddScoped<Hedwig.Security.IAuthorizationEvaluator, Hedwig.Security.AuthorizationEvaluator>();
+			services.AddTransient<IValidationRule, Hedwig.Security.AuthorizationValidationRule>();
+			services.AddScoped<Permissions>();
+			services.AddScoped<DevelopmentRequirement>();
+			services.AddScoped(s => {
+				Permissions permissions = s.GetRequiredService<Permissions>();
+				return permissions.GetAuthorizationSettings();
+			});
+		}
+	// End GraphQL Support
 	}
 }

--- a/src/Hedwig/Startup.cs
+++ b/src/Hedwig/Startup.cs
@@ -1,8 +1,18 @@
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
+// GraphQL Support
+using GraphQL.Server;
+using GraphQL.Server.Ui.Playground;
+using GraphQL.Authorization;
+using GraphQL.Validation;
+using Hedwig.Schema;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+// End GraphQL Support
 
 namespace Hedwig
 {
@@ -25,7 +35,14 @@ namespace Hedwig
 			services.ConfigureAuthentication();
 			services.AddHttpContextAccessor();
 
-			services.AddControllers();
+			// GraphQL Support
+			services.Configure<KestrelServerOptions>(options =>
+			{
+					options.AllowSynchronousIO = true;
+			});
+			services.ConfigureGraphQL();
+			services.ConfigureGraphQLAuthorization();
+			// GraphQL Support
 		}
 
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -44,6 +61,11 @@ namespace Hedwig
 			app.UseAuthentication();
 			app.UseAuthorization();
 
+			// GraphQL Support
+			app.UseGraphQL<AppSchema>();
+			app.UseGraphQLPlayground(options: new GraphQLPlaygroundOptions());
+			// End GraphQL Support
+
 			if (!env.IsDevelopment())
 			{
 				app.UseSpaStaticFiles();
@@ -60,7 +82,8 @@ namespace Hedwig
 
 				if (env.IsDevelopment())
 				{
-					spa.UseProxyToSpaDevelopmentServer("http://client:3000");
+					string CLIENT_HOST = Environment.GetEnvironmentVariable("CLIENT_HOST") ?? "http://localhost:3000";
+					spa.UseProxyToSpaDevelopmentServer(CLIENT_HOST);
 				}
 			});
 		}

--- a/test/HedwigTests/Fixtures/TestApiProvider.cs
+++ b/test/HedwigTests/Fixtures/TestApiProvider.cs
@@ -17,12 +17,15 @@ namespace HedwigTests.Fixtures
 			var config = new ConfigurationBuilder()
 				.AddEnvironmentVariables()
 				.Build();
-				
-			_server = new TestServer(
-				new WebHostBuilder()
-					.UseConfiguration(config)
-					.UseStartup<TestStartup>()
-			);
+
+			var builder = new WebHostBuilder()
+				.UseConfiguration(config)
+				.UseStartup<TestStartup>();
+
+			_server = new TestServer(builder);
+			// GraphQL Support
+			_server.AllowSynchronousIO = true;
+			// End GraphQL Support
 			var scope = _server.Host.Services.CreateScope();
 			Context = scope.ServiceProvider.GetRequiredService<TestHedwigContext>();
 			Client = _server.CreateClient();

--- a/test/HedwigTests/Fixtures/TestHttpClientExtensions.cs
+++ b/test/HedwigTests/Fixtures/TestHttpClientExtensions.cs
@@ -1,0 +1,21 @@
+// GraphQL File
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace HedwigTests.Fixtures
+{
+    public static class TestHttpClientExtensions
+    {
+        public static Task<HttpResponseMessage> GetGraphQLAsync(this HttpClient client, string query)
+        {
+            return client.GetAsync($"/graphql?query={query}");
+        }
+        public static Task<HttpResponseMessage> PostGraphQLAsync(this HttpClient client, string query)
+        {
+            var content = JsonConvert.SerializeObject(new { query = query});
+            return client.PostAsync("/graphql", new StringContent(content, Encoding.UTF8, "application/json"));
+        }
+    }
+}

--- a/test/HedwigTests/Fixtures/TestHttpResponseMessageExtensions.cs
+++ b/test/HedwigTests/Fixtures/TestHttpResponseMessageExtensions.cs
@@ -1,0 +1,42 @@
+// GraphQL File
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using GraphQL.Common.Response;
+
+namespace HedwigTests.Fixtures
+{
+    public static class TestHttpResponseMessageExtensions
+    {
+        public static async Task<GraphQLResponse> ParseGraphQLResponse(this HttpResponseMessage response)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            if(TestEnvironmentFlags.ShouldLogHTTP()) {
+                Console.WriteLine(content);
+            }
+
+            return JsonConvert.DeserializeObject<GraphQLResponse>(content);
+        }
+        public static async Task<T> GetObjectFromGraphQLResponse<T>(this HttpResponseMessage response, string fieldNameOverride = null)
+        {
+            var graphQLResponse = await response.ParseGraphQLResponse();
+            if (graphQLResponse.Errors != null) {
+                throw new Exception($"GraphQL Error: {graphQLResponse.Errors[0].Message}");
+            }
+            var fieldName = fieldNameOverride ?? GetDefaultFieldName<T>();
+            return graphQLResponse.GetDataFieldAs<T>(fieldName);
+        }
+
+        private static string GetDefaultFieldName<T>()
+        {
+            var typeName = typeof(T).Name;
+            return ToCamelCase(typeName);
+        }
+
+        private static String ToCamelCase(String str)
+        {
+            return Char.ToLowerInvariant(str[0]) + str.Substring(1);
+        }
+    }
+}

--- a/test/HedwigTests/HedwigTests.csproj
+++ b/test/HedwigTests/HedwigTests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- GraphQL Support -->
+    <PackageReference Include="GraphQL.Client" Version="1.0.3" />
+    <PackageReference Include="GraphQL.Common" Version="1.0.3" />
+    <!-- End GraphQL Support -->
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0">

--- a/test/HedwigTests/Helpers/AuthorizationRequirementHelper.cs
+++ b/test/HedwigTests/Helpers/AuthorizationRequirementHelper.cs
@@ -6,10 +6,56 @@ using Hedwig.Data;
 using Hedwig.Models;
 using System.Security.Claims;
 
+// GraphQL Support
+using Hedwig.Security;
+// End GraphQL Support
+
 namespace HedwigTests.Helpers
 {
 	public class AuthorizationRequirementHelper
 	{
+		// GraphQL Support
+		public const string RequirementException = "Requirement exception";
+		private class AlwaysTrueRequirement : IAuthorizationRequirement
+		{
+			public Task Authorize(AuthorizationContext _)
+			{
+				return Task.CompletedTask;
+			}
+		}
+
+		private class AlwaysFalseRequirement : IAuthorizationRequirement
+		{
+			public Task Authorize(AuthorizationContext _)
+			{
+				_.ReportError("This always fails");
+				return Task.CompletedTask;
+			}
+		}
+
+		private class ThrowsExceptionRequirement : IAuthorizationRequirement
+		{
+			public Task Authorize(AuthorizationContext _)
+			{
+				throw new Exception(RequirementException);
+			}
+		}
+
+		public static IAuthorizationRequirement GetAlwaysTrueRequirement()
+		{
+			return new AlwaysTrueRequirement();
+		}
+
+		public static IAuthorizationRequirement GetAlwaysFalseRequirement()
+		{
+			return new AlwaysFalseRequirement();
+		}
+
+		public static IAuthorizationRequirement GetThrowsExceptionRequirement()
+		{
+			return new ThrowsExceptionRequirement();
+		}
+		// End GraphQL Support
 		public static ClaimsPrincipal CreatePrincipal(string authenticationType = null, IDictionary<string, string> claims = null)
 		{
 			var identity = CreateIdentity(authenticationType, claims);

--- a/test/HedwigTests/Integration/GraphQLMutations/ChildMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/ChildMutationTests.cs
@@ -1,0 +1,431 @@
+using Xunit;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using Hedwig.Models;
+using Hedwig.Repositories;
+using Hedwig.Schema;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+	public class ChildMutationTests
+	{
+		[Fact]
+		public async Task Create_Child_With_All_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var site = SiteHelper.CreateSite(api.Context);
+				var firstName = "David";
+				var middleName = "Harry";
+				var lastName = "Radcliff";
+				var suffix = "Jr.";
+				var birthdate = new DateTime(2010, 1, 1, 0, 0, 0);
+				var birthCertificateId = "12345";
+				var birthTown = "Here";
+				var birthState = "There";
+				var gender = Gender.Male;
+				var americanIndianOrAlaskaNative = false;
+				var asian = false;
+				var blackOrAfricanAmerican = true;
+				var nativeHawaiianOrPacificIslander = false;
+				var white = true;
+				var hispanicOrLatinxEthnicity = false;
+				var foster = false;
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false/true is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createChildWithSiteEnrollment (
+							firstName: ""{firstName}"",
+							middleName: ""{middleName}"",
+							lastName: ""{lastName}"",
+							suffix: ""{suffix}"",
+							birthdate: ""{birthdate}"",
+							birthCertificateId: ""{birthCertificateId}"",
+							birthTown: ""{birthTown}"",
+							birthState: ""{birthState}"",
+							gender: {gender},
+							americanIndianOrAlaskaNative: false,
+							asian: false,
+							blackOrAfricanAmerican: true,
+							nativeHawaiianOrPacificIslander: false,
+							white: true,
+							hispanicOrLatinxEthnicity: false,
+							foster: false,
+							siteId: {site.Id}
+						) {{
+								firstName
+								middleName
+								lastName
+								suffix
+								birthdate
+								birthCertificateId
+								birthTown
+								birthState
+								gender
+								americanIndianOrAlaskaNative
+								asian
+								blackOrAfricanAmerican
+								nativeHawaiianOrPacificIslander
+								white
+								hispanicOrLatinxEthnicity
+								foster
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Child child = await response.GetObjectFromGraphQLResponse<Child>("createChildWithSiteEnrollment");
+				Assert.Equal(firstName, child.FirstName);
+				Assert.Equal(middleName, child.MiddleName);
+				Assert.Equal(lastName, child.LastName);
+				Assert.Equal(suffix, child.Suffix);
+				Assert.Equal(birthdate, child.Birthdate);
+				Assert.Equal(birthCertificateId, child.BirthCertificateId);
+				Assert.Equal(birthTown, child.BirthTown);
+				Assert.Equal(birthState, child.BirthState);
+				Assert.Equal(gender, child.Gender);
+				Assert.Equal(americanIndianOrAlaskaNative, child.AmericanIndianOrAlaskaNative);
+				Assert.Equal(asian, child.Asian);
+				Assert.Equal(blackOrAfricanAmerican, child.BlackOrAfricanAmerican);
+				Assert.Equal(nativeHawaiianOrPacificIslander, child.NativeHawaiianOrPacificIslander);
+				Assert.Equal(white, child.White);
+				Assert.Equal(hispanicOrLatinxEthnicity, child.HispanicOrLatinxEthnicity);
+				Assert.Equal(foster, child.Foster);
+			}
+		}
+
+		[Fact]
+		public async Task Create_Child_With_Partial_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var site = SiteHelper.CreateSite(api.Context);
+				var firstName = "David";
+				var middleName = "Harry";
+				var lastName = "Radcliff";
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false/true is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createChildWithSiteEnrollment (
+							firstName: ""{firstName}"",
+							middleName: ""{middleName}"",
+							lastName: ""{lastName}"",
+							siteId: {site.Id}
+						) {{
+								firstName
+								middleName
+								lastName
+								suffix
+								birthdate
+								birthCertificateId
+								birthTown
+								birthState
+								gender
+								americanIndianOrAlaskaNative
+								asian
+								blackOrAfricanAmerican
+								nativeHawaiianOrPacificIslander
+								white
+								hispanicOrLatinxEthnicity
+								foster
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Child child = await response.GetObjectFromGraphQLResponse<Child>("createChildWithSiteEnrollment");
+				Assert.Equal(firstName, child.FirstName);
+				Assert.Equal(middleName, child.MiddleName);
+				Assert.Equal(lastName, child.LastName);
+				Assert.Null(child.Suffix);
+				Assert.Null(child.Birthdate);
+				Assert.Null(child.BirthCertificateId);
+				Assert.Null(child.BirthTown);
+				Assert.Null(child.BirthState);
+				Assert.Equal(Gender.Unspecified, child.Gender);
+				Assert.False(child.AmericanIndianOrAlaskaNative);
+				Assert.False(child.Asian);
+				Assert.False(child.BlackOrAfricanAmerican);
+				Assert.False(child.NativeHawaiianOrPacificIslander);
+				Assert.False(child.White);
+				Assert.False(child.HispanicOrLatinxEthnicity);
+				Assert.False(child.Foster);
+			}
+		}
+
+		[Fact]
+		public async Task Create_Child_Site_Id_Not_Found()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var invalidId = 0;
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createChildWithSiteEnrollment (
+							firstName: ""Name"",
+							middleName: ""Middle"",
+							lastName: ""Last"",
+							siteId: {invalidId}
+						) {{
+							firstName
+							middleName
+							lastName
+						}}
+					}}"
+				);
+
+				// Then
+				var gqlResponse = await response.ParseGraphQLResponse();
+				Assert.NotEmpty(gqlResponse.Errors);
+				Assert.Equal(AppErrorMessages.NOT_FOUND("Site", invalidId.ToString()), gqlResponse.Errors[0].Message);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Child_With_All_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var child = ChildHelper.CreateChild(api.Context);
+				var firstName = "David";
+				var middleName = "Harry";
+				var lastName = "Radcliff";
+				var suffix = "Jr.";
+				var birthdate = new DateTime(2010, 1, 1, 0, 0, 0);
+				var birthCertificateId = "12345";
+				var birthTown = "Here";
+				var birthState = "There";
+				var gender = Gender.Male;
+				var americanIndianOrAlaskaNative = false;
+				var asian = false;
+				var blackOrAfricanAmerican = true;
+				var nativeHawaiianOrPacificIslander = false;
+				var white = true;
+				var hispanicOrLatinxEthnicity = false;
+				var foster = false;
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false/true is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateChild (
+							id: ""{child.Id}"",
+							firstName: ""{firstName}"",
+							middleName: ""{middleName}"",
+							lastName: ""{lastName}"",
+							suffix: ""{suffix}"",
+							birthdate: ""{birthdate}"",
+							birthCertificateId: ""{birthCertificateId}"",
+							birthTown: ""{birthTown}"",
+							birthState: ""{birthState}"",
+							gender: {gender},
+							americanIndianOrAlaskaNative: false,
+							asian: false,
+							blackOrAfricanAmerican: true,
+							nativeHawaiianOrPacificIslander: false,
+							white: true,
+							hispanicOrLatinxEthnicity: false,
+							foster: false
+						) {{
+								firstName
+								middleName
+								lastName
+								suffix
+								birthdate
+								birthCertificateId
+								birthTown
+								birthState
+								gender
+								americanIndianOrAlaskaNative
+								asian
+								blackOrAfricanAmerican
+								nativeHawaiianOrPacificIslander
+								white
+								hispanicOrLatinxEthnicity
+								foster
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Child updated = await response.GetObjectFromGraphQLResponse<Child>("updateChild");
+				Assert.Equal(firstName, updated.FirstName);
+				Assert.Equal(middleName, updated.MiddleName);
+				Assert.Equal(lastName, updated.LastName);
+				Assert.Equal(suffix, updated.Suffix);
+				Assert.Equal(birthdate, updated.Birthdate);
+				Assert.Equal(birthCertificateId, updated.BirthCertificateId);
+				Assert.Equal(birthTown, updated.BirthTown);
+				Assert.Equal(birthState, updated.BirthState);
+				Assert.Equal(gender, updated.Gender);
+				Assert.Equal(americanIndianOrAlaskaNative, updated.AmericanIndianOrAlaskaNative);
+				Assert.Equal(asian, updated.Asian);
+				Assert.Equal(blackOrAfricanAmerican, updated.BlackOrAfricanAmerican);
+				Assert.Equal(nativeHawaiianOrPacificIslander, updated.NativeHawaiianOrPacificIslander);
+				Assert.Equal(white, updated.White);
+				Assert.Equal(hispanicOrLatinxEthnicity, updated.HispanicOrLatinxEthnicity);
+				Assert.Equal(foster, updated.Foster);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Child_With_Partial_Fields_No_Clearing()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var child = ChildHelper.CreateChild(api.Context);
+				var firstName = "Roger";
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false/true is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateChild (
+							id: ""{child.Id}"",
+							firstName: ""{firstName}""
+						) {{
+								firstName
+								middleName
+								lastName
+								suffix
+								birthdate
+								birthCertificateId
+								birthTown
+								birthState
+								gender
+								americanIndianOrAlaskaNative
+								asian
+								blackOrAfricanAmerican
+								nativeHawaiianOrPacificIslander
+								white
+								hispanicOrLatinxEthnicity
+								foster
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Child updated = await response.GetObjectFromGraphQLResponse<Child>("updateChild");
+				Assert.Equal(firstName, updated.FirstName);
+				Assert.Equal(child.MiddleName, updated.MiddleName);
+				Assert.Equal(child.LastName, updated.LastName);
+				Assert.Equal(child.Suffix, updated.Suffix);
+				Assert.Equal(child.Birthdate, updated.Birthdate);
+				Assert.Equal(child.BirthCertificateId, updated.BirthCertificateId);
+				Assert.Equal(child.BirthTown, updated.BirthTown);
+				Assert.Equal(child.BirthState, updated.BirthState);
+				Assert.Equal(child.Gender, updated.Gender);
+				Assert.Equal(child.AmericanIndianOrAlaskaNative, updated.AmericanIndianOrAlaskaNative);
+				Assert.Equal(child.Asian, updated.Asian);
+				Assert.Equal(child.BlackOrAfricanAmerican, updated.BlackOrAfricanAmerican);
+				Assert.Equal(child.NativeHawaiianOrPacificIslander, updated.NativeHawaiianOrPacificIslander);
+				Assert.Equal(child.White, updated.White);
+				Assert.Equal(child.HispanicOrLatinxEthnicity, updated.HispanicOrLatinxEthnicity);
+				Assert.Equal(child.Foster, updated.Foster);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Child_With_Partial_Fields_With_Clearing()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var child = ChildHelper.CreateChild(api.Context);
+				var firstName = "Roger";
+				var birthdate = "null";
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false/true is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateChild (
+							id: ""{child.Id}"",
+							firstName: ""{firstName}"",
+							birthdate: ""{birthdate}""
+						) {{
+								firstName
+								middleName
+								lastName
+								suffix
+								birthdate
+								birthCertificateId
+								birthTown
+								birthState
+								gender
+								americanIndianOrAlaskaNative
+								asian
+								blackOrAfricanAmerican
+								nativeHawaiianOrPacificIslander
+								white
+								hispanicOrLatinxEthnicity
+								foster
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Child updated = await response.GetObjectFromGraphQLResponse<Child>("updateChild");
+				Assert.Equal(firstName, updated.FirstName);
+				Assert.Equal(child.MiddleName, updated.MiddleName);
+				Assert.Equal(child.LastName, updated.LastName);
+				Assert.Equal(child.Suffix, updated.Suffix);
+				Assert.Null(updated.Birthdate);
+				Assert.Equal(child.BirthCertificateId, updated.BirthCertificateId);
+				Assert.Equal(child.BirthTown, updated.BirthTown);
+				Assert.Equal(child.BirthState, updated.BirthState);
+				Assert.Equal(child.Gender, updated.Gender);
+				Assert.Equal(child.AmericanIndianOrAlaskaNative, updated.AmericanIndianOrAlaskaNative);
+				Assert.Equal(child.Asian, updated.Asian);
+				Assert.Equal(child.BlackOrAfricanAmerican, updated.BlackOrAfricanAmerican);
+				Assert.Equal(child.NativeHawaiianOrPacificIslander, updated.NativeHawaiianOrPacificIslander);
+				Assert.Equal(child.White, updated.White);
+				Assert.Equal(child.HispanicOrLatinxEthnicity, updated.HispanicOrLatinxEthnicity);
+				Assert.Equal(child.Foster, updated.Foster);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Child_Id_Not_Found()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var childId = Guid.Empty;
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateChild (
+							id: ""{childId}""
+						) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				var gqlResponse = await response.ParseGraphQLResponse();
+				Assert.NotEmpty(gqlResponse.Errors);		
+				Assert.Equal(AppErrorMessages.NOT_FOUND("Child", childId.ToString()), gqlResponse.Errors[0].Message);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLMutations/EnrollmentMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/EnrollmentMutationTests.cs
@@ -1,0 +1,182 @@
+using Xunit;
+using System.Threading.Tasks;
+using System;
+using Hedwig.Models;
+using Hedwig.Schema;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+	public class EnrollmentMutationTests
+	{
+		[Fact]
+		public async Task Update_Enrollmentt()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: "2000-1-1", exit: "2000-2-2");
+				var entry = new DateTime(2019, 10, 10, 0, 0, 0);
+				var exit = new DateTime(2020, 10, 10, 0, 0, 0);
+				var age = Age.School;
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, entry: ""{entry.ToString()}"", exit: ""{exit.ToString()}"", age: {age}) {{
+							id
+							entry
+							exit
+							age
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Equal(exit, updated.Exit);
+				Assert.Equal(age, updated.Age);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_With_Entry()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var exit = new DateTime(2020, 2, 2, 0, 0, 0);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: "2000-1-1", exit: exit.ToString());
+				var entry = new DateTime(2019, 10, 10, 0, 0, 0);
+				
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, entry: ""{entry.ToString()}"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Equal(exit, updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_With_Exit()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var entry = new DateTime(2020, 2, 2, 0, 0, 0);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: entry.ToString(), exit: "2020-06-06");
+				var exit = new DateTime(2020, 8, 8, 0, 0, 0);
+				
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, exit: ""{exit.ToString()}"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Equal(exit, updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_Clear_Exit()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var entry = new DateTime(2020, 2, 2, 0, 0, 0);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: entry.ToString(), exit: "2020-06-06");
+				
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, exit: ""null"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Null(updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_With_Entry_Clear_Exit()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, entry: "2019-01-01", exit: "2020-06-06");
+				var entry = new DateTime(2020, 1, 1, 0, 0, 0);
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {enrollment.Id}, entry: ""{entry.ToString()}"" exit: ""null"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment updated = await response.GetObjectFromGraphQLResponse<Enrollment>("updateEnrollment");
+				Assert.Equal(enrollment.Id, updated.Id);
+				Assert.Equal(entry, updated.Entry);
+				Assert.Null(updated.Exit);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Enrollment_Id_Not_Found()
+		{
+			using (var api = new TestApiProvider()) {
+				var invalidId = 0;
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateEnrollment (id: {invalidId}, entry: ""2010-10-10"") {{
+							id
+							entry
+							exit
+						}}
+					}}"
+				);
+				var gqlResponse = await response.ParseGraphQLResponse();
+				Assert.NotEmpty(gqlResponse.Errors);
+				Assert.Equal(AppErrorMessages.NOT_FOUND("Enrollment", invalidId), gqlResponse.Errors[0].Message);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLMutations/FamilyDeterminationMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/FamilyDeterminationMutationTests.cs
@@ -1,0 +1,125 @@
+using Xunit;
+using Hedwig.Models;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+using Hedwig.Schema;
+using System;
+using System.Threading.Tasks;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+    public class FamilyDeterminationMutationTests
+    {
+        [Fact]
+        public async Task Create_Family_Determination()
+        {
+            using (var api = new TestApiProvider()) {
+                var numberOfPeople = 4;
+                var income = 20000M;
+                var determined = DateTime.Now.Date;
+                var family = FamilyHelper.CreateFamily(api.Context);
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        createFamilyDetermination(
+                            familyId: {family.Id},
+                            numberOfPeople: {numberOfPeople},
+                            income: ""{income}"",
+                            determined: ""{determined}""
+                        ) {{
+                            family {{ id }}
+                            numberOfPeople
+                            income
+                            determined
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                FamilyDetermination determination = await response.GetObjectFromGraphQLResponse<FamilyDetermination>("createFamilyDetermination");
+                Assert.Equal(family.Id, determination.Family.Id);
+                Assert.Equal(numberOfPeople, determination.NumberOfPeople);
+                Assert.Equal(income, determination.Income);
+                Assert.Equal(determined, determination.Determined);
+            }
+        }
+
+        [Fact]
+        public async Task Create_Family_Determination_Family_Id_Not_Found()
+        {
+            using (var api = new TestApiProvider()) {
+                var numberOfPeople = 4;
+                var income = 20000M;
+                var determined = DateTime.Now;
+                var invalidId = 0;
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        createFamilyDetermination(
+                            familyId: {invalidId},
+                            numberOfPeople: {numberOfPeople},
+                            income: {income},
+                            determined: ""{determined}""
+                        ) {{
+                            family {{ id }}
+                            numberOfPeople
+                            income
+                            determined
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                var gqlResponse = await response.ParseGraphQLResponse();
+                Assert.NotEmpty(gqlResponse.Errors);
+                Assert.Equal(AppErrorMessages.NOT_FOUND("Family", invalidId), gqlResponse.Errors[0].Message);
+            }
+        }
+
+        [Fact]
+        public async Task Update_Family_Determination()
+        {
+            using (var api = new TestApiProvider()) {
+                var determination = FamilyDeterminationHelper.CreateDetermination(api.Context);
+                var numberOfPeople = 10;
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        updateFamilyDetermination(
+                            id: {determination.Id},
+                            numberOfPeople: {numberOfPeople}
+                        ) {{
+                            numberOfPeople
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                FamilyDetermination updated = await response.GetObjectFromGraphQLResponse<FamilyDetermination>("updateFamilyDetermination");
+                Assert.Equal(numberOfPeople, updated.NumberOfPeople);
+            }
+        }
+
+        [Fact]
+        public async Task Update_Family_Determination_Not_Found()
+        {
+            using (var api = new TestApiProvider()) {
+                var invalidId = 0;
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        updateFamilyDetermination(
+                            id: {invalidId}
+                        ) {{
+                            id
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                var gqlResponse = await response.ParseGraphQLResponse();
+                Assert.NotEmpty(gqlResponse.Errors);
+                Assert.Equal(AppErrorMessages.NOT_FOUND("FamilyDetermination", invalidId), gqlResponse.Errors[0].Message);
+            }
+        }
+    }
+}

--- a/test/HedwigTests/Integration/GraphQLMutations/FamilyMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/FamilyMutationTests.cs
@@ -1,0 +1,242 @@
+using Xunit;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using Hedwig.Models;
+using Hedwig.Schema;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+	public class FamilyMutationTests
+	{
+		[Fact]
+		public async Task Create_Family_With_All_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var child = ChildHelper.CreateChild(api.Context);
+				var addressLine1 = "123 Home St";
+				var addressLine2 = "Apt 1";
+				var town = "Hometown";
+				var state = "Homestate";
+				var zip = "12345";
+				var homelessness = false;
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createFamilyWithChild (
+							addressLine1: ""{addressLine1}"",
+							addressLine2: ""{addressLine2}"",
+							town: ""{town}"",
+							state: ""{state}"",
+							zip: ""{zip}"",
+							homelessness: false,
+							childId: ""{child.Id}""
+						) {{
+							children {{
+								id
+							}}
+							addressLine1
+							addressLine2
+							town
+							state
+							zip
+							homelessness
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Family family = await response.GetObjectFromGraphQLResponse<Family>("createFamilyWithChild");
+				Assert.Equal(addressLine1, family.AddressLine1);
+				Assert.Equal(addressLine2, family.AddressLine2);
+				Assert.Equal(town, family.Town);
+				Assert.Equal(state, family.State);
+				Assert.Equal(zip, family.Zip);
+				Assert.Equal(homelessness, family.Homelessness);
+				Assert.Equal(child.Id, family.Children.Single().Id);
+			}
+		}
+
+		[Fact]
+		public async Task Create_Family_With_Partial_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var child = ChildHelper.CreateChild(api.Context);
+				var addressLine1 = "123 Home St";
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createFamilyWithChild (
+							addressLine1: ""{addressLine1}"",
+							childId: ""{child.Id}""
+						) {{
+							children {{
+								id
+							}}
+							addressLine1
+							homelessness
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Family family = await response.GetObjectFromGraphQLResponse<Family>("createFamilyWithChild");
+				Assert.Equal(addressLine1, family.AddressLine1);
+				Assert.False(family.Homelessness);
+				Assert.Equal(child.Id, family.Children.Single().Id);
+			}
+		}
+
+		[Fact]
+		public async Task Create_Family_Child_Id_Not_Found()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var invalidId = Guid.Empty;
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						createFamilyWithChild (
+							childId: ""{invalidId}""
+						) {{
+							children {{
+								id
+							}}
+						}}
+					}}"
+				);
+
+				// Then
+				var gqlResponse = await response.ParseGraphQLResponse();
+				Assert.NotEmpty(gqlResponse.Errors);
+				Assert.Equal(AppErrorMessages.NOT_FOUND("Child", invalidId.ToString()), gqlResponse.Errors[0].Message);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Family_With_All_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var family = FamilyHelper.CreateFamily(api.Context);
+				var addressLine1 = "123 Home St";
+				var addressLine2 = "Apt 1";
+				var town = "Hometown";
+				var state = "Homestate";
+				var zip = "12345";
+				var homelessness = false;
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateFamily (
+							id: {family.Id}
+							addressLine1: ""{addressLine1}"",
+							addressLine2: ""{addressLine2}"",
+							town: ""{town}"",
+							state: ""{state}"",
+							zip: ""{zip}"",
+							homelessness: false,
+						) {{
+							addressLine1
+							addressLine2
+							town
+							state
+							zip
+							homelessness
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Family updated = await response.GetObjectFromGraphQLResponse<Family>("updateFamily");
+				Assert.Equal(addressLine1, updated.AddressLine1);
+				Assert.Equal(addressLine2, updated.AddressLine2);
+				Assert.Equal(town, updated.Town);
+				Assert.Equal(state, updated.State);
+				Assert.Equal(zip, updated.Zip);
+				Assert.Equal(homelessness, updated.Homelessness);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Family_With_Partial_Fields()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var family = FamilyHelper.CreateFamily(api.Context);
+				var addressLine1 = "123 Home St";
+
+				// When
+
+				// Issue properly serializing boolean values, hence why false is hardcoded
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateFamily (
+							id: {family.Id}
+							addressLine1: ""{addressLine1}""
+						) {{
+							addressLine1
+							addressLine2
+							town
+							state
+							zip
+							homelessness
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Family updated = await response.GetObjectFromGraphQLResponse<Family>("updateFamily");
+				Assert.Equal(addressLine1, updated.AddressLine1);
+				Assert.Equal(family.AddressLine2, updated.AddressLine2);
+				Assert.Equal(family.Town, updated.Town);
+				Assert.Equal(family.State, updated.State);
+				Assert.Equal(family.Zip, updated.Zip);
+				Assert.Equal(family.Homelessness, updated.Homelessness);
+			}
+		}
+
+		[Fact]
+		public async Task Update_Family_Id_Not_Found()
+		{
+			using (var api = new TestApiProvider()) {
+				// If
+				var invalidId = 0;
+
+				// When
+				var response = await api.Client.PostGraphQLAsync(
+					$@"mutation {{
+						updateFamily (
+							id: {invalidId}
+						) {{
+							children {{
+								id
+							}}
+						}}
+					}}"
+				);
+
+				// Then
+				var gqlResponse = await response.ParseGraphQLResponse();
+				Assert.NotEmpty(gqlResponse.Errors);
+				Assert.Equal(AppErrorMessages.NOT_FOUND("Family", invalidId.ToString()), gqlResponse.Errors[0].Message);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLMutations/FundingMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/FundingMutationTests.cs
@@ -1,0 +1,121 @@
+using System.Threading.Tasks;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+using Hedwig.Models;
+using Hedwig.Schema;
+using Xunit;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+    public class FundingMutationTests
+    {
+        [Fact]
+        public async Task Create_Funding()
+        {
+            using (var api = new TestApiProvider()) {
+                var enrollment = EnrollmentHelper.CreateEnrollment(api.Context);
+                var source = FundingSource.CDC;
+                var time = FundingTime.Full;
+                
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        createFunding(
+                            enrollmentId: {enrollment.Id},
+                            source: {source},
+                            time: {time}
+                        ) {{
+                            enrollment {{ id }}
+                            source
+                            time
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                Funding funding = await response.GetObjectFromGraphQLResponse<Funding>("createFunding");
+                Assert.Equal(enrollment.Id, funding.Enrollment.Id);
+                Assert.Equal(source, funding.Source);
+                Assert.Equal(time, funding.Time);
+            }
+        }
+
+        [Fact]
+        public async Task Create_Funding_Enrollment_Not_Found()
+        {
+            using (var api = new TestApiProvider()) {
+                var invalidEnrollmentId = 0;
+                var source = FundingSource.CDC;
+                var time = FundingTime.Full;
+                
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        createFunding(
+                            enrollmentId: {invalidEnrollmentId},
+                            source: {source},
+                            time: {time}
+                        ) {{
+                            id
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                var gqlResponse =  await response.ParseGraphQLResponse();
+                Assert.NotEmpty(gqlResponse.Errors);
+                Assert.Equal(AppErrorMessages.NOT_FOUND("Enrollment", invalidEnrollmentId), gqlResponse.Errors[0].Message);
+            }
+        }
+
+        [Fact]
+        public async Task Update_Funding()
+        {
+            using (var api = new TestApiProvider()) {
+                var funding = FundingHelper.CreateFunding(api.Context);
+                var time = FundingTime.Part;
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        updateFunding(
+                            id: {funding.Id},
+                            time: {time}
+                        ) {{
+                            time
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                Funding update = await response.GetObjectFromGraphQLResponse<Funding>("updateFunding");
+                Assert.Equal(time, update.Time);
+            }
+        }
+
+        [Fact]
+        public async Task Update_Funding_Not_Found()
+        {
+            using (var api = new TestApiProvider()) {
+                var invalidId = 0;
+                var source = FundingSource.CDC;
+                
+
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        updateFunding(
+                            id: {invalidId},
+                            source: {source},
+                        ) {{
+                            id
+                        }}
+                    }}"
+                );
+
+                response.EnsureSuccessStatusCode();
+                var gqlResponse =  await response.ParseGraphQLResponse();
+                Assert.NotEmpty(gqlResponse.Errors);
+                Assert.Equal(AppErrorMessages.NOT_FOUND("Funding", invalidId), gqlResponse.Errors[0].Message);
+            }
+        }
+    }
+}

--- a/test/HedwigTests/Integration/GraphQLMutations/ReportMutationTests.cs
+++ b/test/HedwigTests/Integration/GraphQLMutations/ReportMutationTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+using System.Threading.Tasks;
+using System;
+using Hedwig.Models;
+using Hedwig.Schema;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Integration.GraphQLMutations
+{
+    public class ReportMutationTests
+    {
+        [Fact]
+        public async Task Update_Report()
+        {
+            using (var api = new TestApiProvider()) {
+                // Given
+                var report = ReportHelper.CreateCdcReport(api.Context);
+
+                // When
+                var submittedAt = DateTime.UtcNow.Date;
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        submitCdcReport (id: {report.Id}, accredited: true) {{
+                            ...on CdcReportType {{
+                                id,
+                                submittedAt
+                            }}
+                        }}
+                    }}"
+                );
+
+                // Then
+                response.EnsureSuccessStatusCode();
+                CdcReport updated = await response.GetObjectFromGraphQLResponse<CdcReport>("submitCdcReport");
+                Assert.Equal(report.Id, updated.Id);
+                Assert.Equal(submittedAt, updated.SubmittedAt);
+            }
+        }
+
+        [Fact]
+        public async Task Update_Report_Id_Not_Found()
+        {
+            using (var api = new TestApiProvider()) {
+                var invalidId = 0;
+                var response = await api.Client.PostGraphQLAsync(
+                    $@"mutation {{
+                        submitCdcReport (id: {invalidId}, accredited: true) {{
+                            ...on CdcReportType {{
+                                id
+                            }}
+                        }}
+                    }}"
+                );
+                var gqlResponse = await response.ParseGraphQLResponse();
+                Assert.NotEmpty(gqlResponse.Errors);
+                Assert.Equal(AppErrorMessages.NOT_FOUND("Report", invalidId), gqlResponse.Errors[0].Message);
+            }
+        }
+    }
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/ChildQueryPermissionsTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/ChildQueryPermissionsTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
+using Xunit;
+using Hedwig.Data;
+using Hedwig.Models;
+using HedwigTests.Helpers;
+using HedwigTests.Fixtures;
+using GraphQL.Common.Response;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+	public class ChildQueryPermissionsTests
+	{
+		[Fact]
+		public async Task When_No_Auth_Get_Child_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var child = ChildHelper.CreateChild(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("no_auth", "true");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						child (id: ""{child.Id}"" ) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Not_Developer_Get_Child_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var child = ChildHelper.CreateChild(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("role", "not a developer");
+				api.Client.DefaultRequestHeaders.Add("claims_sub", "123");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						child (id: ""{child.Id}"" ) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Developer_Get_Child_By_Id_Succeeds()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var child = ChildHelper.CreateChild(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("role", "developer");
+				api.Client.DefaultRequestHeaders.Add("claims_sub", "123");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						child (id: ""{child.Id}"" ) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Child childRes = await response.GetObjectFromGraphQLResponse<Child>();
+				Assert.Equal(firstName, childRes.FirstName);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/ChildQueryTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/ChildQueryTests.cs
@@ -1,0 +1,166 @@
+using Xunit;
+using System;
+using System.Threading.Tasks;
+using Hedwig.Data;
+using HedwigTests.Helpers;
+using Hedwig.Models;
+using HedwigTests.Fixtures;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+	[Collection("SqlServer")]
+	public class ChildQueryTests
+	{
+		[Fact]
+		public async Task Get_Child_By_Id_As_Of()
+		{
+			using (var api = new TestApiProvider())
+			{
+				//Given
+				var originalName = "FIRST";
+				var updatedName = "UPDATED";
+				var child = ChildHelper.CreateChild(api.Context, firstName: originalName);
+				var asOf = Utilities.GetAsOfWithSleep();
+				child.FirstName = updatedName;
+				api.Context.SaveChanges();
+
+
+				// When child is queried with asOf timestamp
+				var responseAsOf = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        child(id: ""{child.Id}"", asOf: ""{asOf}"") {{
+                            firstName
+                        }}
+                    }}"
+				);
+
+				// Then the old version of the child  is returned
+				responseAsOf.EnsureSuccessStatusCode();
+				Child childAsOf = await responseAsOf.GetObjectFromGraphQLResponse<Child>();
+				Assert.Equal(originalName, childAsOf.FirstName);
+
+				// When child is queried
+				var responseCurrent = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        child(id: ""{child.Id}"") {{
+                            firstName
+                        }}
+                    }}"
+				);
+
+				// Then the current version of the child is returned
+				responseCurrent.EnsureSuccessStatusCode();
+				Child childCurrent = await responseCurrent.GetObjectFromGraphQLResponse<Child>();
+				Assert.Equal(updatedName, childCurrent.FirstName);
+			}
+		}
+
+		[Fact]
+		public async Task Get_Child_By_Id_As_Of_With_Family()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// Given
+				var family = FamilyHelper.CreateFamily(api.Context);
+				var child = ChildHelper.CreateChild(api.Context, family: family);
+				var asOf = Utilities.GetAsOfWithSleep();
+
+				var address = "my address";
+				family.AddressLine1 = address;
+				api.Context.SaveChanges();
+
+				// When child is queried with asOf timestamp
+				var responseAsOf = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        child(asOf: ""{asOf}"", id: ""{child.Id}"") {{
+                            family {{
+                                id,
+                                addressLine1
+                            }}
+                        }}
+                    }}"
+				);
+
+				// Then then old version of the child is returned
+				responseAsOf.EnsureSuccessStatusCode();
+				Child childAsOf = await responseAsOf.GetObjectFromGraphQLResponse<Child>();
+				Assert.Equal(family.Id, childAsOf.Family.Id);
+				Assert.Null(childAsOf.Family.AddressLine1);
+
+				// When child is queried
+				var responseCurrent = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        child(id: ""{child.Id}"") {{
+                            family {{
+                                id,
+                                addressLine1
+                            }}
+                        }}
+                    }}"
+				);
+
+				// Then the current version of the child is returned
+				responseCurrent.EnsureSuccessStatusCode();
+				Child childCurrent = await responseCurrent.GetObjectFromGraphQLResponse<Child>();
+				Assert.Equal(family.Id, childCurrent.Family.Id);
+				Assert.Equal(address, childCurrent.Family.AddressLine1);
+			}
+		}
+
+		[Fact]
+		public async Task Get_Child_By_Id_As_Of_With_Family_And_Determinations()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// Given
+				var family = FamilyHelper.CreateFamily(api.Context);
+				var child = ChildHelper.CreateChild(api.Context, family: family);
+				var asOf = Utilities.GetAsOfWithSleep();
+
+				var determination = FamilyDeterminationHelper.CreateDetermination(api.Context, family: family);
+				family.Determinations = new FamilyDetermination[] { determination };
+				api.Context.SaveChanges();
+
+				// When child is queried with asOf timestamp
+				var responseAsOf = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        child(asOf: ""{asOf}"", id: ""{child.Id}"") {{
+                            family {{
+                                id,
+                                determinations {{
+                                    id
+                                }}
+                            }}
+                        }}
+                    }}"
+				);
+
+				// Then then old version of the child 
+				responseAsOf.EnsureSuccessStatusCode();
+				Child childAsOf = await responseAsOf.GetObjectFromGraphQLResponse<Child>();
+				Assert.Equal(family.Id, childAsOf.Family.Id);
+				Assert.Empty(childAsOf.Family.Determinations);
+
+				// When child is queried
+				var responseCurrent = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        child(id: ""{child.Id}"") {{
+                            family {{
+                                id,
+                                determinations {{
+                                    id
+                                }}
+                            }}
+                        }}
+                    }}"
+				);
+
+				// Then the current version of the child is returned
+				responseCurrent.EnsureSuccessStatusCode();
+				Child childCurrent = await responseCurrent.GetObjectFromGraphQLResponse<Child>();
+				Assert.Equal(family.Id, childCurrent.Family.Id);
+				Assert.Single(childCurrent.Family.Determinations);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/EnrollmentQueryPermissionsTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/EnrollmentQueryPermissionsTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
+using Xunit;
+using Hedwig.Data;
+using Hedwig.Models;
+using HedwigTests.Helpers;
+using HedwigTests.Fixtures;
+using GraphQL.Common.Response;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+	public class EnrollmentQueryPermissionsTests
+	{
+		[Fact]
+		public async Task When_No_Auth_Get_Enrollment_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context);
+				api.Client.DefaultRequestHeaders.Add("no_auth", "true");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						enrollment (id: ""{enrollment.Id}"" ) {{
+							id
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Not_Developer_Get_Enrollment_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context);
+				api.Client.DefaultRequestHeaders.Add("role", "not a developer");
+				api.Client.DefaultRequestHeaders.Add("claims_sub", "123");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						enrollment (id: ""{enrollment.Id}"" ) {{
+							id
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Developer_Get_Enrollment_By_Id_Succeeds()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context);
+				api.Client.DefaultRequestHeaders.Add("role", "developer");
+				api.Client.DefaultRequestHeaders.Add("claims_sub", "123");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						enrollment (id: ""{enrollment.Id}"" ) {{
+							id
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				Enrollment enrollmentRes = await response.GetObjectFromGraphQLResponse<Enrollment>();
+				Assert.Equal(enrollment.Id, enrollmentRes.Id);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/EnrollmentQueryTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/EnrollmentQueryTests.cs
@@ -1,0 +1,144 @@
+using Xunit;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Hedwig.Data;
+using Hedwig.Models;
+using HedwigTests.Helpers;
+using HedwigTests.Fixtures;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+	public class EnrollmentQueryTests
+	{
+		[Fact]
+		public async Task Get_Enrollment_By_Id_As_Of()
+		{
+			using (var api = new TestApiProvider())
+			{
+				//Given 
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context);
+				var asOf = Utilities.GetAsOfWithSleep();
+
+				var exit = DateTime.Now.AddDays(3).Date;
+				enrollment.Exit = exit;
+				api.Context.SaveChanges();
+
+				// When
+				var responseCurrent = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        enrollment(id: ""{enrollment.Id}"") {{
+                            exit
+                        }}
+                    }}"
+				);
+
+				responseCurrent.EnsureSuccessStatusCode();
+				Enrollment enrollmentCurrent = await responseCurrent.GetObjectFromGraphQLResponse<Enrollment>();
+				Assert.Equal(exit, enrollmentCurrent.Exit);
+
+
+				var responseAsOf = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        enrollment(asOf: ""{asOf}"", id: ""{enrollment.Id}"") {{
+                            exit
+                        }}
+                    }}"
+				);
+
+				responseAsOf.EnsureSuccessStatusCode();
+				Enrollment enrollmentAsOf = await responseAsOf.GetObjectFromGraphQLResponse<Enrollment>();
+				Assert.False(enrollmentAsOf.Exit.HasValue);
+			}
+		}
+
+		[Fact]
+		public async Task Get_Enrollment_By_Id_As_Of_With_Child()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// Given
+				var originalName = "FIRST";
+				var updatedName = "UPDATED";
+				var child = ChildHelper.CreateChild(api.Context, firstName: originalName);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, child: child);
+				var asOf = Utilities.GetAsOfWithSleep();
+
+				child.FirstName = updatedName;
+				api.Context.SaveChanges();
+
+				var responseCurrent = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        enrollment(id: ""{enrollment.Id}"") {{
+                            child {{
+                                firstName
+                            }}
+                        }}
+                    }}"
+				);
+
+				responseCurrent.EnsureSuccessStatusCode();
+				Enrollment enrollmentCurrent = await responseCurrent.GetObjectFromGraphQLResponse<Enrollment>();
+				Assert.Equal(updatedName, enrollmentCurrent.Child.FirstName);
+
+
+				var responseAsOf = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        enrollment(asOf: ""{asOf}"", id: ""{enrollment.Id}"") {{
+                            child {{
+                                firstName
+                            }}
+                        }}
+                    }}"
+				);
+
+				responseAsOf.EnsureSuccessStatusCode();
+				Enrollment enrollmentAsOf = await responseAsOf.GetObjectFromGraphQLResponse<Enrollment>();
+				Assert.Equal(originalName, enrollmentAsOf.Child.FirstName);
+			}
+		}
+
+		[Fact]
+		public async Task Get_Enrollment_By_Id_As_Of_With_Funding()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// Given
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context);
+				var asOf = Utilities.GetAsOfWithSleep();
+
+				var funding = FundingHelper.CreateFunding(api.Context, enrollment: enrollment);
+				api.Context.SaveChanges();
+
+				// When
+				var responseCurrent = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        enrollment(id: ""{enrollment.Id}"") {{
+							fundings {{
+								id
+							}}
+                        }}
+                    }}"
+				);
+
+				responseCurrent.EnsureSuccessStatusCode();
+				Enrollment enrollmentCurrent = await responseCurrent.GetObjectFromGraphQLResponse<Enrollment>();
+				Assert.Single(enrollmentCurrent.Fundings);
+
+				var responseAsOf = await api.Client.GetGraphQLAsync(
+						$@"{{
+                        enrollment(asOf: ""{asOf}"", id: ""{enrollment.Id}"") {{
+							fundings {{
+								id
+							}}
+                        }}
+                    }}"
+				);
+
+				responseAsOf.EnsureSuccessStatusCode();
+				Enrollment enrollmentAsOf = await responseAsOf.GetObjectFromGraphQLResponse<Enrollment>();
+				Assert.Empty(enrollmentAsOf.Fundings);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/ReportQueryPermissionsTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/ReportQueryPermissionsTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
+using Xunit;
+using Hedwig.Data;
+using Hedwig.Models;
+using HedwigTests.Helpers;
+using HedwigTests.Fixtures;
+using GraphQL.Common.Response;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+	public class ReportQueryPermissionsTests
+	{
+		[Fact]
+		public async Task When_No_Auth_Get_Report_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var report = ReportHelper.CreateCdcReport(api.Context);
+				api.Client.DefaultRequestHeaders.Add("no_auth", "true");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+						$@"{{
+								report (id : {report.Id}) {{
+										...on CdcReportType {{
+												id
+										}}
+								}}
+						}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Not_Developer_Get_Report_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var report = ReportHelper.CreateCdcReport(api.Context);
+				api.Client.DefaultRequestHeaders.Add("roles", "not a developer");
+				api.Client.DefaultRequestHeaders.Add("claims_sub", "123");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+						$@"{{
+								report (id : {report.Id}) {{
+										...on CdcReportType {{
+												id
+										}}
+								}}
+						}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Developer_Get_Report_By_Id_Succeeds()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var report = ReportHelper.CreateCdcReport(api.Context);
+				api.Client.DefaultRequestHeaders.Add("role", "developer");
+				api.Client.DefaultRequestHeaders.Add("claims_sub", "123");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+						$@"{{
+								report (id : {report.Id}) {{
+										...on CdcReportType {{
+												id
+										}}
+								}}
+						}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				CdcReport reportRes = await response.GetObjectFromGraphQLResponse<CdcReport>("report");
+				Assert.Equal(report.Id, reportRes.Id);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/ReportQueryTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/ReportQueryTests.cs
@@ -1,0 +1,37 @@
+using Xunit;
+using System.Threading.Tasks;
+using Hedwig.Models;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+    public class ReportQueryTests
+    {
+        [Fact]
+        public async Task Get_Report_By_Id()
+        {
+            using (var api = new TestApiProvider())
+            {
+                // Given
+                var report = ReportHelper.CreateCdcReport(api.Context);
+
+                // When
+                var response = await api.Client.GetGraphQLAsync(
+                    $@"{{
+                        report (id : {report.Id}) {{
+                            ...on CdcReportType {{
+                                id
+                            }}
+                        }}
+                    }}"
+                );
+
+                // Then
+                response.EnsureSuccessStatusCode();
+                CdcReport reportRes = await response.GetObjectFromGraphQLResponse<CdcReport>("report");
+                Assert.Equal(report.Id, reportRes.Id);
+            }
+        }
+    }
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/UserQueryPermissionsTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/UserQueryPermissionsTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
+using Xunit;
+using Hedwig.Data;
+using Hedwig.Models;
+using HedwigTests.Helpers;
+using HedwigTests.Fixtures;
+using GraphQL.Common.Response;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+	public class UserQueryPermissionsTests
+	{
+		[Fact]
+		public async Task When_No_Auth_Get_User_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var user = UserHelper.CreateUser(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("no_auth", "true");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						user (id: {user.Id} ) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_No_Auth_Me_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var user = UserHelper.CreateUser(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("no_auth", "true");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						me {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Not_Current_User_Get_User_By_Id_Fails()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var user = UserHelper.CreateUser(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("claims_sub", $"{user.Id + 100000}");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						user (id: {user.Id} ) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				GraphQLResponse res = await response.ParseGraphQLResponse();
+				Assert.NotNull(res.Errors);
+			}
+		}
+
+		[Fact]
+		public async Task When_Current_User_Get_User_By_Id_Succeeds()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var user = UserHelper.CreateUser(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("claims_sub", $"{user.Id}");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						user (id: {user.Id} ) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				User userRes = await response.GetObjectFromGraphQLResponse<User>();
+				Assert.Equal(firstName, userRes.FirstName);
+			}
+		}
+
+		[Fact]
+		public async Task When_Current_User_Me_Succeeds()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// If
+				var firstName = "FIRSTNAME";
+				var user = UserHelper.CreateUser(api.Context, firstName: firstName);
+				api.Client.DefaultRequestHeaders.Add("claims_sub", $"{user.Id}");
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						me {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				User userRes = await response.GetObjectFromGraphQLResponse<User>("me");
+				Assert.Equal(firstName, userRes.FirstName);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLQueries/UserQueryTests.cs
+++ b/test/HedwigTests/Integration/GraphQLQueries/UserQueryTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Xunit;
+using Hedwig.Data;
+using Hedwig.Models;
+using HedwigTests.Helpers;
+using HedwigTests.Fixtures;
+
+namespace HedwigTests.Integration.GraphQLQueries
+{
+	public class UserQueryTests
+	{
+
+		[Fact]
+		public async Task Get_User_By_Id()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// Given
+				var firstName = "FIRSTNAME";
+				var user = UserHelper.CreateUser(api.Context, firstName: firstName);
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+					$@"{{
+						user (id: {user.Id} ) {{
+							firstName
+						}}
+					}}"
+				);
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				User userRes = await response.GetObjectFromGraphQLResponse<User>();
+				Assert.Equal(firstName, userRes.FirstName);
+			}
+		}
+
+		[Fact]
+		public async Task Get_Sites_With_Enrollments_Filtered_By_Dates_By_Id()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// Given
+				var user = UserHelper.CreateUser(api.Context);
+				var sitePermission = PermissionHelper.CreateSitePermission(api.Context, user: user);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, site: sitePermission.Site);
+				var entry = new DateTime(2019, 1, 1);
+				enrollment.Entry = entry;
+				api.Context.SaveChanges();
+
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+										$@"{{
+                        user(id: ""{user.Id}"") {{
+                            sites {{
+                                enrollments(from:""{entry.AddYears(-1)}"", to: ""{entry.AddYears(1)}"") {{
+                                    id
+                                }}
+                            }}
+                        }}
+                    }}"
+                );
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				User userRes = await response.GetObjectFromGraphQLResponse<User>();
+				Assert.Single(userRes.Sites);
+				Assert.Single(userRes.Sites.First().Enrollments);
+				Assert.Equal(enrollment.Id, userRes.Sites.First().Enrollments.First().Id);
+			}
+		}
+
+		[Fact]
+		public async Task Get_Sites_With_Enrollments_Filtered_By_Dates_By_Id_No_Match()
+		{
+			using (var api = new TestApiProvider())
+			{
+				// Given
+				var user = UserHelper.CreateUser(api.Context);
+				var sitePermission = PermissionHelper.CreateSitePermission(api.Context, user: user);
+				var enrollment = EnrollmentHelper.CreateEnrollment(api.Context, site: sitePermission.Site);
+				var entry = new DateTime(2021, 1, 1);
+				enrollment.Entry = entry;
+				api.Context.SaveChanges();
+
+				// When
+				var response = await api.Client.GetGraphQLAsync(
+                    $@"{{
+                        user(id: {user.Id}) {{
+                            sites {{
+                                enrollments (from: ""{entry.AddYears(-3)}"", to: ""{entry.AddYears(-1)}"") {{
+                                    id
+                                }}
+                            }}
+                        }}
+                    }}"
+                );
+
+				// Then
+				response.EnsureSuccessStatusCode();
+				User userRes = await response.GetObjectFromGraphQLResponse<User>();
+				Assert.Single(userRes.Sites);
+				Assert.Empty(userRes.Sites.First().Enrollments);
+			}
+		}
+	}
+}

--- a/test/HedwigTests/Integration/GraphQLTests.cs
+++ b/test/HedwigTests/Integration/GraphQLTests.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Xunit;
+using HedwigTests.Fixtures;
+
+namespace HedwigTests.Integration
+{
+    public class GraphQLTests
+    {
+        [Fact]
+        public async Task GraphQL_Exists()
+        {
+			using (var client = new TestApiProvider().Client) {
+                var response = await client.GetAsync("/graphql");
+                response.EnsureSuccessStatusCode();
+            }
+        }
+	}
+}

--- a/test/HedwigTests/Schema/TemporalGraphTypeTests.cs
+++ b/test/HedwigTests/Schema/TemporalGraphTypeTests.cs
@@ -1,0 +1,57 @@
+using Xunit;
+using Moq;
+using GraphQL.Types;
+using Hedwig.Schema;
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace HedwigTests.Schema
+{
+    public class TemporalGraphTypeTests
+    {
+        [Fact]
+        public void SetAsOfGlobal_Adds_AsOf_To_GlobalArguments()
+        {
+            var context = new ResolveFieldContext<object>();
+            var httpCtx = new Mock<HttpContext>();
+            var userContext= new RequestContext(httpCtx.Object.User);
+            var globalArguments = new Dictionary<string, object>();
+            userContext.GlobalArguments = globalArguments;
+            context.UserContext = userContext;
+
+            DateTime asOf = DateTime.Now;
+            TemporalGraphType<object>.SetAsOfGlobal(context, asOf);
+
+            Assert.Single(globalArguments);
+            Assert.True(globalArguments.ContainsValue(asOf));
+        }
+
+        [Fact]
+        public void GetAsOfGlobal_Gets_AsOf_From_GlobalArguments()
+        {
+            var context = new ResolveFieldContext<object>();
+            var httpCtx = new Mock<HttpContext>();
+            var userContext= new RequestContext(httpCtx.Object.User);
+            var globalArguments = new Dictionary<string, object>();
+            DateTime asOf = DateTime.Now;
+            userContext.GlobalArguments = globalArguments;
+            context.UserContext = userContext;
+            TemporalGraphType<object>.SetAsOfGlobal(context, asOf);
+
+            Assert.Equal(asOf, TemporalGraphType<object>.GetAsOfGlobal(context));
+        }
+
+        [Fact]
+        public void GetAsOfGlobal_Gets_Null_If_AsOf_Not_Set()
+        {
+            var context = new ResolveFieldContext<object>();
+            var httpCtx = new Mock<HttpContext>();
+            var userContext= new RequestContext(httpCtx.Object.User);
+            userContext.GlobalArguments = new Dictionary<string, object>();
+            context.UserContext = userContext;
+
+            Assert.Null(TemporalGraphType<object>.GetAsOfGlobal(context));
+        }
+    }
+}

--- a/test/HedwigTests/Schema/UserContextTests.cs
+++ b/test/HedwigTests/Schema/UserContextTests.cs
@@ -1,0 +1,27 @@
+using Xunit;
+using Hedwig.Schema;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace HedwigTests.Schema
+{
+    public class UserContextTests
+    {
+        [Fact]
+        public void Has_GlobalArguments_Dict()
+        {
+            var httpCtx = new Mock<HttpContext>();
+            var userContext= new RequestContext(httpCtx.Object.User);
+            Assert.IsType<Dictionary<string, object>>(userContext.GlobalArguments);
+        }
+
+        [Fact]
+        public void UserContextCreator_Returns_New_UserContext()
+        {
+            var httpContextMock = new Mock<HttpContext>();
+            var userContext = RequestContext.RequestContextCreator(httpContextMock.Object);
+            Assert.IsType<RequestContext>(userContext);
+        }
+    }
+}

--- a/test/HedwigTests/Security/AuthorizationEvaluatorTests.cs
+++ b/test/HedwigTests/Security/AuthorizationEvaluatorTests.cs
@@ -1,0 +1,540 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+using Hedwig.Security;
+using HedwigTests.Helpers;
+using System;
+
+namespace HedwigTests.Security
+{
+    public class AuthorizationEvaluatorTests
+    {
+        private readonly AuthorizationEvaluator _evaluator;
+        private readonly AuthorizationSettings _settings;
+
+        public AuthorizationEvaluatorTests()
+        {
+            _settings = new AuthorizationSettings();
+            _evaluator = new AuthorizationEvaluator(_settings);
+        }
+
+        [Fact]
+        public async Task Succedes_When_No_Policies()
+        {
+          // If
+          var rules = new AuthorizationRules();
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Succedes_When_No_Rules()
+        {
+          // If
+          _settings.AddPolicy("AlwaysFalse", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement()));
+          var rules = new AuthorizationRules();
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+        
+        [Fact]
+        public async Task Succeedes_When_Allow_Rule_Succeedes()
+        {
+          // If
+          _settings.AddPolicy("AlwaysTrue", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement()));
+          var rules = new AuthorizationRules();
+          rules.Allow("AlwaysTrue");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Fails_When_Deny_Rule_Succeedes()
+        {
+          // If
+          _settings.AddPolicy("AlwaysTrue", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement()));
+          var rules = new AuthorizationRules();
+          rules.Deny("AlwaysTrue");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Continues_When_AllowNot_Rule_Succeedes()
+        {
+          // If
+          _settings.AddPolicy("AlwaysTrue", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement()));
+          _settings.AddPolicy("Exception", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetThrowsExceptionRequirement()));
+          var rules = new AuthorizationRules();
+          rules.AllowNot("AlwaysTrue");
+          // Rule action irrelevant
+          rules.Allow("Exception");
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+
+          // Then
+          Assert.Equal(AuthorizationRequirementHelper.RequirementException, ex.Message);
+        }
+
+        [Fact]
+        public async Task Continues_When_DenyNot_Rule_Succeedes()
+        {
+          // If
+          _settings.AddPolicy("AlwaysTrue", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement()));
+          _settings.AddPolicy("Exception", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetThrowsExceptionRequirement()));
+          var rules = new AuthorizationRules();
+          rules.DenyNot("AlwaysTrue");
+          // Rule action irrelevant
+          rules.Allow("Exception");
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            var result = await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+
+          // Then
+          Assert.Equal(AuthorizationRequirementHelper.RequirementException, ex.Message);
+        }
+
+        [Fact]
+        public async Task Continues_When_Allow_Rule_Fails()
+        {
+          // If
+          _settings.AddPolicy("AlwaysFalse", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement()));
+          _settings.AddPolicy("Exception", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetThrowsExceptionRequirement()));
+          var rules = new AuthorizationRules();
+          rules.Allow("AlwaysFalse");
+          // Rule action irrelevant
+          rules.Allow("Exception");
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            var result = await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+
+          // Then
+          Assert.Equal(AuthorizationRequirementHelper.RequirementException, ex.Message);
+        }
+
+        [Fact]
+        public async Task Continues_When_Deny_Rule_Fails()
+        {
+          // If
+          _settings.AddPolicy("AlwaysFalse", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement()));
+          _settings.AddPolicy("Exception", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetThrowsExceptionRequirement()));
+          var rules = new AuthorizationRules();
+          rules.Deny("AlwaysFalse");
+          // Rule action irrelevant
+          rules.Allow("Exception");
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+
+          // Then
+          Assert.Equal(AuthorizationRequirementHelper.RequirementException, ex.Message);
+        }
+
+        [Fact]
+        public async Task Succeedes_When_AllowNot_Rule_Fails()
+        {
+          // If
+          _settings.AddPolicy("AlwaysFalse", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement()));
+          var rules = new AuthorizationRules();
+          rules.AllowNot("AlwaysFalse");
+
+          // When 
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Fails_When_DenyNot_Rule_Fails()
+        {
+          // If
+          _settings.AddPolicy("AlwaysFalse", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement()));
+          var rules = new AuthorizationRules();
+          rules.DenyNot("AlwaysFalse");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Succedes_When_Allow_Policy_Has_No_Requirement()
+        {
+          // If
+          _settings.AddPolicy("NoRequirement", _ => {});
+          var rules = new AuthorizationRules();
+          rules.Allow("NoRequirement");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Fails_When_Deny_Policy_Has_No_Requirement()
+        {
+          // If
+          _settings.AddPolicy("NoRequirement", _ => {});
+          var rules = new AuthorizationRules();
+          rules.Deny("NoRequirement");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Continues_When_AllowNot_Policy_Has_No_Requirement()
+        {
+          // If
+          _settings.AddPolicy("NoRequirement", _ => {});
+          _settings.AddPolicy("Exception", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetThrowsExceptionRequirement()));
+          var rules = new AuthorizationRules();
+          rules.AllowNot("NoRequirement");
+          // Rule action irrelevant
+          rules.Allow("Exception");
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+
+          // Then
+          Assert.Equal(AuthorizationRequirementHelper.RequirementException, ex.Message);
+        }
+
+        [Fact]
+        public async Task Continues_When_DenyNot_Policy_Has_No_Requirement()
+        {
+          // If
+          _settings.AddPolicy("NoRequirement", _ => {});
+          _settings.AddPolicy("Exception", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetThrowsExceptionRequirement()));
+          var rules = new AuthorizationRules();
+          rules.DenyNot("NoRequirement");
+          // Rule action irrelevant
+          rules.Allow("Exception");
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+
+          // Then
+          Assert.Equal(AuthorizationRequirementHelper.RequirementException, ex.Message);
+        }
+
+        [Fact]
+        public async Task Succeedes_When_Allow_CatchAll()
+        {
+          // If
+          var rules = new AuthorizationRules();
+          rules.Allow();
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Fails_When_Deny_CatchAll()
+        {
+          // If
+          var rules = new AuthorizationRules();
+          rules.Deny();
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Throws_When_AllowNot_CatchAll()
+        {
+          // If
+          var message = "Final rule must be Allow or Deny";
+          var rules = new AuthorizationRules();
+          rules.AllowNot();
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+          
+          // Then
+          Assert.Equal(message, ex.Message);
+        }
+
+        [Fact]
+        public async Task Throws_When_DenyNot_CatchAll()
+        {
+          // If
+          var message = "Final rule must be Allow or Deny";
+          var rules = new AuthorizationRules();
+          rules.DenyNot();
+
+          // When
+          Exception ex = await Assert.ThrowsAsync<Exception>(async () => {
+            await _evaluator.Evaluate(
+              null, // principal
+              null, // user context
+              null, // input variables
+              rules,
+              null // query arguments
+            );
+          });
+          
+          // Then
+          Assert.Equal(message, ex.Message);
+        }
+        
+        [Fact]
+        public async Task Succeeds_When_Allow_Rule_Two_Requirements_Succeed()
+        {
+          // If
+          _settings.AddPolicy("TwoAlwaysTrue", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement())
+             .AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement())
+          );
+          var rules = new AuthorizationRules();
+          rules.Allow("TwoAlwaysTrue");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Succeedes_When_AllowNot_Rule_Two_Requirements_Fail()
+        {
+          // If
+          _settings.AddPolicy("TwoAlwaysFalse", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement())
+             .AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement())
+          );
+          var rules = new AuthorizationRules();
+          rules.AllowNot("TwoAlwaysFalse");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Succeedes_When_AllowNot_Rule_Requirements_One_Success_One_Fail()
+        {
+          // If
+          _settings.AddPolicy("OneAlwaysTrueOneAlwaysFalse", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement())
+             .AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement())
+          );
+          var rules = new AuthorizationRules();
+          rules.AllowNot("OneAlwaysTrueOneAlwaysFalse");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Succeedes_When_AllowNot_Rule_Requirements_One_Fail_One_Success()
+        {
+          // If
+          _settings.AddPolicy("OneAlwaysFalseOneAlwaysTrue", _ =>
+            _.AddRequirement(AuthorizationRequirementHelper.GetAlwaysFalseRequirement())
+             .AddRequirement(AuthorizationRequirementHelper.GetAlwaysTrueRequirement())
+          );
+          var rules = new AuthorizationRules();
+          rules.AllowNot("OneAlwaysFalseOneAlwaysTrue");
+
+          // When
+          var result = await _evaluator.Evaluate(
+            null, // principal
+            null, // user context
+            null, // input variables
+            rules,
+            null // query arguments
+          );
+
+          // Then
+          Assert.True(result.Succeeded);
+        }
+    }
+}

--- a/test/HedwigTests/Security/AuthorizationRuleTests.cs
+++ b/test/HedwigTests/Security/AuthorizationRuleTests.cs
@@ -1,0 +1,33 @@
+using Xunit;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Hedwig.Security;
+
+namespace HedwigTests.Security
+{
+	public class AuthorizationRuleTests
+	{
+		[Theory]
+		[InlineData(true, AuthorizationAction.Allow, AuthorizationRuleResult.Continue)]
+		[InlineData(true, AuthorizationAction.Deny, AuthorizationRuleResult.Continue)]
+		[InlineData(true, AuthorizationAction.AllowNot, AuthorizationRuleResult.Success)]
+		[InlineData(true, AuthorizationAction.DenyNot, AuthorizationRuleResult.Failure)]
+		[InlineData(false, AuthorizationAction.Allow, AuthorizationRuleResult.Success)]
+		[InlineData(false, AuthorizationAction.Deny, AuthorizationRuleResult.Failure)]
+		[InlineData(false, AuthorizationAction.AllowNot, AuthorizationRuleResult.Continue)]
+		[InlineData(false, AuthorizationAction.DenyNot, AuthorizationRuleResult.Continue)]
+		public void Assess_Returns_Corresponding_Result(bool didError, AuthorizationAction action, AuthorizationRuleResult expectedRuleResult)
+		{
+			// If
+			var rule = new AuthorizationRule("", action);
+
+			// Then
+			var result = rule.Action.Assess(didError);
+
+			// Ensure the number of rules equals number of results
+			
+			Assert.Equal(expectedRuleResult, result);
+		}
+	}
+}

--- a/test/HedwigTests/Security/AuthorizationRulesTests.cs
+++ b/test/HedwigTests/Security/AuthorizationRulesTests.cs
@@ -1,0 +1,88 @@
+using Xunit;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Hedwig.Security;
+using System;
+
+namespace HedwigTests.Security
+{
+	public class AuthorizationRulesTests
+	{
+		[Fact]
+		public void Allow_Adds_AuthorizationRule_With_Allow_Result()
+		{
+			// If
+			var rules = new AuthorizationRules();
+			var policy = "policy";
+
+			// When
+			rules.Allow(policy);
+
+			// Then
+			var rulesList = rules.GetEnumerator();
+			rulesList.MoveNext();
+			var rule = rulesList.Current;
+
+			// Ensure the action is Allow
+			Assert.Equal(AuthorizationAction.Allow, rule.Action);
+		}
+
+		[Fact]
+		public void AllowNot_Adds_AuthorizationRule_With_AllowNot_Result()
+		{
+			// If
+			var rules = new AuthorizationRules();
+			var policy = "policy";
+
+			// When
+			rules.AllowNot(policy);
+
+			// Then
+			var rulesList = rules.GetEnumerator();
+			rulesList.MoveNext();
+			var rule = rulesList.Current;
+
+			// Ensure the action is AllowNot
+			Assert.Equal(AuthorizationAction.AllowNot, rule.Action);
+		}
+
+		[Fact]
+			public void Deny_Adds_AuthorizationRule_With_Deny_Result()
+			{
+				// If
+				var rules = new AuthorizationRules();
+				var policy = "policy";
+
+				// When
+				rules.Deny(policy);
+
+				// Then
+				var rulesList = rules.GetEnumerator();
+				rulesList.MoveNext();
+				var rule = rulesList.Current;
+
+				// Ensure the action is Deny
+				Assert.Equal(AuthorizationAction.Deny, rule.Action);
+			}
+
+			[Fact]
+			public void DenyNot_Adds_AuthorizationRule_With_DenyNot_Result()
+			{
+				// If
+				var rules = new AuthorizationRules();
+				var policy = "policy";
+
+				// When
+				rules.DenyNot(policy);
+
+				// Then
+				var rulesList = rules.GetEnumerator();
+				rulesList.MoveNext();
+				var rule = rulesList.Current;
+
+				// Ensure the action is DenyNot
+				Assert.Equal(AuthorizationAction.DenyNot, rule.Action);
+			}
+	}
+}

--- a/test/HedwigTests/Security/AuthorizationSettings.cs
+++ b/test/HedwigTests/Security/AuthorizationSettings.cs
@@ -1,0 +1,117 @@
+using Xunit;
+using System.Collections.Generic;
+using Moq;
+using Hedwig.Security;
+
+namespace HedwigTests.Security
+{
+    public class AuthorizationSettingsTests
+    {
+        [Fact]
+        public void When_Nonexistant_Policy_GetPolicy_Returns_Null()
+        {
+          // If
+          var authSettings = new AuthorizationSettings();
+
+          // When
+          var policy = authSettings.GetPolicy("DoesNotExist");
+
+          // Then
+          Assert.Null(policy);
+        }
+
+        [Fact]
+        public void When_Existant_Policy_GetPolicy_Returns_Policy()
+        {
+          // If
+          var authSettings = new AuthorizationSettings();
+          var mockPolicy = new Mock<IAuthorizationPolicy>();
+          authSettings.AddPolicy("Policy", mockPolicy.Object);
+
+          // When
+          var policy = authSettings.GetPolicy("Policy");
+
+          // Then
+          Assert.Equal<IAuthorizationPolicy>(mockPolicy.Object, policy);
+        }
+
+        [Fact]
+        public void When_Existant_Policy_Via_Builder_GetPolicy_Returns_Policy()
+        {
+          // If
+          var authSettings = new AuthorizationSettings();
+          var mockRequirement = new Mock<IAuthorizationRequirement>();
+          authSettings.AddPolicy("Policy", _ => 
+            _.AddRequirement(mockRequirement.Object));
+          
+          // When
+          var policy = authSettings.GetPolicy("Policy");
+          var requirementEnumator = policy.Requirements.GetEnumerator();
+          requirementEnumator.MoveNext();
+          var requirement = requirementEnumator.Current;
+
+          // Then
+          Assert.Equal<IAuthorizationRequirement>(mockRequirement.Object, requirement);
+        }
+
+        [Fact]
+        public void When_Nonexistant_Policy_GetPolicies_Returns_Empty_Enumerable()
+        {
+          // If
+          var authSettings = new AuthorizationSettings();
+
+          // When
+          var policy = authSettings.GetPolicies(new string[] {
+            "DoesNotExist"
+          });
+
+          // Then
+          Assert.Empty(policy);
+        }
+
+        [Fact]
+        public void When_Existant_Policies_GetPolicies_Returns_Policies()
+        {
+          // If
+          var authSettings = new AuthorizationSettings();
+          var mockPolicy1 = new Mock<IAuthorizationPolicy>();
+          var mockPolicy2 = new Mock<IAuthorizationPolicy>();
+          var mockPolicies = new List<IAuthorizationPolicy> {
+            mockPolicy1.Object,
+            mockPolicy2.Object
+          };
+          authSettings.AddPolicy("Policy1", mockPolicy1.Object);
+          authSettings.AddPolicy("Policy2", mockPolicy2.Object);
+
+          // When
+          var policies = authSettings.GetPolicies(new string[] {
+            "Policy1",
+            "Policy2"
+          });
+
+          // Then
+          Assert.Equal(mockPolicies, policies);
+        }
+
+        [Fact]
+        public void When_Both_Non_And_Existant_Policies_GetPolicies_Returns_Only_Existant_Policies()
+        {
+          // If
+          var authSettings = new AuthorizationSettings();
+          var mockPolicy1 = new Mock<IAuthorizationPolicy>();
+          var mockPolicies = new List<IAuthorizationPolicy> {
+            mockPolicy1.Object,
+          };
+          authSettings.AddPolicy("Policy1", mockPolicy1.Object);
+
+          // When
+          var policies = authSettings.GetPolicies(new string[] {
+            "Policy1",
+            "DoesNotExist"
+          });
+
+          // Then
+          Assert.Equal(mockPolicies, policies);
+        }
+    }
+}

--- a/test/HedwigTests/Security/Policies/AuthenticatedUserRequirementTests.cs
+++ b/test/HedwigTests/Security/Policies/AuthenticatedUserRequirementTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+using System.Collections.Generic;
+using Moq;
+using Hedwig.Security;
+using System.Security.Claims;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Security
+{
+    public class AuthenticatedUserRequirementTests
+    {
+        [Fact]
+        public async void When_Authenticated_User_Authorize_Produces_No_Error()
+        {
+          // If
+          var requirement = new AuthenticatedUserRequirement();
+          var context = new AuthorizationContext();
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password");
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.False(context.HasErrors);
+        }
+
+        [Fact]
+        public async void When_Not_Authenticated_User_Authorize_Produces_Error()
+        {
+          // If
+          var requirement = new AuthenticatedUserRequirement();
+          var context = new AuthorizationContext();
+          context.User = AuthorizationRequirementHelper.CreatePrincipal();
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.True(context.HasErrors);
+        }
+    }
+}

--- a/test/HedwigTests/Security/Policies/CurrentUserRequirementTests.cs
+++ b/test/HedwigTests/Security/Policies/CurrentUserRequirementTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+using System.Collections.Generic;
+using Moq;
+using Hedwig.Security;
+using System.Security.Claims;
+using HedwigTests.Helpers;
+using Microsoft.AspNetCore.Hosting;
+using GraphQL.Language.AST;
+using System;
+
+namespace HedwigTests.Security
+{
+    public class CurrentUserRequirementTests
+    {
+        [Fact]
+        public async void When_Current_User_Authorize_Produces_No_Error()
+        {
+          // If
+          var requirement = new CurrentUserRequirement();
+          var context = new AuthorizationContext();
+          var claims = new Dictionary<string, string>() {
+            { "sub", "1" }
+          };
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password", claims);
+          var argument = BuildArgument(typeof(IntValue), "id", 1);
+          var arguments = new Arguments();
+          arguments.Add(argument);
+          context.Arguments = arguments;
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.False(context.HasErrors);
+        }
+
+        [Fact]
+        public async void When_Not_Current_User_Authorize_Produces_Error()
+        {
+          // If
+          var requirement = new CurrentUserRequirement();
+          var context = new AuthorizationContext();
+          var claims = new Dictionary<string, string>() {
+            { "sub", "1" }
+          };
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password", claims);
+          var argument = BuildArgument(typeof(IntValue), "id", 2);
+          var arguments = new Arguments();
+          arguments.Add(argument);
+          context.Arguments = arguments;
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.True(context.HasErrors);
+        }
+
+        private static Argument BuildArgument(Type t, string name, object value)
+        {
+          var nameNode = new NameNode(name);
+          var argument = new Argument(nameNode);
+          var iValue = (IValue) Activator.CreateInstance(t, value);
+          argument.Value = iValue;
+          return argument;
+        }
+    }
+}

--- a/test/HedwigTests/Security/Policies/DeveloperUserRequirementTests.cs
+++ b/test/HedwigTests/Security/Policies/DeveloperUserRequirementTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+using System.Collections.Generic;
+using Moq;
+using Hedwig.Security;
+using System.Security.Claims;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Security
+{
+    public class DeveloperUserRequirementTests
+    {
+        [Fact]
+        public async void When_Developer_User_Authorize_Produces_No_Error()
+        {
+          // If
+          var requirement = new DeveloperUserRequirement();
+          var context = new AuthorizationContext();
+          var claims = new Dictionary<string, string>() {
+            { "role", "developer" }
+          };
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password", claims);
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.False(context.HasErrors);
+        }
+
+        [Fact]
+        public async void When_Not_Developer_User_Authorize_Produces_Error()
+        {
+          // If
+          var requirement = new DeveloperUserRequirement();
+          var context = new AuthorizationContext();
+          var claims = new Dictionary<string, string>() {
+            { "role", "not developer" }
+          };
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password", claims);
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.True(context.HasErrors);
+        }
+    }
+}

--- a/test/HedwigTests/Security/Policies/DevelopmentRequirementTests.cs
+++ b/test/HedwigTests/Security/Policies/DevelopmentRequirementTests.cs
@@ -1,0 +1,47 @@
+using Xunit;
+using System.Collections.Generic;
+using Moq;
+using Hedwig.Security;
+using System.Security.Claims;
+using HedwigTests.Helpers;
+using Microsoft.AspNetCore.Hosting;
+
+namespace HedwigTests.Security
+{
+    public class DevelopmentRequirementTests
+    {
+        [Fact]
+        public async void When_Development_Authorize_Produces_No_Error()
+        {
+          // If
+          var env = new Mock<IHostingEnvironment>();
+          env.Setup(_env => _env.EnvironmentName).Returns("Development");
+          var requirement = new DevelopmentRequirement(env.Object);
+          var context = new AuthorizationContext();
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password");
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.False(context.HasErrors);
+        }
+
+        [Fact]
+        public async void When_Not_Development_Authorize_Produces_Error()
+        {
+          // If
+          var env = new Mock<IHostingEnvironment>();
+          env.Setup(_env => _env.EnvironmentName).Returns("Not Development");
+          var requirement = new DevelopmentRequirement(env.Object);
+          var context = new AuthorizationContext();
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password");
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.True(context.HasErrors);
+        }
+    }
+}

--- a/test/HedwigTests/Security/Policies/TestModeRequirementTests.cs
+++ b/test/HedwigTests/Security/Policies/TestModeRequirementTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+using System.Collections.Generic;
+using Moq;
+using Hedwig.Security;
+using System.Security.Claims;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Security
+{
+    public class TestModeRequirementTests
+    {
+        [Fact]
+        public async void When_TestMode_Authorize_Produces_No_Error()
+        {
+          // If
+          var requirement = new TestModeRequirement();
+          var context = new AuthorizationContext();
+          var claims = new Dictionary<string, string>() {
+            { "test_mode", "true" }
+          };
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password", claims);
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.False(context.HasErrors);
+        }
+
+        [Fact]
+        public async void When_Not_TestMode_Authorize_Produces_Error()
+        {
+          // If
+          var requirement = new TestModeRequirement();
+          var context = new AuthorizationContext();
+          var claims = new Dictionary<string, string>() {
+            { "test_mode", "false" }
+          };
+          context.User = AuthorizationRequirementHelper.CreatePrincipal("password", claims);
+
+          // When
+          await requirement.Authorize(context);
+
+          // Then
+          Assert.True(context.HasErrors);
+        }
+    }
+}


### PR DESCRIPTION
Adds back the graphql logic into the dotnet core 3 MVC app.

Code is commented with `// GraphQL Support` guards for when we need to fully remove graphql support.