### PR TITLE
Make childArgsAreValid return true

### DIFF
--- a/src/Hedwig/ClientApp/src/utils/models/child.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/child.ts
@@ -54,4 +54,5 @@ export function birthCertPresent(child: Child) {
 export function childArgsAreValid(args: any) {
   // required fields
   if (!args.firstName || !args.lastName) return false;
+  return true;
 }


### PR DESCRIPTION
`childArgsAreValid` never returns true -- only false and undefined, so we can never save