### PR TITLE
232 authorization

### DIFF
--- a/src/Hedwig/Repositories/OrganizationRepository.cs
+++ b/src/Hedwig/Repositories/OrganizationRepository.cs
@@ -8,11 +8,10 @@ using Hedwig.Data;
 
 namespace Hedwig.Repositories
 {
-	public class OrganizationRepository : IOrganizationRepository
+	public class OrganizationRepository : HedwigRepository, IOrganizationRepository
 	{
-		private readonly HedwigContext _context;
 
-		public OrganizationRepository(HedwigContext context) => _context = context;
+		public OrganizationRepository(HedwigContext context) : base(context) {}
 
 		public async Task<IDictionary<int, Organization>> GetOrganizationsByIdsAsync(IEnumerable<int> ids)
 		{

--- a/src/Hedwig/Repositories/PermissionRepository.cs
+++ b/src/Hedwig/Repositories/PermissionRepository.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using System.Linq;
+using Hedwig.Data;
+using Hedwig.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Hedwig.Repositories
+{
+    public class PermissionRepository : HedwigRepository, IPermissionRepository
+    {
+        public PermissionRepository(HedwigContext context) : base(context) {}
+        public bool UserCanAccessSite(int userId, int siteId)
+        {
+            // User can access site if:
+            // - Site permission exists for user for site
+            // - Organization permission exists for user for organization that includes site 
+
+            var sitePermissions = _context.Permissions
+                .OfType<SitePermission>()
+                .Where(sp => sp.UserId == userId && sp.SiteId == siteId)
+                .FirstOrDefault();
+            
+            if(sitePermissions != null) return true;
+
+            var organizationPermissions = _context.Permissions
+                .OfType<OrganizationPermission>()
+                    .Include(op => op.Organization)
+                        .ThenInclude(o => o.Sites)
+                .Where(op => op.UserId == userId
+                    && op.Organization.Sites.Any(s => s.Id == siteId))
+                .FirstOrDefault();
+
+
+            return organizationPermissions != null;
+        }
+
+        public bool UserCanAccessOrganization(int userId, int organizationId)
+        {
+            // User can access organization if:
+            // - Organization permission exists for user for organization
+            var organizationPermission = _context.Permissions
+                .OfType<OrganizationPermission>()
+                .Where(op => op.UserId == userId && op.OrganizationId == organizationId)
+                .FirstOrDefault();
+                
+            return organizationPermission != null;
+        }
+    }
+
+    public interface IPermissionRepository
+    {
+        bool UserCanAccessSite(int userId, int siteId);
+        bool UserCanAccessOrganization(int userId, int organizationId);
+    }
+}

--- a/src/Hedwig/Repositories/SiteRepository.cs
+++ b/src/Hedwig/Repositories/SiteRepository.cs
@@ -7,11 +7,10 @@ using Hedwig.Data;
 
 namespace Hedwig.Repositories
 {
-    public class SiteRepository : ISiteRepository
+    public class SiteRepository : HedwigRepository, ISiteRepository
     {
-        private readonly HedwigContext _context;
 
-        public SiteRepository(HedwigContext context) => _context = context;
+        public SiteRepository(HedwigContext context) : base(context) {}
 
         public async Task<ILookup<int, Site>> GetSitesByOrganizationIdsAsync(IEnumerable<int> organizationIds)
         {

--- a/src/Hedwig/Repositories/UserRepository.cs
+++ b/src/Hedwig/Repositories/UserRepository.cs
@@ -5,11 +5,10 @@ using Hedwig.Data;
 
 namespace Hedwig.Repositories
 {
-	public class UserRepository : IUserRepository
+	public class UserRepository : HedwigRepository, IUserRepository
 	{
-		private readonly HedwigContext _context;
 
-		public UserRepository(HedwigContext context) => _context = context;
+		public UserRepository(HedwigContext context) : base(context) {}
 
 		public async Task<User> GetUserByIdAsync(int id) => await _context.Users.SingleOrDefaultAsync(u => u.Id == id);
 	}

--- a/src/Hedwig/Security_NEW/Requirements/IPermissionRequirement.cs
+++ b/src/Hedwig/Security_NEW/Requirements/IPermissionRequirement.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Hedwig.Repositories;
+
+namespace Hedwig.Security_NEW
+{
+    public interface IPermissionRequirement : IAuthorizationRequirement
+    {
+        bool Evaluate(
+            ClaimsPrincipal User,
+            HttpContext httpContext,
+            IPermissionRepository permissions
+        );
+    }
+}

--- a/src/Hedwig/Security_NEW/Requirements/UserOrganizationAccessRequirement.cs
+++ b/src/Hedwig/Security_NEW/Requirements/UserOrganizationAccessRequirement.cs
@@ -1,0 +1,46 @@
+using System;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Hedwig.Repositories;
+
+namespace Hedwig.Security_NEW
+{
+    public class UserOrganizationAccessRequirement : IAuthorizationRequirement, IPermissionRequirement
+    {  
+        public const string NAME = "UserOrganizationAccess";
+
+        public bool Evaluate(
+            ClaimsPrincipal user,
+            HttpContext httpContext,
+            IPermissionRepository permissions
+        )
+        {
+            return  UserCanAccessOrganization(user, httpContext, permissions);
+        }
+
+        private bool UserCanAccessOrganization(
+            ClaimsPrincipal user,
+            HttpContext httpContext,
+            IPermissionRepository permissions
+        )
+        {
+            var userIdStr = user.FindFirst("sub")?.Value;
+            var routeData = httpContext.GetRouteData();
+            // If request controller = 'Organizations', path param for organiation id is 'id'
+            // else, path param is 'orgId'
+            var orgIdParam = (string)routeData.Values["controller"] == "Organizations" ? "id" : "orgId";
+            var orgIdStr = (string)routeData.Values[orgIdParam];
+            if(userIdStr != null && orgIdStr != null) {
+                var userId = Int32.Parse(userIdStr);
+                var orgId = Int32.Parse(orgIdStr);
+                return permissions.UserCanAccessOrganization(userId, orgId);
+            }
+
+            return false;
+
+        }
+    }
+}

--- a/src/Hedwig/Security_NEW/Requirements/UserSiteAccessRequirement.cs
+++ b/src/Hedwig/Security_NEW/Requirements/UserSiteAccessRequirement.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Security.Claims;
+using Hedwig.Repositories;
+
+namespace Hedwig.Security_NEW
+{
+    public class UserSiteAccessRequirement : IPermissionRequirement
+    {  
+        public const string NAME = "UserSiteAccess";
+
+        public bool Evaluate(
+            ClaimsPrincipal user,
+            HttpContext httpContext,
+            IPermissionRepository permissions
+        )
+        {
+            return UserCanAccessSite(user, httpContext, permissions);
+        }
+        
+        private bool UserCanAccessSite(
+            ClaimsPrincipal user,
+            HttpContext httpContext,
+            IPermissionRepository permissions 
+        )
+        {
+            var userIdStr = user.FindFirst("sub")?.Value;
+            var routeData = httpContext.GetRouteData();
+            // If request controller is 'Sites', path param for site id is 'id'
+            // else, path param is 'siteId'
+            var siteIdParam = (string)routeData.Values["controller"] == "Sites" ? "id" : "siteId";
+            var siteIdStr = (string)routeData.Values[siteIdParam];
+            
+            if(userIdStr != null && siteIdStr != null) {
+                var userId = Int32.Parse(userIdStr);
+                var siteId = Int32.Parse(siteIdStr);
+                return permissions.UserCanAccessSite(userId, siteId);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Hedwig/Security_NEW/RequirementsHandler.cs
+++ b/src/Hedwig/Security_NEW/RequirementsHandler.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Hedwig.Repositories;
+
+namespace Hedwig.Security_NEW
+{
+    public class RequirementsHandler : IAuthorizationHandler
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IPermissionRepository _permissions;
+
+        public RequirementsHandler(IHttpContextAccessor httpContextAccessor, IPermissionRepository permissions)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _permissions = permissions;
+        }
+        public Task HandleAsync(AuthorizationHandlerContext context)
+        {
+            var pendingRequirements = context.PendingRequirements.ToList();
+
+            foreach (var req in pendingRequirements) {
+                if (req is IPermissionRequirement pReq)
+                    if(pReq.Evaluate(
+                        context.User,
+                        _httpContextAccessor.HttpContext,
+                        _permissions
+                        )
+                    ) context.Succeed(req);
+                }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -2,7 +2,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Hedwig.Data;
 using Hedwig.Repositories;
+using Hedwig.Security_NEW;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using System.Net.Http;
 using System.IdentityModel.Tokens.Jwt;
 
@@ -63,6 +65,7 @@ namespace Hedwig
 			services.AddScoped<IReportRepository, ReportRepository>();
 			services.AddScoped<ISiteRepository, SiteRepository>();
 			services.AddScoped<IUserRepository, UserRepository>();
+			services.AddScoped<IPermissionRepository, PermissionRepository>();
 		}
 
 		public static void ConfigureAuthentication(this IServiceCollection services)
@@ -78,6 +81,22 @@ namespace Hedwig
 							ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
 						};
 					});
+		}
+
+		public static void ConfigureAuthorization(this IServiceCollection services)
+		{
+			services.AddScoped<IAuthorizationHandler, RequirementsHandler>();
+			services.AddAuthorization(options => 
+			{
+				options.AddPolicy(
+					UserSiteAccessRequirement.NAME, 
+					policy => policy .AddRequirements(new UserSiteAccessRequirement())
+				);
+				options.AddPolicy(
+					UserOrganizationAccessRequirement.NAME,
+					policy => policy.AddRequirements(new UserOrganizationAccessRequirement())
+				);
+			});
 		}
 
 		public static void ConfigureControllers(this IServiceCollection services)

--- a/src/Hedwig/Startup.cs
+++ b/src/Hedwig/Startup.cs
@@ -33,6 +33,7 @@ namespace Hedwig
 			services.ConfigureSpa();
 			services.ConfigureRepositories();
 			services.ConfigureAuthentication();
+			services.ConfigureAuthorization();
 			services.AddHttpContextAccessor();
 
 			// GraphQL Support

--- a/test/HedwigTests/Repositories/PermissionRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/PermissionRepositoryTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+using Hedwig.Repositories;
+using Hedwig.Models;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Repositories
+{
+    public class PermissionRepositoryTests
+    {
+        [Fact]
+        public void UserCanAccessSite_SitePermission()
+        {
+            using( var context = new TestContextProvider().Context) {
+                // If user exists with site permission
+                var user = UserHelper.CreateUser(context);
+                var site = SiteHelper.CreateSite(context);
+                PermissionHelper.CreateSitePermission(context, user, site);
+
+                // When repository is queried for user access to site
+                var permissionRepo = new PermissionRepository(context);
+                var res = permissionRepo.UserCanAccessSite(user.Id, site.Id);
+
+                // Then result is true
+                Assert.True(res);
+            } 
+        }
+
+        [Fact]
+        public void UserCanAccessSite_OrganizationPermission()
+        {
+            using( var context = new TestContextProvider().Context) {
+                // If user exists with organization permission that includes site
+                var user = UserHelper.CreateUser(context);
+                var site = SiteHelper.CreateSite(context);
+                var organization = OrganizationHelper.CreateOrganization(context, sites: new Site[]{site});
+                PermissionHelper.CreateOrganizationPermission(context, user, organization);
+
+                // When repository is queried for user access to site
+                var permissionRepo = new PermissionRepository(context);
+                var res = permissionRepo.UserCanAccessSite(user.Id, site.Id);
+
+                // Then result is true
+                Assert.True(res);
+            } 
+        }
+        
+        [Fact]
+        public void UserCanAccessSite_No_Permission()
+        {
+            using( var context = new TestContextProvider().Context) {
+                // If user exists without any permissions
+                var user = UserHelper.CreateUser(context);
+                var site = SiteHelper.CreateSite(context);
+                PermissionHelper.CreateSitePermission(context, user, site);
+
+                // When repository is queried for user access to some other site
+                var permissionRepo = new PermissionRepository(context);
+                var res = permissionRepo.UserCanAccessSite(user.Id, 0);
+
+                // Then result is false
+                Assert.False(res);
+            } 
+        }
+
+
+    }
+}

--- a/test/HedwigTests/Security_NEW/Requirements/UserOrganizationAccessRequirementTests.cs
+++ b/test/HedwigTests/Security_NEW/Requirements/UserOrganizationAccessRequirementTests.cs
@@ -1,0 +1,117 @@
+using Xunit;
+using Moq;
+using System.Security.Claims;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Hedwig.Repositories;
+using Hedwig.Security_NEW;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Security_NEW
+{
+    public class UserOrganizationAccessRequirementTests
+    {
+        [Fact]
+        public void Organization_Controller_User_Has_Organization_Access_Evaluate_Returns_True()
+        {
+            using (var dbContext = new TestContextProvider().Context) {
+                // If user exists with access to organization
+                var user = UserHelper.CreateUser(dbContext);
+                var organization = OrganizationHelper.CreateOrganization(dbContext);
+                PermissionHelper.CreateOrganizationPermission(dbContext, user, organization);
+
+                // When requirement is evaluated with:
+                // - claim for that user
+                var claim = new Claim("sub", $"{user.Id}");
+                var userClaim = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {claim}));
+
+                // - httpContext for request to 'Organizations' controller for that organization
+                var httpContext = new Mock<HttpContext>();
+                var routeValues = new RouteValueDictionary(new Dictionary<string, string>{
+                    {"controller", "Organizations"},
+                    {"id", $"{organization.Id}"}
+                });
+                httpContext.Setup(hc => hc.Features.Get<IRoutingFeature>()).Returns(new Mock<IRoutingFeature>().Object);
+                httpContext.Setup(hc => hc.Request.RouteValues).Returns(routeValues);
+
+                // - permission repository
+                var permissions = new PermissionRepository(dbContext);
+
+                var req = new UserOrganizationAccessRequirement();
+                var res = req.Evaluate(userClaim, httpContext.Object, permissions);
+
+                // Then it should evaluate to True
+                Assert.True(res);
+            }
+        }
+
+        [Fact]
+        public void Other_Controller_User_Has_Organization_Access_Evaluate_Returns_True()
+        {
+            using (var dbContext = new TestContextProvider().Context) {
+                // If user exists with access to organization
+                var user = UserHelper.CreateUser(dbContext);
+                var organization = OrganizationHelper.CreateOrganization(dbContext);
+                PermissionHelper.CreateOrganizationPermission(dbContext, user, organization);
+
+                // When requirement is evaluated with:
+                // - claim for that user
+                var claim = new Claim("sub", $"{user.Id}");
+                var userClaim = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {claim}));
+
+                // - httpContext for request to other controller nested under that organization
+                var httpContext = new Mock<HttpContext>();
+                var routeValues = new RouteValueDictionary(new Dictionary<string, string>{
+                    {"controller", "Other"},
+                    {"orgId", $"{organization.Id}"}
+                });
+                httpContext.Setup(hc => hc.Features.Get<IRoutingFeature>()).Returns(new Mock<IRoutingFeature>().Object);
+                httpContext.Setup(hc => hc.Request.RouteValues).Returns(routeValues);
+
+                // - permission repository
+                var permissions = new PermissionRepository(dbContext);
+
+                var req = new UserOrganizationAccessRequirement();
+                var res = req.Evaluate(userClaim, httpContext.Object, permissions);
+
+                // Then it should evaluate to True
+                Assert.True(res);
+            }
+        }
+
+
+        [Fact]
+        public void User_Does_Not_Have_Organization_Access_Evaluate_Returns_False()
+        {
+            using (var dbContext = new TestContextProvider().Context) {
+                // If user exists without access to any organization
+                var user = UserHelper.CreateUser(dbContext);
+
+                // When requirement is evaluated with:
+                // - claim for that user
+                var claim = new Claim("sub", $"{user.Id}");
+                var userClaim = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {claim}));
+
+                // - httpContext for request to 'Organizations' controller for any organization
+                var httpContext = new Mock<HttpContext>();
+                var routeValues = new RouteValueDictionary(new Dictionary<string, string>{
+                    {"controller", "Organizations"},
+                    {"id", "1"}
+                });
+                httpContext.Setup(hc => hc.Features.Get<IRoutingFeature>()).Returns(new Mock<IRoutingFeature>().Object);
+                httpContext.Setup(hc => hc.Request.RouteValues).Returns(routeValues);
+
+                // - permission repository
+                var permissions = new PermissionRepository(dbContext);
+
+                var req = new UserOrganizationAccessRequirement();
+                var res = req.Evaluate(userClaim, httpContext.Object, permissions);
+
+                // Then it should evaluate to False
+                Assert.False(res);
+            }
+        }
+    }
+}

--- a/test/HedwigTests/Security_NEW/Requirements/UserSiteAccessRequirementTests.cs
+++ b/test/HedwigTests/Security_NEW/Requirements/UserSiteAccessRequirementTests.cs
@@ -1,0 +1,117 @@
+using Xunit;
+using Moq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System.Security.Claims;
+using System.Collections.Generic;
+using Hedwig.Repositories;
+using Hedwig.Models;
+using Hedwig.Security_NEW;
+using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+
+namespace HedwigTests.Security_NEW
+{
+    public class UserSiteAccessRequirementTests
+    {
+        [Fact]
+        public void Site_Controller_User_Has_Site_Access_Evaluate_Returns_True()
+        {
+            using (var dbContext = new TestContextProvider().Context) {
+                // If user exists with access to site
+                var user = UserHelper.CreateUser(dbContext);
+                var site = SiteHelper.CreateSite(dbContext);
+                PermissionHelper.CreateSitePermission(dbContext, user, site);
+
+                // When requirement is evaluated with:
+                // - claim for that user
+                var claim = new Claim("sub", $"{user.Id}");
+                var userClaim = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {claim}));
+
+                // - httpContext for request to 'Sites' controller for that site
+                var httpContext = new Mock<HttpContext>();
+                var routeValues = new RouteValueDictionary(new Dictionary<string, string>{
+                    {"controller", "Sites"},
+                    {"id", $"{site.Id}"}
+                });
+                httpContext.Setup(hc => hc.Features.Get<IRoutingFeature>()).Returns(new Mock<IRoutingFeature>().Object);
+                httpContext.Setup(hc => hc.Request.RouteValues).Returns(routeValues);
+
+                // - permission repository
+                var permissions = new PermissionRepository(dbContext);
+
+                var req = new UserSiteAccessRequirement();
+                var res = req.Evaluate(userClaim, httpContext.Object, permissions);
+
+                // Then it should evaluate to True
+                Assert.True(res);
+            }
+        }
+        [Fact]
+        public void Other_Controller_User_Has_Site_Access_Evaluate_Returns_True()
+        {
+            using (var dbContext = new TestContextProvider().Context) {
+                // If user exists with access to site
+                var user = UserHelper.CreateUser(dbContext);
+                var site = SiteHelper.CreateSite(dbContext);
+                PermissionHelper.CreateSitePermission(dbContext, user, site);
+
+                // When requirement is evaluated with:
+                // - claim for that user
+                var claim = new Claim("sub", $"{user.Id}");
+                var userClaim = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {claim}));
+
+                // - httpContext for request to other controller nested under that site
+                var httpContext = new Mock<HttpContext>();
+                var routeValues = new RouteValueDictionary(new Dictionary<string, string>{
+                    {"controller", "Other"},
+                    {"siteId", $"{site.Id}"}
+                });
+                httpContext.Setup(hc => hc.Features.Get<IRoutingFeature>()).Returns(new Mock<IRoutingFeature>().Object);
+                httpContext.Setup(hc => hc.Request.RouteValues).Returns(routeValues);
+
+                // - permission repository
+                var permissions = new PermissionRepository(dbContext);
+
+                var req = new UserSiteAccessRequirement();
+                var res = req.Evaluate(userClaim, httpContext.Object, permissions);
+
+                // Then it should evaluate to True
+                Assert.True(res);
+            }
+        }
+
+        [Fact]
+        public void User_Does_Not_Have_Site_Access_Evaluate_Returns_False()
+        {
+            using (var dbContext = new TestContextProvider().Context) {
+                // If user exists with out access to any site
+                var user = UserHelper.CreateUser(dbContext);
+
+                // When requirement is evaluated with:
+                // - claim for that user
+                var claim = new Claim("sub", $"{user.Id}");
+                var userClaim = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {claim}));
+
+                // - httpContext for request to 'Sites' controller for any site
+                var httpContext = new Mock<HttpContext>();
+                var routeValues = new RouteValueDictionary(new Dictionary<string, string>{
+                    {"controller", "Site"},
+                    {"id", "1"}
+                });
+                httpContext.Setup(hc => hc.Features.Get<IRoutingFeature>()).Returns(new Mock<IRoutingFeature>().Object);
+                httpContext.Setup(hc => hc.Request.RouteValues).Returns(routeValues);
+
+                // - permission repository
+                var permissions = new PermissionRepository(dbContext);
+
+                var req = new UserSiteAccessRequirement();
+                var res = req.Evaluate(userClaim, httpContext.Object, permissions);
+
+                // Then it should evaluate to False
+                Assert.False(res);
+            }
+        }
+
+    }
+}

