### PR TITLE
Add ability for selecting CDC funding / private pay during enrollment

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.tsx
@@ -65,7 +65,7 @@ export default function EnrollmentNew({
 		id: enrollmentId ? enrollmentId : 0,
 		orgId: getIdForUser(user, 'org'),
 		siteId: getIdForUser(user, 'site'),
-		include: ['child', 'family', 'determinations', 'fundings'],
+		include: ['child', 'family', 'determinations', 'fundings', 'sites'],
 	};
 	const [loading, error, enrollment, mutate] = useApi<Enrollment>(
 		api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet(params),

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { Section } from '../enrollmentTypes';
 import Button from '../../../components/Button/Button';
 import DatePicker from '../../../components/DatePicker/DatePicker';
@@ -7,12 +7,16 @@ import RadioGroup from '../../../components/RadioGroup/RadioGroup';
 import dateFormatter from '../../../utils/dateFormatter';
 import moment from 'moment';
 import idx from 'idx';
-import { ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest, Age, Enrollment } from '../../../generated';
+import { ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest, Age, FundingTime, Funding, FundingSource, ReportingPeriod } from '../../../generated';
 import UserContext from '../../../contexts/User/UserContext';
 import { ageFromString, prettyAge } from '../../../utils/ageGroupUtils';
 import getIdForUser from '../../../utils/getIdForUser';
-import Alert from '../../../components/Alert/Alert';
+import { DeepNonUndefineable } from '../../../utils/types';
 import { sectionHasValidationErrors } from '../../../utils/validations';
+import { prettyFundingTime, fundingTimeFromString } from '../../../utils/fundingTimeUtils';
+import { nextNReportingPeriods } from '../../../utils/models/reportingPeriod';
+import ReportingPeriodContext from '../../../contexts/ReportingPeriod/ReportingPeriodContext';
+import { currentFunding } from '../../../utils/models';
 
 const EnrollmentFunding: Section = {
   key: 'enrollment-funding',
@@ -20,95 +24,180 @@ const EnrollmentFunding: Section = {
   status: ({ enrollment }) => enrollment && sectionHasValidationErrors([enrollment, enrollment.fundings]) ? 'incomplete' : 'complete',
 
   Summary: ({ enrollment }) => {
-    if (!enrollment) return <></>;
-    return (
-      <div className="EnrollmentFundingSummary">
-        {enrollment && (
-          <>
-            <p>Site: {idx(enrollment, _ => _.site.name)} </p>
-            <p>
-              Enrolled:{' '}
-              {dateFormatter(idx(enrollment, _ => _.entry)) +
-                '–' +
-                dateFormatter(idx(enrollment, _ => _.exit))}
-            </p>
-            <p>Age: {prettyAge(idx(enrollment, _ => _.ageGroup) || null)}</p>
-          </>
-        )}
-      </div>
-    );
+		const { cdcReportingPeriods: reportingPeriods } = useContext(ReportingPeriodContext);
+
+		if (!enrollment) return <></>;
+
+		const cdcFundings = (enrollment.fundings || []).filter<DeepNonUndefineable<Funding>>(
+			(funding => funding.source === FundingSource.CDC)
+		).sort((a,b) => {
+			if (a.firstReportingPeriod.periodStart === b.firstReportingPeriod.periodStart) {
+				return 0;
+			} else if (a.firstReportingPeriod.periodStart < b.firstReportingPeriod.periodStart) {
+				return -1;
+			} else {
+				return 1;
+			}
+		});
+		const cdcFunding = cdcFundings.length > 0 ? cdcFundings[0] : undefined;
+		const isPrivatePay = cdcFunding === undefined;
+
+		const fundingFirstReportingPeriod = reportingPeriods.find<DeepNonUndefineable<ReportingPeriod>>(period => cdcFunding ? cdcFunding.firstReportingPeriodId == period.id : false);
+		return (
+			<div className="EnrollmentFundingSummary">
+				{enrollment && (
+					<>
+						<p>Site: {idx(enrollment, _ => _.site.name)} </p>
+						<p>Age Group: {prettyAge(idx(enrollment, _ => _.ageGroup) || null)}</p>
+						<p>
+							Enrollement date:{' '}
+							{dateFormatter(idx(enrollment, _ => _.entry))}
+						</p>
+						<p>Funding:{' '}
+							{isPrivatePay ?
+								'Private pay' :
+								`CDC - ${prettyFundingTime((cdcFunding as Funding).time)}` // cdcFunding will always be defined by Typescript does not infer so
+							}
+						</p>
+						{!isPrivatePay &&
+							<p>First reporting period:{' '}
+								{dateFormatter((fundingFirstReportingPeriod as ReportingPeriod).period)} {/*cdcFunding will always be defined by Typescript does not infer so*/}
+							</p>
+						}
+					</>
+				)}
+			</div>
+		);
   },
 
   Form: ({ enrollment, mutate, callback }) => {
     if (!enrollment) {
-      throw new Error('EnrollmentFunding rendered without an enrollment');
-    }
+			throw new Error('EnrollmentFunding rendered without an enrollment');
+		}
 
-    const { user } = useContext(UserContext);
-    const defaultParams: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest = {
-      id: enrollment.id || 0,
-      orgId: getIdForUser(user, "org"),
-      siteId: getIdForUser(user, "site"),
-      enrollment: enrollment
-    }
+		const { user } = useContext(UserContext);
+		const { cdcReportingPeriods: reportingPeriods } = useContext(ReportingPeriodContext);
 
-    const [siteId, updateSiteId] = React.useState(idx(enrollment, _ => _.siteId));
+		const defaultParams: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest = {
+			id: enrollment.id || 0,
+			orgId: getIdForUser(user, "org"),
+			siteId: getIdForUser(user, "site"),
+			enrollment: enrollment
+		}
 
-    const [entry, updateEntry] = React.useState(enrollment ? enrollment.entry : null);
-    const [age, updateAge] = React.useState(enrollment ? enrollment.ageGroup : null);
+		const [siteId, updateSiteId] = useState(idx(enrollment, _ => _.siteId));
 
-    const familyDeterminationNotDisclosed = (enrollment: Enrollment) : boolean => {
-      let determinations = idx(enrollment, _ => _.child.family.determinations)
-  
-      // If no determinations are present, not disclosed = false
-      // (because it is not explicitly true)
-      if (!determinations || determinations.length === 0) return false;
-      determinations = determinations.sort((a, b) => {
-        if (a.determinationDate > b.determinationDate) return 1;
-        if (a.determinationDate < b.determinationDate) return -1;
-        return 0;
-      });
+		const [entry, updateEntry] = useState(enrollment ? enrollment.entry : null);
+		const [age, updateAge] = useState(enrollment ? enrollment.ageGroup : null);
 
-      return determinations[0].notDisclosed;
-    };
-    
-    const save = () => {
+		const fundings = enrollment.fundings ? enrollment.fundings : [] as DeepNonUndefineable<Funding[]>;
+		const cdcFundings = fundings.filter(funding => funding.source === FundingSource.CDC);
+		const cdcFunding = currentFunding(cdcFundings);
+		const [cdcFundingId] = useState<number | null>(cdcFunding ? cdcFunding.id : null);
+		const [cdcFundingTime, updateCdcFundingTime] = useState<FundingTime | null>(cdcFunding ? cdcFunding.time : null);
+		const [privatePay, updatePrivatePay] = useState<boolean>(cdcFundings.length === 0);
+
+		const [cdcReportingPeriod, updateCdcReportingPeriod] = useState<ReportingPeriod | null>(null);
+
+		const [reportingPeriodOptions, updateReportingPeriodOptions] = useState<ReportingPeriod[]>([]);
+
+		useEffect(() => {
+			if (reportingPeriods) {
+				const _cdcReporingPeriod = cdcFunding ?
+					reportingPeriods.find<DeepNonUndefineable<ReportingPeriod>>(
+						period => period.id === cdcFunding.firstReportingPeriodId
+					) :
+					null;
+				updateCdcReportingPeriod(_cdcReporingPeriod ? _cdcReporingPeriod : null);
+			}
+		}, [reportingPeriods, cdcFunding]);
+
+		useEffect(() => {
+			const startDate = entry ? entry : enrollment.entry ? enrollment.entry : new Date();
+			updateReportingPeriodOptions(nextNReportingPeriods(reportingPeriods, startDate, 3));
+		}, [enrollment.entry, entry, reportingPeriods])
+
+		const save = () => {
+			const currentCdcFunding = fundings.find<DeepNonUndefineable<Funding>>(
+				(funding => funding.id === cdcFundingId) as (_: DeepNonUndefineable<Funding>) => _ is DeepNonUndefineable<Funding>
+			);
+
+			let updatedFundings: Funding[];
+			if (cdcFundingId && privatePay) {
+				// Current funding exists, remove it because it has been switched to private pay
+				// TODO: Consider whether this should instead set the exit date on funding to today
+				updatedFundings = [
+					...(fundings.filter<DeepNonUndefineable<Funding>>(funding => funding.id !== cdcFundingId))
+				]
+			} else if (cdcFundingId && !privatePay) {
+				// Current funding exists, update it with supplied information
+				const newCdcFunding: Funding = {
+					...(currentCdcFunding as Funding), // currentCdcFunding will always be defined but typescript doesn't infer so
+					time: cdcFundingTime ? cdcFundingTime : undefined,
+					firstReportingPeriodId: (cdcReportingPeriod as ReportingPeriod).id // cdcReporingPeriod will always be defined but typescript doesn't infer so
+				};
+				updatedFundings = [
+					...(fundings.filter<DeepNonUndefineable<Funding>>(funding => funding.id !== cdcFundingId)),
+					newCdcFunding
+				]
+			} else if (!cdcFundingId && privatePay) {
+				// No current funding, do nothing because private pay has been selected
+				updatedFundings = [...fundings];
+			} else /* !cdcFunding && !privatePay */ { 
+				// No current funding, add new funding with supplied information
+				const newCdcFunding: Funding = {
+					id: 0,
+					enrollmentId: enrollment.id,
+					source: FundingSource.CDC,
+					time: cdcFundingTime ? cdcFundingTime : undefined,
+					firstReportingPeriodId: (cdcReportingPeriod as ReportingPeriod).id // cdcReporingPeriod will always be defined but typescript doesn't infer so
+				}
+				updatedFundings = [
+					...fundings,
+					newCdcFunding
+				]
+			}
+
       const args = {
         entry: entry,
-        age: age
+        ageGroup: age || undefined,
+				fundings: updatedFundings
       };
 
-      if (enrollment) {
-        const params: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest = {
-          ...defaultParams,
-          enrollment: {
-            ...enrollment,
-            ...args
-          }
-        }
-        mutate((api) => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
-          .then((res) => {
-            if (callback && res) callback(res);
-          });
-      }
-    };
+			if (enrollment) {
+				const params: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest = {
+					...defaultParams,
+					enrollment: {
+						...enrollment,
+						...args
+					}
+				}
+				mutate((api) => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
+					.then((res) => {
+						if (callback && res) callback(res);
+					});
+			}
+		};
 
-    return (
-      <div className="EnrollmentFundingForm">
-        <div className="usa-form">
-          <Dropdown
-            options={
-              idx(user, _ => _.orgPermissions[0].organization.sites.map(s => ({
-                value: `${s.id}`,
-                text: s.name
-              })))
-              || []
-            }
-            label="Site"
-            selected={siteId ? '' + siteId : undefined}
-            onChange={event => updateSiteId(parseInt(event.target.value, 10))}
-            id="enrollment-site"
-          />
+		return (
+			<div className="EnrollmentFundingForm">
+				<div className="usa-form">
+					<Dropdown
+						id="site"
+						options={
+							idx(user, _ => _.orgPermissions[0].organization.sites.map(s => ({
+								value: `${s.id}`,
+								text: s.name
+							})))
+							|| []
+						}
+						label="Site"
+						selected={siteId ? '' + siteId : undefined}
+						onChange={event => updateSiteId(parseInt(event.target.value, 10))}
+					/>
+					<label className="usa-label" htmlFor="date">
+						Start date
+					</label>
 					<DatePicker
 						onChange={range =>
 							updateEntry((range.startDate && range.startDate.toDate()) || null)
@@ -119,56 +208,105 @@ const EnrollmentFunding: Section = {
 					/>
 
 					<h3>Age group</h3>
-  				<RadioGroup
-            legend="Age"
-  					id="age"
-  					options={[
-  						{
-  							text: 'Infant/Toddler',
-                 value: Age.InfantToddler,
-  						},
-  						{
-  							text: 'Preschool',
-  							value: Age.Preschool,
-  						},
-  						{
-  							text: 'School-age',
-  							value: Age.SchoolAge,
-  						},
-  					]}
-  					selected={'' + age}
-  					onChange={event => updateAge(ageFromString(event.target.value))}
-  				/>
-
-          {!familyDeterminationNotDisclosed(enrollment) &&
-            <>
-            <h3>Funding</h3>
- 				    <ul className="oec-action-list">
- 				  	  <li>
- 				  		  <Button appearance="unstyled" text="Assign to a Child Day Care space" />
- 				  		  &nbsp; (1 available starting December 2019)
- 				  	  </li>
-              <li>
-                <Button appearance="unstyled" text="Add Care 4 Kids subsidy" />
-              </li>
-            </ul>
-            </>
-          } 
+					<RadioGroup
+						legend="Age"
+						id="age"
+						options={[
+							{
+								text: 'Infant/Toddler',
+								value: Age.InfantToddler,
+							},
+							{
+								text: 'Preschool',
+								value: Age.Preschool,
+							},
+							{
+								text: 'School-age',
+								value: Age.SchoolAge,
+							},
+						]}
+						selected={'' + age}
+						onChange={event => 
+							updateAge(ageFromString(event.target.value))
+						}
+					/>
+					<h2>Funding</h2>
+					<Dropdown
+						id="fundingType"
+						options={
+							[
+								{
+									value: '',
+									text: '- Select -'
+								},
+								...Object.values(FundingTime).map(fundingTime => {
+									return {
+										value: fundingTime,
+										text: `CDC - ${prettyFundingTime(fundingTime)}`
+									}
+								}),
+								{
+									value: 'privatePay',
+									text: 'Private pay'
+								}
+							]
+						}
+						label="Funding type"
+						onChange={event => {
+							if (event.target.value === 'privatePay') {
+								updatePrivatePay(true);
+								updateCdcFundingTime(null);
+							} else if (event.target.value === '') {
+								updatePrivatePay(false);
+								updateCdcFundingTime(null);
+							} else {
+								updatePrivatePay(false);
+								updateCdcFundingTime(fundingTimeFromString(event.target.value))
+							}
+						}}
+						selected={
+							privatePay ?
+							'privatePay' :
+							cdcFundingTime !== null ?
+								cdcFundingTime :
+								''
+						}
+					/>
+					{(!privatePay && cdcFundingTime) && (
+						<Dropdown
+							id="firstReportingPeriod"
+							options={
+								[
+									...(reportingPeriodOptions.map(period => {
+										return {
+											value: '' + period.id,
+											text: `${period.periodStart.toLocaleDateString()} - ${period.periodEnd.toLocaleDateString()}`
+										}
+									}))
+								]
+							}
+							label="First reporting period"
+							onChange={event => {
+								const chosen = reportingPeriodOptions.find(period => period.id === parseInt(event.target.value));
+								updateCdcReportingPeriod(chosen || reportingPeriodOptions[0]);
+							}}
+							selected={
+								cdcReportingPeriod ?
+								'' + cdcReportingPeriod.id :
+									reportingPeriodOptions[0] ?
+										'' + reportingPeriodOptions[0].id :
+										''
+							}
+						/>
+					)}
 				</div>
 
-        {familyDeterminationNotDisclosed(enrollment) &&
-          <Alert 
-            type="info"
-            text="Funding options not available because family income was not provided. To change, edit the previous section."
-          />
-        }
-        
-        <div className="usa-form">
-          <Button text="Save" onClick={save} />
-        </div>
-      </div>
-    );
-  },
+				<div className="usa-form">
+					<Button text="Save" onClick={save} />
+				</div>
+			</div>
+		);
+	},
 };
 
 export default EnrollmentFunding;

--- a/src/Hedwig/ClientApp/src/containers/Roster/AgeGroupSection.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/AgeGroupSection.tsx
@@ -22,10 +22,10 @@ type AgeGroupSectionProps = {
 	fundingSpaces?: FundingSpace[];
 };
 
-function generateFundingTag(funding: DeepNonUndefineable<Funding>): JSX.Element {
+function generateFundingTag(funding: DeepNonUndefineable<Funding>, index: number): JSX.Element {
 	return (
 		<Tag
-			key={`${funding.source}-${funding.time}`}
+			key={`${funding.source}-${funding.time}-${index}`}
 			text={funding.source ? fundingSourceDetails[funding.source].tagFormatter(funding) : ''}
 			color={funding.source ? getColorForFundingSource(funding.source) : 'gray-90'}
 		/>
@@ -67,8 +67,8 @@ const defaultRosterTableProps: TableProps<DeepNonUndefineable<Enrollment>> = {
 			cell: ({ row }) => (
 				<td>
 					{row.fundings && row.fundings.length > 0 ?
-						row.fundings.map<React.ReactNode>((funding: DeepNonUndefineable<Funding>) =>
-							generateFundingTag(funding)
+						row.fundings.map<React.ReactNode>((funding: DeepNonUndefineable<Funding>, index: number) =>
+							generateFundingTag(funding, index)
 						) :
 						<span className="text-italic text-base">Private pay</span>
 					}

--- a/src/Hedwig/ClientApp/src/contexts/ReportingPeriod/ReportingPeriodContext.tsx
+++ b/src/Hedwig/ClientApp/src/contexts/ReportingPeriod/ReportingPeriodContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext } from 'react';
+import { DeepNonUndefineable } from '../../utils/types';
+import { ReportingPeriod, ApiReportingPeriodSourceGetRequest, FundingSource } from '../../generated';
+import useApi from '../../hooks/useApi';
+
+export type ReportingPeriodContextType = { 
+	cdcReportingPeriods: DeepNonUndefineable<ReportingPeriod[]>
+};
+
+const ReportingPeriodContext = createContext<ReportingPeriodContextType>({
+	cdcReportingPeriods: []
+});
+
+const { Provider, Consumer } = ReportingPeriodContext;
+
+
+const ReportingPeriodProvider: React.FC<{}> = ({
+	 children
+}) => {
+	const cdcReportingPeriodParams: ApiReportingPeriodSourceGetRequest = {
+		source: FundingSource.CDC
+	};
+
+	const [, , cdcReportingPeriods] = useApi<ReportingPeriod[]>(
+		(api) => api.apiReportingPeriodSourceGet(cdcReportingPeriodParams)
+	);
+	
+	return (
+		<Provider
+			value={{
+				cdcReportingPeriods
+			}}
+		>
+			{children}
+		</Provider>
+	)
+};
+
+export { ReportingPeriodProvider };
+export { Consumer as ReportingPeriodConsumer };
+export default ReportingPeriodContext;

--- a/src/Hedwig/ClientApp/src/generated/apis/HedwigApi.ts
+++ b/src/Hedwig/ClientApp/src/generated/apis/HedwigApi.ts
@@ -21,12 +21,18 @@ import {
     Enrollment,
     EnrollmentFromJSON,
     EnrollmentToJSON,
+    FundingSource,
+    FundingSourceFromJSON,
+    FundingSourceToJSON,
     Organization,
     OrganizationFromJSON,
     OrganizationToJSON,
     ProblemDetails,
     ProblemDetailsFromJSON,
     ProblemDetailsToJSON,
+    ReportingPeriod,
+    ReportingPeriodFromJSON,
+    ReportingPeriodToJSON,
     Site,
     SiteFromJSON,
     SiteToJSON,
@@ -92,6 +98,10 @@ export interface ApiOrganizationsOrgIdSitesSiteIdEnrollmentsPostRequest {
     orgId: number;
     siteId: number;
     enrollment?: Enrollment;
+}
+
+export interface ApiReportingPeriodSourceGetRequest {
+    source: FundingSource;
 }
 
 /**
@@ -489,6 +499,38 @@ export class HedwigApi extends runtime.BaseAPI {
      */
     async apiOrganizationsOrgIdSitesSiteIdEnrollmentsPost(requestParameters: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsPostRequest): Promise<Enrollment> {
         const response = await this.apiOrganizationsOrgIdSitesSiteIdEnrollmentsPostRaw(requestParameters);
+        return await response.value();
+    }
+
+    /**
+     */
+    async apiReportingPeriodSourceGetRaw(requestParameters: ApiReportingPeriodSourceGetRequest): Promise<runtime.ApiResponse<Array<ReportingPeriod>>> {
+        if (requestParameters.source === null || requestParameters.source === undefined) {
+            throw new runtime.RequiredError('source','Required parameter requestParameters.source was null or undefined when calling apiReportingPeriodSourceGet.');
+        }
+
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["Authorization"] = this.configuration.apiKey("Authorization"); // Bearer authentication
+        }
+
+        const response = await this.request({
+            path: `/api/ReportingPeriod/{source}`.replace(`{${"source"}}`, encodeURIComponent(String(requestParameters.source))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        });
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(ReportingPeriodFromJSON));
+    }
+
+    /**
+     */
+    async apiReportingPeriodSourceGet(requestParameters: ApiReportingPeriodSourceGetRequest): Promise<Array<ReportingPeriod>> {
+        const response = await this.apiReportingPeriodSourceGetRaw(requestParameters);
         return await response.value();
     }
 

--- a/src/Hedwig/ClientApp/src/index.tsx
+++ b/src/Hedwig/ClientApp/src/index.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter } from 'react-router-dom';
 import * as serviceWorker from './serviceWorker';
 import { AuthenticationProvider } from './contexts/Authentication/AuthenticationContext';
 import { UserProvider } from './contexts/User/UserContext';
+import { ReportingPeriodProvider } from './contexts/ReportingPeriod/ReportingPeriodContext';
 
 const render = (Component: React.FC) => {
 	return ReactDOM.render(
@@ -22,7 +23,9 @@ const render = (Component: React.FC) => {
 				}}
 			>
 				<UserProvider>
-					<Component />
+					<ReportingPeriodProvider>
+						<Component />
+					</ReportingPeriodProvider>
 				</UserProvider>
 			</AuthenticationProvider>
 		</BrowserRouter>,

--- a/src/Hedwig/ClientApp/src/utils/fundingTimeUtils.ts
+++ b/src/Hedwig/ClientApp/src/utils/fundingTimeUtils.ts
@@ -1,5 +1,16 @@
 import { FundingTime } from "../generated";
 
+export function fundingTimeFromString(str: string) {
+  switch (str) {
+    case FundingTime.Full:
+      return FundingTime.Full;
+    case FundingTime.Part:
+      return FundingTime.Part;
+    default:
+      return null;
+  }
+};
+
 export function prettyFundingTime(time: FundingTime | null | undefined) {
   switch (time) {
     case FundingTime.Full:

--- a/src/Hedwig/ClientApp/src/utils/models/familyDetermination.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/familyDetermination.ts
@@ -1,0 +1,17 @@
+import idx from 'idx';
+import { Enrollment } from '../../generated';
+
+export const familyDeterminationNotDisclosed = (enrollment: Enrollment) : boolean => {
+	let determinations = idx(enrollment, _ => _.child.family.determinations)
+
+	// If no determinations are present, not disclosed = false
+	// (because it is not explicitly true)
+	if (!determinations || determinations.length == 0) return false;
+	determinations = determinations.sort((a, b) => {
+		if (a.determinationDate > b.determinationDate) return 1;
+		if (a.determinationDate < b.determinationDate) return -1;
+		return 0;
+	});
+
+	return determinations[0].notDisclosed;
+};

--- a/src/Hedwig/ClientApp/src/utils/models/funding.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/funding.ts
@@ -1,0 +1,6 @@
+import { Funding } from '../../generated';
+import { DeepNonUndefineable } from '../types';
+
+export const currentFunding = (fundings: DeepNonUndefineable<Funding[]>): DeepNonUndefineable<Funding> | undefined => {
+	return fundings.find<DeepNonUndefineable<Funding>>(funding => funding.lastReportingPeriodId === undefined);
+}

--- a/src/Hedwig/ClientApp/src/utils/models/index.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/index.ts
@@ -2,3 +2,4 @@ export * from './gender';
 export * from './child';
 export * from './family';
 export * from './determination';
+export * from './funding';

--- a/src/Hedwig/ClientApp/src/utils/models/reportingPeriod.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/reportingPeriod.ts
@@ -1,0 +1,70 @@
+import { ReportingPeriod, Funding, Enrollment } from '../../generated';
+import idx from 'idx';
+
+export const currentReportingPeriod = (periods: ReportingPeriod[]): ReportingPeriod | undefined => {
+	const now = new Date(Date.now());
+	const currentYear = now.getFullYear();
+	const currentMonth = now.getMonth();
+	const startOfMonthDate = new Date(currentYear, currentMonth);
+	// Assumes that ReportingPeriod.Period will always be on the first day of the month
+	return periods.find(period => period.period.getTime() === startOfMonthDate.getTime());
+}
+
+/**
+ * Sorts reporting periods by period start date.
+ * @param a Reporting Period
+ * @param b Reporting Period
+ */
+const periodSorter = (a: ReportingPeriod, b: ReportingPeriod) => {
+	if (a.periodStart === b.periodStart) return 0;
+	if (a.periodStart < b.periodStart) return -1;
+	return 1;
+}
+
+/**
+ * Function to determine the first eligible reporting period for a given enrollment start date/entry.
+ * @param periods The array of reporting periods provided by ReportingPeriodContext
+ * @param startDate The enrollment start date (aka entry)
+ */
+export const firstEligibleReportingPeriod = (periods: ReportingPeriod[], startDate: Date): ReportingPeriod | undefined => {
+	const filteredPeriods = [...periods].filter(period => startDate <= period.periodEnd);
+	const sortedPeriods = filteredPeriods.sort(periodSorter);
+	return sortedPeriods[0];
+}
+
+/**
+ * Function to determine whether the given funding is compatible with the given reporting period.
+ * @param funding Funding to check whether it is compatible with the given reporting period.
+ * @param period Reporting period to check whether the given funding is compatible.
+ */
+export const fundingWithinReportingPeriod = (funding: Funding, period: ReportingPeriod): boolean => {
+	const fundingPeriodStart = idx(funding, _ => _.firstReportingPeriod.periodStart);
+	const fundingPeriodEnd = idx(funding, _ => _.lastReportingPeriod.periodEnd);
+	const start = period.periodStart;
+	const end = period.periodEnd;
+
+	if (!fundingPeriodStart && !fundingPeriodEnd) {
+		return false;
+	} else if (!fundingPeriodEnd) {
+		return (fundingPeriodStart as Date) < end;
+	} else {
+		return start < fundingPeriodEnd;
+	}
+}
+
+/**
+ * Function to return array of first N reporting periods sorted by date such that all are eligible reporting periods for the given start date.
+ * @param periods The array of reporting periods provided by ReportingPeriodContext
+ * @param startDate The enrollment start date (aka entry)
+ * @param n The number of reporting periods to return
+ */
+export const nextNReportingPeriods = (periods: ReportingPeriod[], startDate: Date, n: number): ReportingPeriod[] => {
+	const sortedPeriods = [...periods].sort(periodSorter);
+
+	const _firstEligibleReportingPeriod = firstEligibleReportingPeriod(periods, startDate);
+	if (!_firstEligibleReportingPeriod) {
+		throw new Error("First eligible reporting period cannot be found");
+	}
+	const index = sortedPeriods.findIndex(period => period.id === _firstEligibleReportingPeriod.id);
+	return sortedPeriods.slice(index, index + n);
+}

--- a/src/Hedwig/ClientApp/src/utils/models/reportingPeriod.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/reportingPeriod.ts
@@ -28,7 +28,7 @@ const periodSorter = (a: ReportingPeriod, b: ReportingPeriod) => {
  */
 export const firstEligibleReportingPeriod = (periods: ReportingPeriod[], startDate: Date): ReportingPeriod | undefined => {
 	const filteredPeriods = [...periods].filter(period => startDate <= period.periodEnd);
-	const sortedPeriods = filteredPeriods.sort(periodSorter);
+	const sortedPeriods = [...filteredPeriods].sort(periodSorter);
 	return sortedPeriods[0];
 }
 

--- a/src/Hedwig/ClientApp/src/utils/types.ts
+++ b/src/Hedwig/ClientApp/src/utils/types.ts
@@ -23,14 +23,20 @@ type DeepNonUndefineableObject<T extends object> =
 	// Add type for symbols
 	& AddSymbolToPrimitive<T>
 
-// Helper interface for handling arrays
-// Interface is required because defined types cannot use extend
-// class DeepNonUndefineableArray<T> extends Array<DeepNonUndefineable<T>> {
-// 	tsFilter<T>(filterFunc: (value: DeepNonUndefineable<T>) => boolean): DeepNonUndefineable<T>[] {
-// 		return this.filter<DeepNonUndefineable<T>>(filterFunc as ((_: DeepNonUndefineable<T>) => _ is DeepNonUndefineable<TemplateStringsArray>));
-// 	}
-// };
-interface DeepNonUndefineableArray<T> extends Array<DeepNonUndefineable<T>> {};
+// Class for handling arrays with overriden methods to handle typescript limitations
+export class DeepNonUndefineableArray<T> extends Array<DeepNonUndefineable<T>> {
+	constructor() {
+		super();
+	}
+
+	filter<S extends DeepNonUndefineable<T>>(callbackfn: (value: DeepNonUndefineable<T>, index: number, array: DeepNonUndefineable<T>[]) => boolean, thisArg?: any): DeepNonUndefineable<T[]> {
+		return super.filter<S>(((obj, i, arr) => callbackfn(obj, i, arr)) as (_: DeepNonUndefineable<T>, i: number, a: DeepNonUndefineable<T>[]) => _ is S);
+	}
+
+	find<S extends DeepNonUndefineable<T>>(predicate: (value: DeepNonUndefineable<T>, index: number, obj: DeepNonUndefineable<T>[]) => boolean, thisArg?: any): DeepNonUndefineable<T> | undefined {
+		return super.find<S>(((val, i, o) => predicate(val, i, o)) as (_: DeepNonUndefineable<T>, i: number, o: DeepNonUndefineable<T>[]) => _ is S);
+	}
+}
 
 // Helper type to make the return type of a funtion required
 type FunctionWithRequiredReturnType<

--- a/src/Hedwig/Controllers/ReportingPeriodController.cs
+++ b/src/Hedwig/Controllers/ReportingPeriodController.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Hedwig.Repositories;
+using Hedwig.Models;
+using System.Security.Claims;
+
+namespace Hedwig.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ReportingPeriodController : ControllerBase
+    {
+        private readonly IReportingPeriodRepository _periods;
+
+        public ReportingPeriodController(IReportingPeriodRepository periods)
+        {
+            _periods = periods;
+        }
+
+        // GET api/ReportingPeriod/CDC
+        [HttpGet("{source}")]
+        public async Task<ActionResult<List<ReportingPeriod>>> Get(
+            FundingSource source
+        )
+        {
+            return await _periods.GetReportingPeriodsByFundingSourceAsync(source);
+        }
+    }
+}

--- a/src/Hedwig/Data/DbInitializer.cs
+++ b/src/Hedwig/Data/DbInitializer.cs
@@ -36,8 +36,11 @@ namespace Hedwig.Data
       var reportingPeriods = new ReportingPeriod[] {
         CreateReportingPeriod(period: "2019-08-01", start: "2019-07-29", end: "2019-09-01", due: "2019-09-15"),
         CreateReportingPeriod(period: "2019-09-01", start: "2019-09-02", end: "2019-09-29", due: "2019-10-15"),
-        CreateReportingPeriod(period: "2019-10-01", start: "2019-09-30", end: "2019-10-29", due: "2019-11-15"),
-        CreateReportingPeriod(period: "2019-11-01", start: "2019-10-30", end: "2019-12-01", due: "2019-12-15")
+        CreateReportingPeriod(period: "2019-10-01", start: "2019-09-30", end: "2019-10-27", due: "2019-11-15"),
+        CreateReportingPeriod(period: "2019-11-01", start: "2019-10-28", end: "2019-11-29", due: "2019-12-15"),
+        CreateReportingPeriod(period: "2019-12-01", start: "2019-12-02", end: "2019-12-27", due: "2020-01-15"),
+        CreateReportingPeriod(period: "2020-01-01", start: "2019-12-30", end: "2020-01-31", due: "2020-02-15"),
+        CreateReportingPeriod(period: "2020-02-01", start: "2020-02-03", end: "2020-02-28", due: "2020-03-15")
       };
 
       CreateCdcReport(organizationId: organization.Id, reportingPeriodId: reportingPeriods[0].Id, submittedAt: "2019-09-09");

--- a/src/Hedwig/Models/Funding.cs
+++ b/src/Hedwig/Models/Funding.cs
@@ -27,7 +27,6 @@ namespace Hedwig.Models
     public DateTime? CertificateStartDate { get; set; }
     public DateTime? CertificateEndDate { get; set; }
 
-
     // CDC funding fields
     [RequiredForFundingSource(FundingSource.CDC)]
     public int? FirstReportingPeriodId {get; set; }

--- a/src/Hedwig/Repositories/EnrollmentRepository.cs
+++ b/src/Hedwig/Repositories/EnrollmentRepository.cs
@@ -41,8 +41,8 @@ namespace Hedwig.Repositories
 						_context.Fundings.Add(funding);
 					}
 				}
-				_context.Update(enrollment);
 			}
+      _context.Update(enrollment);
 		}
 
 		public void AddEnrollment(Enrollment enrollment)

--- a/src/Hedwig/Repositories/FundingRepository.cs
+++ b/src/Hedwig/Repositories/FundingRepository.cs
@@ -12,7 +12,6 @@ namespace Hedwig.Repositories
 	{
 
 		public FundingRepository(HedwigContext context) : base(context) {}
-
 	}
 
 	public interface IFundingRepository

--- a/src/Hedwig/Repositories/ReportRepository.cs
+++ b/src/Hedwig/Repositories/ReportRepository.cs
@@ -84,14 +84,14 @@ namespace Hedwig.Repositories
         var fundings = await (asOf.HasValue ? _context.Fundings.AsOf(asOf.Value) : _context.Fundings)
           .AsNoTracking()
           .Where(funding => enrollmentIds.Contains(funding.EnrollmentId))
-          .Where(funding => funding.CertificateStartDate <= reportResult.ReportingPeriod.PeriodStart)
-          .Where(funding => funding.CertificateEndDate == null || funding.CertificateEndDate >= reportResult.ReportingPeriod.PeriodEnd)
+          .Where(funding => funding.FirstReportingPeriod.PeriodStart <= reportResult.ReportingPeriod.PeriodStart)
+          .Where(funding => funding.LastReportingPeriod == null || funding.LastReportingPeriod.PeriodEnd >= reportResult.ReportingPeriod.PeriodEnd)
           .ToListAsync();
 
         // Add fundings to enrollments
         enrollments.ForEach(enrollment =>
         {
-          enrollment.Fundings = fundings.Where(funding => funding.EnrollmentId == enrollment.Id).ToList();
+          enrollment.Fundings = fundings.Where(funding => funding.EnrollmentId == enrollment.Id).ToList() as ICollection<Funding>;
         });
 
         // Filter for funded enrollments (only funded enrollments are included in report)

--- a/src/Hedwig/Repositories/ReportingPeriodRepository.cs
+++ b/src/Hedwig/Repositories/ReportingPeriodRepository.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Linq;
+using Hedwig.Models;
+using Hedwig.Data;
+
+namespace Hedwig.Repositories
+{
+	public class ReportingPeriodRepository : HedwigRepository, IReportingPeriodRepository
+	{
+		public ReportingPeriodRepository(HedwigContext context) : base(context) { }
+
+		public Task SaveChangesAsync()
+		{
+			return _context.SaveChangesAsync();
+		}
+
+		public async Task<List<ReportingPeriod>> GetReportingPeriodsByFundingSourceAsync(FundingSource source)
+		{
+			return await _context.ReportingPeriods
+				.Where(period => period.Type == source)
+				.ToListAsync();
+		}
+	}
+
+	public interface IReportingPeriodRepository
+	{
+		Task SaveChangesAsync();
+		Task<List<ReportingPeriod>> GetReportingPeriodsByFundingSourceAsync(FundingSource source);
+	}
+}

--- a/src/Hedwig/ServiceExtensions.cs
+++ b/src/Hedwig/ServiceExtensions.cs
@@ -50,6 +50,7 @@ namespace Hedwig
 			services.AddScoped<IFamilyRepository, FamilyRepository>();
 			services.AddScoped<IFundingRepository, FundingRepository>();
 			services.AddScoped<IOrganizationRepository, OrganizationRepository>();
+			services.AddScoped<IReportingPeriodRepository, ReportingPeriodRepository>();
 			services.AddScoped<IReportRepository, ReportRepository>();
 			services.AddScoped<ISiteRepository, SiteRepository>();
 			services.AddScoped<IUserRepository, UserRepository>();

--- a/test/HedwigTests/Helpers/FundingHelper.cs
+++ b/test/HedwigTests/Helpers/FundingHelper.cs
@@ -11,8 +11,8 @@ namespace HedwigTests.Helpers
 			FundingSource source = FundingSource.CDC,
 			FundingTime time = FundingTime.Full,
 			Enrollment enrollment = null,
-      string entry = "2000-01-01",
-			string exit = null
+			ReportingPeriod firstReportingPeriod = null,
+			ReportingPeriod lastReportingPeriod = null
 		)
 		{
 			enrollment = enrollment ?? EnrollmentHelper.CreateEnrollment(context);
@@ -22,10 +22,10 @@ namespace HedwigTests.Helpers
 				EnrollmentId = enrollment.Id,
 				Source = source,
 				Time = time,
-        CertificateStartDate = DateTime.Parse(entry)
+        FirstReportingPeriod = firstReportingPeriod
 			};
 
-			if (exit != null) funding.CertificateEndDate = DateTime.Parse(exit);
+			if (lastReportingPeriod != null) funding.LastReportingPeriod = lastReportingPeriod;
 
 			context.Fundings.Add(funding);
 			context.SaveChanges();

--- a/test/HedwigTests/Helpers/ReportHelper.cs
+++ b/test/HedwigTests/Helpers/ReportHelper.cs
@@ -15,7 +15,7 @@ namespace HedwigTests.Helpers
       string submittedAt = null
     )
     {
-      reportingPeriod = reportingPeriod ?? ReportingPeriodHelper.CreatePeriod(context, type: FundingSource.CDC);
+      reportingPeriod = reportingPeriod ?? ReportingPeriodHelper.CreateReportingPeriod(context, type: FundingSource.CDC);
       organization = organization ?? OrganizationHelper.CreateOrganization(context);
 
       var report = new CdcReport

--- a/test/HedwigTests/Helpers/ReportingPeriodHelper.cs
+++ b/test/HedwigTests/Helpers/ReportingPeriodHelper.cs
@@ -6,7 +6,7 @@ namespace HedwigTests.Helpers
 {
 	public class ReportingPeriodHelper
 	{
-		public static ReportingPeriod CreatePeriod(
+		public static ReportingPeriod CreateReportingPeriod(
 			HedwigContext context,
 			FundingSource type = FundingSource.CDC,
 			string period = "2019-10-01",

--- a/test/HedwigTests/Repositories/ReportRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/ReportRepositoryTests.cs
@@ -27,7 +27,8 @@ namespace HedwigTests.Repositories
         var report = ReportHelper.CreateCdcReport(context, organization: organization);
         var site = SiteHelper.CreateSite(context, organization: organization);
         var enrollment = EnrollmentHelper.CreateEnrollment(context, site: site, ageGroup: Age.Preschool);
-        var funding = FundingHelper.CreateFunding(context, enrollment: enrollment, time: FundingTime.Full);
+        var reportingPeriod = ReportingPeriodHelper.CreateReportingPeriod(context);
+        var funding = FundingHelper.CreateFunding(context, enrollment: enrollment, time: FundingTime.Full, firstReportingPeriod: reportingPeriod);
 
         if (submitted)
         {


### PR DESCRIPTION
* Updates backend enrollment save to support updating funding --> because the mapping for fundings <--> enrollment lives on funding, we cannot just use _context.Update(enrollment) and instead need to inspect the fundings pointing to enrollment.Id. And then ef is very opininated on the order of everything and aggressive tracking.
* Creates backend reportingperiod controller. I feel like there should be a better way for all of this reporting period stuff given it lives so far away (within the db) to funding.
* Creates reportingperiod repo
* Adds in smarter typings for removing the type predicate =/= bool problem
* A fair amount of ui wrangling -- several utils updates to summary and form and some strong-ish assumptions. /shrug/

Should close #150

URL: ....