### PR TITLE
509: Fixes bad validations around empty strings

### DIFF
--- a/src/Hedwig/Validations/Rules/ConditionalFieldRequired.cs
+++ b/src/Hedwig/Validations/Rules/ConditionalFieldRequired.cs
@@ -25,7 +25,7 @@ namespace Hedwig.Validations.Rules
       if(prop != null)
       {
         var value = prop.GetValue(entity);
-        if(CheckCondition(entity) && value == null)
+        if(CheckCondition(entity) && (value == null || value as string == ""))
         {
           return new ValidationError(
             field: _fieldName,

--- a/src/Hedwig/Validations/Rules/FieldRequired.cs
+++ b/src/Hedwig/Validations/Rules/FieldRequired.cs
@@ -21,7 +21,7 @@ namespace Hedwig.Validations.Rules
       if(prop != null)
       {
         var value = prop.GetValue(entity);
-        if (value == null)
+        if (value == null || value as string == "")
         {
           return new ValidationError(
             message: $"{(_prettyFieldName != null ? _prettyFieldName : _fieldName)} is required",

--- a/test/HedwigTests/Validations/Rules/ConditionalFieldRequiredTests.cs
+++ b/test/HedwigTests/Validations/Rules/ConditionalFieldRequiredTests.cs
@@ -29,23 +29,24 @@ namespace HedwigTests.Validations.Rules
     }
 
     [Theory]
-    [InlineData(true, false, true)]
-    [InlineData(true, true, false)]
-    [InlineData(false, true, false)]
-    [InlineData(false, false, false)]
-    public void Execute_ReturnsError_IfConditionTrueAndFieldDoesNotExist(
+    [InlineData(true, null, true)]
+    [InlineData(true, "", true)]
+    [InlineData(true, "Value", false)]
+    [InlineData(false, "Value", false)]
+    [InlineData(false, null, false)]
+    [InlineData(false, "", false)]
+    public void Execute_ReturnsError_IfConditionTrueAndFieldDoesNotExist_OrIsEmptyString(
       bool conditionResult,
-      bool fieldExists,
+      string fieldValue,
       bool doesError
     )
     {
       // if
       var fieldName = "FieldName";
-      var entity = new TestValidatableEntity();
-      if (fieldExists)
+      var entity = new TestValidatableEntity
       {
-        entity.FieldName = true;
-      }
+        FieldName = fieldValue
+      };
 
       // when
       var rule = new Mock<ConditionalFieldRequired<TestValidatableEntity>>("condition Message", fieldName, null);

--- a/test/HedwigTests/Validations/Rules/FieldRequiredTests.cs
+++ b/test/HedwigTests/Validations/Rules/FieldRequiredTests.cs
@@ -26,5 +26,30 @@ namespace HedwigTests.Validations.Rules
       // then
       Assert.Equal(!prettyFieldNameExists, result.Message.Contains(fieldName));
     }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("Value", false)]
+    public void Execute_ReturnsError_IfFieldDoesNotExist_OrIsEmptyString(
+      string fieldValue,
+      bool doesError
+    )
+    {
+      // if
+      var fieldName = "FieldName";
+      var entity = new TestValidatableEntity
+      {
+        FieldName = fieldValue
+      };
+
+      // when
+      var rule = new Mock<FieldRequired<TestValidatableEntity>>(fieldName, null, false);
+      rule.CallBase = true;
+      var result = rule.Object.Execute(entity);
+
+      // then
+      Assert.Equal(doesError, result != null);
+    }
   }
 }

--- a/test/HedwigTests/Validations/TestValidatableEntity.cs
+++ b/test/HedwigTests/Validations/TestValidatableEntity.cs
@@ -6,7 +6,7 @@ namespace HedwigTests.Validations
 
  public class TestValidatableEntity : INonBlockingValidatableObject
   {
-    public bool? FieldName { get; set; }
+    public string FieldName { get; set; }
     public List<ValidationError> ValidationErrors { get; set; }
   }
 }


### PR DESCRIPTION
This is how dotnet core does it as well (aka why our required FirstName and LastName are appropriate failing when we send empty string)