### PR TITLE
Add FamilyId to Funding and C4K ui selection

### DIFF
--- a/src/Hedwig/ClientApp/src/generated/models/Funding.ts
+++ b/src/Hedwig/ClientApp/src/generated/models/Funding.ts
@@ -72,6 +72,12 @@ export interface Funding {
     source?: FundingSource;
     /**
      * 
+     * @type {number}
+     * @memberof Funding
+     */
+    familyId?: number | null;
+    /**
+     * 
      * @type {Date}
      * @memberof Funding
      */
@@ -146,6 +152,7 @@ export function FundingFromJSONTyped(json: any, ignoreDiscriminator: boolean): F
         'enrollmentId': json['enrollmentId'],
         'enrollment': !exists(json, 'enrollment') ? undefined : EnrollmentFromJSON(json['enrollment']),
         'source': !exists(json, 'source') ? undefined : FundingSourceFromJSON(json['source']),
+        'familyId': !exists(json, 'familyId') ? undefined : json['familyId'],
         'certificateStartDate': !exists(json, 'certificateStartDate') ? undefined : (json['certificateStartDate'] === null ? null : new Date(json['certificateStartDate'])),
         'certificateEndDate': !exists(json, 'certificateEndDate') ? undefined : (json['certificateEndDate'] === null ? null : new Date(json['certificateEndDate'])),
         'firstReportingPeriodId': !exists(json, 'firstReportingPeriodId') ? undefined : json['firstReportingPeriodId'],
@@ -172,6 +179,7 @@ export function FundingToJSON(value?: Funding | null): any {
         'enrollmentId': value.enrollmentId,
         'enrollment': EnrollmentToJSON(value.enrollment),
         'source': FundingSourceToJSON(value.source),
+        'familyId': value.familyId,
         'certificateStartDate': value.certificateStartDate === undefined ? undefined : (value.certificateStartDate === null ? null : value.certificateStartDate.toISOString()),
         'certificateEndDate': value.certificateEndDate === undefined ? undefined : (value.certificateEndDate === null ? null : value.certificateEndDate.toISOString()),
         'firstReportingPeriodId': value.firstReportingPeriodId,

--- a/src/Hedwig/Migrations/20200101153302_AddFamilyIdToFunding.Designer.cs
+++ b/src/Hedwig/Migrations/20200101153302_AddFamilyIdToFunding.Designer.cs
@@ -5,14 +5,16 @@ using Hedwig.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Hedwig.Migrations
+namespace hedwig.Migrations
 {
     [DbContext(typeof(HedwigContext))]
-    partial class HedwigContextModelSnapshot : ModelSnapshot
+    [Migration("20200101153302_AddFamilyIdToFunding")]
+    partial class AddFamilyIdToFunding
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Hedwig/Migrations/20200101153302_AddFamilyIdToFunding.cs
+++ b/src/Hedwig/Migrations/20200101153302_AddFamilyIdToFunding.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace hedwig.Migrations
+{
+    public partial class AddFamilyIdToFunding : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FamilyId",
+                table: "Funding",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FamilyId",
+                table: "Funding");
+        }
+    }
+}

--- a/src/Hedwig/Models/Funding.cs
+++ b/src/Hedwig/Models/Funding.cs
@@ -24,6 +24,8 @@ namespace Hedwig.Models
 
     // C4K funding fields
     [RequiredForFundingSource(FundingSource.C4K)]
+    public int? FamilyId { get; set; }
+    [RequiredForFundingSource(FundingSource.C4K)]
     public DateTime? CertificateStartDate { get; set; }
     public DateTime? CertificateEndDate { get; set; }
 


### PR DESCRIPTION
Should close #458 

The fundings (and updated fundings) array update logic can probably be cleaned up. See #482 

@atreni: It didn't look like there was info on the comp (https://skylight.invisionapp.com/public/share/FZWU9IO32#/screens/391165739) about what to show in the summary view. Let me know if there should be any changes from my assumptions here.

URL: https://3.15.236.11:5001