--- a/test/HedwigTests/Security_NEW/RequirementsHandlerTests.cs
+++ b/test/HedwigTests/Security_NEW/RequirementsHandlerTests.cs
@@ -1,0 +1,66 @@
+using Xunit;
+using Moq;
+using System.Security.Claims;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
+using Hedwig.Repositories;
+using Hedwig.Security_NEW;
+
+namespace HedwigTests.Security_NEW
+{
+    public class RequirementsHandlerTests
+    {
+        [Fact]
+        public void When_IPermissionRequirement_Evaluates_True_Succeeds()
+        {
+            // If requirement handler exists
+            var user = new Mock<ClaimsPrincipal>();
+            var httpContext = new Mock<HttpContext>();
+            var permissions = new Mock<IPermissionRepository>();
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(hca => hca.HttpContext)
+                .Returns(httpContext.Object);
+
+            var reqHandler = new RequirementsHandler(httpContextAccessor.Object, permissions.Object);
+
+            // and authorization context exists with permission requirement that evaluates to true
+            var req = new Mock<IPermissionRequirement>();
+            req.Setup(r => r.Evaluate(user.Object, httpContext.Object, permissions.Object))
+                .Returns(true);
+            var authContext = new AuthorizationHandlerContext(new List<IAuthorizationRequirement> { req.Object }, user.Object, new object());
+
+            // When requirement handler handles authorization context
+            reqHandler.HandleAsync(authContext);
+
+            // Then authorization context will have succeeded
+            Assert.True(authContext.HasSucceeded);
+        }
+
+        [Fact]
+        public void When_IPermissionRequirement_Evaluates_False_Does_Not_Succeed()
+        {
+            // If requirement handler exists
+            var user = new Mock<ClaimsPrincipal>();
+            var httpContext = new Mock<HttpContext>();
+            var permissions = new Mock<IPermissionRepository>();
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(hca => hca.HttpContext)
+                .Returns(httpContext.Object);
+
+            var reqHandler = new RequirementsHandler(httpContextAccessor.Object, permissions.Object);
+
+            // and authorization context exists with permission requirement that evaluates to false
+            var req = new Mock<IPermissionRequirement>();
+            req.Setup(r => r.Evaluate(user.Object, httpContext.Object, permissions.Object))
+                .Returns(false);
+            var authContext = new AuthorizationHandlerContext(new List<IAuthorizationRequirement> { req.Object }, user.Object, new object());
+
+            // When requirement handler handles authorization context
+            reqHandler.HandleAsync(authContext);
+
+            // Then authorization context will not have succeeded
+            Assert.False(authContext.HasSucceeded);
+        }
+    }
+}


### PR DESCRIPTION
- Implements simple authorization requirements to enforce user access to an organization or a site; see: `Security_NEW/UserSiteAccessRequirement.cs` and `Security_New/UserOrganizationAccessRequirement.cs`
- Adds each custom requirement to an authorization policy; see: `ServiceExtensions.cs` and `Startup.cs`
- Adds a multi-policy AuthorizationHandler, called `PermissionHandler` for now copied from a microsoft example, but maybe confusing since nothing else is called "permissions"; see: `Secutiry_NEW/PermissionHandler.cs`

note: this does not explicitly add an authenticated user requirement. the requirement is implicit in the other requirements. this may not be the best design.

TODO: actually implement the PermissionRepository code for user/site and user/organization logic

closes #232 