### PR TITLE
Add serializing support without DTO

### DIFF
--- a/src/Hedwig/Controllers/OrganizationController.cs
+++ b/src/Hedwig/Controllers/OrganizationController.cs
@@ -13,10 +13,17 @@ namespace Hedwig.Controllers
     public class OrganizationsController : ControllerBase
     {
         private readonly IOrganizationRepository _organizations;
+        private readonly ISiteRepository _sites;
+        private readonly IEnrollmentRepository _enrollments;
 
-        public OrganizationsController(IOrganizationRepository organizations)
+        public OrganizationsController(
+            IOrganizationRepository organizations,
+            ISiteRepository sites,
+            IEnrollmentRepository enrollments)
         {
             _organizations = organizations;
+            _sites = sites;
+            _enrollments = enrollments;
         }
 
         // GET api/organizations
@@ -28,9 +35,19 @@ namespace Hedwig.Controllers
 
         // GET api/organizations/5
         [HttpGet("{id}")]
-        public ActionResult<string> Get(int id)
+        public async Task<ActionResult<object>> Get(int id, [FromQuery(Name ="include[]")] string[] include)
         {
-            return "hello org";
+            var organization = await _organizations.GetOrganizationByIdAsync(id);
+
+            if (include.Contains("site"))
+            {
+                var sites = await _sites.GetSitesByOrganizationIdsAsync(new int[] { id });
+                if (include.Contains("enrollment"))
+                {
+                    await _enrollments.GetEnrollmentsBySiteIdsAsync(from site in sites select site.Key);
+                }
+            }
+            return organization;
         }
     }
 }

--- a/src/Hedwig/Hedwig.csproj
+++ b/src/Hedwig/Hedwig.csproj
@@ -24,6 +24,7 @@
     <!-- End GraphQL Support -->
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />

--- a/src/Hedwig/Repositories/OrganizationRepository.cs
+++ b/src/Hedwig/Repositories/OrganizationRepository.cs
@@ -21,10 +21,17 @@ namespace Hedwig.Repositories
 				.ToDictionaryAsync(x => x.Id);
 			return dict as IDictionary<int, Organization>;
 		}
+
+		public async Task<Organization> GetOrganizationByIdAsync(int id)
+		{
+			return await _context.Organizations
+				.SingleOrDefaultAsync(o => o.Id == id);
+		}
 	}
 
 	public interface IOrganizationRepository
 	{
 		Task<IDictionary<int, Organization>> GetOrganizationsByIdsAsync(IEnumerable<int> ids);
+		Task<Organization> GetOrganizationByIdAsync(int id);
 	}
 }

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -82,7 +82,12 @@ namespace Hedwig
 
 		public static void ConfigureControllers(this IServiceCollection services)
 		{
-			services.AddControllers();
+			services
+			.AddControllers()
+			.AddNewtonsoftJson(options =>
+				{
+					options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
+				});
 		}
 
 // GraphQL Support


### PR DESCRIPTION
Should close #258 

Added Newtonsoft b/c the Dotnet Core 3 built-in is not feature-ful enough for our use case, re recursive serialization.

As part of this, I explored additional sub-field inclusion. ASPNet Core provides us great query string inspection that makes adding this super easy! Combined with EF's hydration support and we can do some fancy things!

For example, try these queries:
* `/api/organizations/1`
* `/api/organizations/1?include[]=site`
* `/api/organizations/1?include[]=site&include[]=enrollment`