### PR TITLE
(WingedKeys) Add database in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,11 +47,17 @@ services:
     entrypoint:
       - sh
       - /entrypoint.sh
+  winged-keys-db:
+    image: mcr.microsoft.com/mssql/server
+    environment:
+      SA_PASSWORD: TestPassword1
+      ACCEPT_EULA: Y
   winged-keys:
     build:
         context: .
         dockerfile: ./winged-keys/Dockerfile
     environment:
+      SQLCONNSTR_WINGEDKEYS: Server=winged-keys-db;Database=master;User=sa;Password=TestPassword1
       ASPNETCORE_ENVIRONMENT: Development
     volumes:
       - ./winged-keys/src/WingedKeys:/app/src/WingedKeys:cached


### PR DESCRIPTION
This is a dependency of ctoec/winged-keys#11. Adds the database to the docker compose project.