### PR TITLE
Jump to first input field with a blocking error

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
@@ -32,6 +32,7 @@ import {
 	getSummaryLine,
 } from '../../../utils/models';
 import {
+	useFocusFirstError,
 	sectionHasValidationErrors,
 	warningForFieldSet,
 	warningForField,
@@ -131,6 +132,8 @@ const ChildInfo: Section = {
 		};
 		const [apiError, setApiError] = useState<ValidationProblemDetails>();
 
+		useFocusFirstError([apiError]);
+
 		const save = () => {
 
 			if (enrollment) {
@@ -223,7 +226,7 @@ const ChildInfo: Section = {
 							defaultValue={lastName || ''}
 							onChange={event => updateLastName(event.target.value)}
 							status={serverErrorForField(
-								"child.lastname", 
+								"child.lastname",
 								apiError,
 								"This information is required for enrollment"
 							)}

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.tsx
@@ -27,8 +27,8 @@ export default function ReportDetail() {
 		api => api.apiOrganizationsOrgIdReportsIdGet(reportParams),
 		[user]
 	);
-	
-	if (loading || error || !report) {
+
+	if (loading || !report) {
 		return <div className="Report"></div>;
 	}
 
@@ -36,16 +36,27 @@ export default function ReportDetail() {
 		e => !!e.validationErrors && e.validationErrors.length > 0
 	).length;
 
-	let additionalAlerts: AlertProps[] | undefined;
+	let additionalAlerts: AlertProps[] = [];
+
+	if (error) {
+		additionalAlerts.push(
+			{
+	      type: 'error',
+	      heading: 'Something went wrong',
+	      text: 'There was an error loading the report',
+			},
+		);
+	}
+
 	if (numEnrollmentsMissingInfo) {
-		additionalAlerts = [
+		additionalAlerts.push(
 			{
 				type: 'error',
 				heading: 'Update roster',
 				text: `There are ${numEnrollmentsMissingInfo} enrollments missing information required to submit this CDC report.`,
 				actionItem: <Button text="Update roster" href="/roster" />,
 			},
-		];
+		);
 	}
 
 	const directionalLinkProps: DirectionalLinkProps = {

--- a/src/Hedwig/ClientApp/src/utils/validations/index.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/index.ts
@@ -4,3 +4,4 @@ export * from './Validatable';
 export * from './sectionHasValidationErrors';
 export * from './errorForFieldSet';
 export * from './errorForField';
+export * from './useFocusFirstError';

--- a/src/Hedwig/ClientApp/src/utils/validations/useFocusFirstError.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/useFocusFirstError.ts
@@ -1,0 +1,8 @@
+import { useEffect, DependencyList } from 'react';
+
+export function useFocusFirstError(deps?: DependencyList | undefined) {
+	return useEffect(() => {
+		const input = document.getElementsByClassName('usa-input--error')[0];
+		if (input) { (input as HTMLElement).focus() }
+	}, deps);
+}


### PR DESCRIPTION
Closes #534 and #535.

Also shows an error instead of a blank page on a 500, but does not fix that reports are currently unable to be submitted due to an undiagnosed 500 error.