### PR TITLE
Add InitialLoadingErrorGuard

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
@@ -39,6 +39,7 @@ import {
 	serverErrorForField,
 } from '../../../utils/validations';
 import FieldSet from '../../../components/FieldSet/FieldSet';
+import initialLoadErrorGuard from '../../../utils/validations/initialLoadErrorGuard';
 
 const ChildInfo: Section = {
 	key: 'child-information',
@@ -64,10 +65,12 @@ const ChildInfo: Section = {
 		);
 	},
 
-	Form: ({ enrollment, siteId, mutate, callback }) => {
+	Form: ({ enrollment, siteId, mutate, callback, visitedSections }) => {
 		if (!enrollment && !siteId) {
 			throw new Error('ChildInfo rendered without an enrollment or a siteId');
 		}
+
+		const initialLoad = visitedSections ? !visitedSections[ChildInfo.key] : false;
 
 		const { user } = useContext(UserContext);
 		const defaultPostParams: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsPostRequest = {
@@ -203,11 +206,14 @@ const ChildInfo: Section = {
 							label="First name"
 							defaultValue={firstName || ''}
 							onChange={event => updateFirstName(event.target.value)}
-							status={serverErrorForField(
-								'child.firstname',
-								apiError,
-								'This information is required for enrollment'
-							)}
+							status={initialLoadErrorGuard(
+									initialLoad,
+									serverErrorForField(
+										'child.firstname',
+										apiError,
+										'This information is required for enrollment'
+									)
+								)}
 						/>
 					</div>
 					<div className="mobile-lg:grid-col-9">
@@ -225,10 +231,13 @@ const ChildInfo: Section = {
 							label="Last name"
 							defaultValue={lastName || ''}
 							onChange={event => updateLastName(event.target.value)}
-							status={serverErrorForField(
-								'child.lastname',
-								apiError,
-								'This information is required for enrollment'
+							status={initialLoadErrorGuard(
+								initialLoad,
+								serverErrorForField(
+									'child.lastname',
+									apiError,
+									'This information is required for enrollment'
+								)
 							)}
 						/>
 					</div>
@@ -250,21 +259,27 @@ const ChildInfo: Section = {
 					label="Birth date"
 					id="birthdate-picker"
 					hideLabel
-					status={warningForFieldSet(
-						'birthdate-fields',
-						['birthdate'],
-						enrollment ? enrollment.child : null,
-						'This information is required for OEC reporting'
+					status={initialLoadErrorGuard(
+						initialLoad,
+						warningForFieldSet(
+							'birthdate-fields',
+							['birthdate'],
+							enrollment ? enrollment.child : null,
+							'This information is required for OEC reporting'
+						)
 					)}
 				/>
 
 				<h3>Birth certificate</h3>
 				<FieldSet
-					status={warningForFieldSet(
-						'birth-certificate-fields',
-						['birthCertificateId', 'birthState', 'birthTown'],
-						enrollment ? enrollment.child : null,
-						'This information is required for OEC reporting'
+					status={initialLoadErrorGuard(
+						initialLoad,
+						warningForFieldSet(
+							'birth-certificate-fields',
+							['birthCertificateId', 'birthState', 'birthTown'],
+							enrollment ? enrollment.child : null,
+							'This information is required for OEC reporting'
+						)
 					)}
 					legend="Birth certificate"
 					className="display-inline-block"
@@ -276,10 +291,13 @@ const ChildInfo: Section = {
 							label="Birth certificate ID #"
 							defaultValue={birthCertificateId || ''}
 							onChange={event => updateBirthCertificateId(event.target.value)}
-							status={warningForField(
-								'birthCertificateId',
-								enrollment ? enrollment.child : null,
-								''
+							status={initialLoadErrorGuard(
+								initialLoad,
+								warningForField(
+									'birthCertificateId',
+									enrollment ? enrollment.child : null,
+									''
+								)
 							)}
 						/>
 					</div>
@@ -289,7 +307,14 @@ const ChildInfo: Section = {
 							label="State"
 							defaultValue={birthState || ''}
 							onChange={event => updateBirthState(event.target.value)}
-							status={warningForField('birthState', enrollment ? enrollment.child : null, '')}
+							status={initialLoadErrorGuard(
+								initialLoad,
+								warningForField(
+									'birthState',
+									enrollment ? enrollment.child : null,
+									''
+								)
+							)}
 						/>
 					</div>
 					<div className="mobile-lg:grid-col-8 display-inline-block">
@@ -298,7 +323,14 @@ const ChildInfo: Section = {
 							label="Town"
 							defaultValue={birthTown || ''}
 							onChange={event => updateBirthTown(event.target.value)}
-							status={warningForField('birthTown', enrollment ? enrollment.child : null, '')}
+							status={initialLoadErrorGuard(
+								initialLoad,
+								warningForField(
+									'birthTown',
+									enrollment ? enrollment.child : null,
+									''
+								)
+							)}
 						/>
 					</div>
 				</FieldSet>
@@ -306,17 +338,20 @@ const ChildInfo: Section = {
 				<h3>Race</h3>
 				<Checklist
 					hint="As identified by family"
-					status={warningForFieldSet(
-						'race-checklist',
-						[
-							'americanIndianOrAlaskaNative',
-							'asian',
-							'blackOrAfricanAmerican',
-							'NativeHawaiianOrPacificIslander',
-							'white',
-						],
-						enrollment ? enrollment.child : null,
-						'This information is required for OEC reporting'
+					status={initialLoadErrorGuard(
+						initialLoad,
+						warningForFieldSet(
+							'race-checklist',
+							[
+								'americanIndianOrAlaskaNative',
+								'asian',
+								'blackOrAfricanAmerican',
+								'NativeHawaiianOrPacificIslander',
+								'white',
+							],
+							enrollment ? enrollment.child : null,
+							'This information is required for OEC reporting'
+						)
 					)}
 					legend="Race"
 					id="race-checklist"
@@ -357,11 +392,14 @@ const ChildInfo: Section = {
 				<h3>Ethnicity</h3>
 				<RadioGroup
 					hint="As identified by family"
-					status={warningForFieldSet(
-						'ethnicity-radiogroup',
-						['hispanicOrLatinxEthnicity'],
-						enrollment ? enrollment.child : null,
-						'This information is required for OEC reporting'
+					status={initialLoadErrorGuard(
+						initialLoad,
+						warningForFieldSet(
+							'ethnicity-radiogroup',
+							['hispanicOrLatinxEthnicity'],
+							enrollment ? enrollment.child : null,
+							'This information is required for OEC reporting'
+						)
 					)}
 					legend="Ethnicity"
 					id="ethnicity-radiogroup"
@@ -418,11 +456,14 @@ const ChildInfo: Section = {
 					selected={gender || Gender.Unspecified}
 					onChange={event => updateGender(genderFromString(event.target.value))}
 					id="gender-select"
-					status={warningForFieldSet(
-						'gender-select',
-						['gender'],
-						enrollment ? enrollment.child : null,
-						'This information is required for OEC reporting'
+					status={initialLoadErrorGuard(
+						initialLoad,
+						warningForFieldSet(
+							'gender-select',
+							['gender'],
+							enrollment ? enrollment.child : null,
+							'This information is required for OEC reporting'
+						)
 					)}
 				/>
 

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
@@ -34,6 +34,7 @@ import { familyDeterminationNotDisclosed, currentFunding, updateFunding, createF
 import Checklist from '../../../components/Checklist/Checklist';
 import TextInput from '../../../components/TextInput/TextInput';
 import InlineIcon from '../../../components/InlineIcon/InlineIcon';
+import initialLoadErrorGuard from '../../../utils/validations/initialLoadErrorGuard';
 
 const EnrollmentFunding: Section = {
 	key: 'enrollment-funding',
@@ -352,11 +353,13 @@ const EnrollmentFunding: Section = {
 						dateRange={{ startDate: entry ? moment(entry) : null, endDate: null }}
 						label="Start date"
 						id="enrollment-start-date"
-						status={warningForField(
-							'entry',
-							enrollment,
-							'This information is required for OEC reporting'
-						)}
+						status={initialLoadErrorGuard(
+							initialLoad,
+							warningForField(
+								'entry',
+								enrollment,
+								'This information is required for OEC reporting'
+						))}
 					/>
 
 					<h3>Age group</h3>
@@ -379,11 +382,14 @@ const EnrollmentFunding: Section = {
 						]}
 						selected={'' + age}
 						onChange={event => updateAge(ageFromString(event.target.value))}
-						status={warningForFieldSet(
-							'age-group-warning',
-							['ageGroup'],
-							enrollment,
-							'This field is required for OEC reporting'
+						status={initialLoadErrorGuard(
+							initialLoad,
+							warningForFieldSet(
+								'age-group-warning',
+								['ageGroup'],
+								enrollment,
+								'This field is required for OEC reporting'
+							)
 						)}
 					/>
 					<h3>Funding</h3>
@@ -440,14 +446,17 @@ const EnrollmentFunding: Section = {
 							}}
 							selected={cdcReportingPeriod ? '' + cdcReportingPeriod.id : ''}
 							status={
-								serverErrorForField(
-									'fundings',
-									apiError
-								) ||
-								warningForField(
-									'firstReportingPeriod',
-									cdcFunding ? cdcFunding as Funding : null,
-									'This information is required for OEC reporting'
+								initialLoadErrorGuard(
+									initialLoad,
+									serverErrorForField(
+										'fundings',
+										apiError
+									) ||
+									warningForField(
+										'firstReportingPeriod',
+										cdcFunding ? cdcFunding as Funding : null,
+										'This information is required for OEC reporting'
+									)
 								)
 							}
 						/>
@@ -473,10 +482,13 @@ const EnrollmentFunding: Section = {
 								label="Family ID"
 								defaultValue={c4kFamilyId ? '' + c4kFamilyId : ''}
 								onChange={event => updateC4kFamilyId(parseInt(event.target.value))}
-								status={warningForField(
-									'familyId',
-									c4kFunding ? c4kFunding : null,
-									'This information is required for OEC reporting'
+								status={initialLoadErrorGuard(
+									initialLoad,
+									warningForField(
+										'familyId',
+										c4kFunding ? c4kFunding : null,
+										'This information is required for OEC reporting'
+									)
 								)}
 							/>
 							<DatePicker
@@ -491,10 +503,13 @@ const EnrollmentFunding: Section = {
 								}}
 								label="Certificate start date"
 								id="c4k-certificate-start-date"
-								status={warningForField(
-									'certificateStartDate',
-									c4kFunding ? c4kFunding : null,
-									'This information is required for OEC reporting'
+								status={initialLoadErrorGuard(
+									initialLoad,
+									warningForField(
+										'certificateStartDate',
+										c4kFunding ? c4kFunding : null,
+										'This information is required for OEC reporting'
+									)
 								)}
 							/>
 						</>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../../utils/validations';
 import FieldSet from '../../../components/FieldSet/FieldSet';
 import InlineIcon from '../../../components/InlineIcon/InlineIcon';
+import initialLoadErrorGuard from '../../../utils/validations/initialLoadErrorGuard';
 
 const FamilyIncome: Section = {
 	key: 'family-income',
@@ -62,10 +63,12 @@ const FamilyIncome: Section = {
 		return <div className="FamilyIncomeSummary">{elementToReturn}</div>;
 	},
 
-	Form: ({ enrollment, mutate, callback }) => {
+	Form: ({ enrollment, mutate, callback, visitedSections }) => {
 		if (!enrollment || !enrollment.child || !enrollment.child.family) {
 			throw new Error('FamilyIncome rendered without enrollment.child.family');
 		}
+
+		const initialLoad = visitedSections ? !visitedSections[FamilyIncome.key] : false;
 
 		const { user } = useContext(UserContext);
 		const defaultParams: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest = {
@@ -159,20 +162,21 @@ const FamilyIncome: Section = {
 							<FieldSet
 								id="family-income"
 								legend="Family income"
-								status={
+								status={initialLoadErrorGuard(
+									initialLoad,
 									warningForFieldSet(
-									'family-income',
-									['numberOfPeople', 'income', 'determinationDate'],
-									determination ? determination : null,
-									'This information is required for enrollment'
-									) ||
+										'family-income',
+										['numberOfPeople', 'income', 'determinationDate'],
+										determination ? determination : null,
+										'This information is required for enrollment'
+										) ||
 									warningForFieldSet(
 										'family-income',
 										['child.family.determinations'],
 										enrollment,
 										'Income must be determined for funded enrollments'
 									)
-								}
+								)}
 							>
 								<TextInput
 									id="numberOfPeople"
@@ -183,10 +187,13 @@ const FamilyIncome: Section = {
 										updateNumberOfPeople(value);
 									}}
 									onBlur={event => (event.target.value = numberOfPeople ? '' + numberOfPeople : '')}
-									status={warningForField(
-										'numberOfPeople',
-										determination ? determination : null,
-										''
+									status={initialLoadErrorGuard(
+										initialLoad,
+										warningForField(
+											'numberOfPeople',
+											determination ? determination : null,
+											''
+										)
 									)}
 									small
 								/>
@@ -202,10 +209,13 @@ const FamilyIncome: Section = {
 											? currencyFormatter(income)
 											: '')
 									}
-									status={warningForField(
-										'income',
-										determination ? determination : null,
-										''
+									status={initialLoadErrorGuard(
+										initialLoad,
+										warningForField(
+											'income',
+											determination ? determination : null,
+											''
+										)
 									)}
 								/>
 								<DatePicker
@@ -218,10 +228,13 @@ const FamilyIncome: Section = {
 										startDate: determinationDate ? moment(determinationDate) : null,
 										endDate: null,
 									}}
-									status={warningForField(
-										'determintionDate',
-										determination ? determination : null,
-										''
+									status={initialLoadErrorGuard(
+										initialLoad,
+										warningForField(
+											'determintionDate',
+											determination ? determination : null,
+											''
+										)
 									)}
 								/>
 							</FieldSet>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../utils/validations';
 import FieldSet from '../../../components/FieldSet/FieldSet';
 import { addressFormatter, homelessnessText, fosterText } from '../../../utils/models';
+import initialLoadErrorGuard from '../../../utils/validations/initialLoadErrorGuard';
 
 const FamilyInfo: Section = {
 	key: 'family-information',
@@ -47,10 +48,12 @@ const FamilyInfo: Section = {
 		);
 	},
 
-	Form: ({ enrollment, mutate, callback }) => {
+	Form: ({ enrollment, mutate, callback, visitedSections }) => {
 		if (!enrollment || !enrollment.child) {
 			throw new Error('FamilyInfo rendered without a child');
 		}
+
+		const initialLoad = visitedSections ? !visitedSections[FamilyInfo.key] : false;
 
 		const child = enrollment.child;
 		const { user } = useContext(UserContext);
@@ -116,11 +119,14 @@ const FamilyInfo: Section = {
 				<FieldSet
 					id="family-address"
 					legend="Address"
-					status={warningForFieldSet(
-						'family-address',
-						['addressLine1', 'state', 'town', 'zip'],
-						idx(enrollment, _ => _.child.family) || null,
-						'This information is required for OEC reporting'
+					status={initialLoadErrorGuard(
+						initialLoad,
+						warningForFieldSet(
+							'family-address',
+							['addressLine1', 'state', 'town', 'zip'],
+							idx(enrollment, _ => _.child.family) || null,
+							'This information is required for OEC reporting'
+						)
 					)}
 					className="display-inline-block"
 				>
@@ -130,10 +136,13 @@ const FamilyInfo: Section = {
 							label="Address line 1"
 							defaultValue={addressLine1 || ''}
 							onChange={event => updateAddressLine1(event.target.value ? event.target.value : null)}
-							status={warningForField(
-								'addressLine1',
-								idx(enrollment, _ => _.child.family) || null,
-								''
+							status={initialLoadErrorGuard(
+								initialLoad,
+								warningForField(
+									'addressLine1',
+									idx(enrollment, _ => _.child.family) || null,
+									''
+								)
 							)}
 						/>
 					</div>
@@ -152,7 +161,14 @@ const FamilyInfo: Section = {
 							label="State"
 							defaultValue={state || ''}
 							onChange={event => updateState(event.target.value ? event.target.value : null)}
-							status={warningForField('state', idx(enrollment, _ => _.child.family) || null, '')}
+							status={initialLoadErrorGuard(
+								initialLoad,
+								warningForField(
+									'state',
+									idx(enrollment, _ => _.child.family) || null,
+									''
+								)
+							)}
 						/>
 					</div>
 					<div className="mobile-lg:grid-col-8 display-inline-block">
@@ -161,7 +177,14 @@ const FamilyInfo: Section = {
 							label="Town"
 							defaultValue={town || ''}
 							onChange={event => updateTown(event.target.value ? event.target.value : null)}
-							status={warningForField('town', idx(enrollment, _ => _.child.family) || null, '')}
+							status={initialLoadErrorGuard(
+								initialLoad,
+								warningForField(
+									'town',
+									idx(enrollment, _ => _.child.family) || null,
+									''
+								)
+							)}
 						/>
 					</div>
 					<div className="mobile-lg:grid-col-6">
@@ -170,7 +193,14 @@ const FamilyInfo: Section = {
 							label="ZIP Code"
 							defaultValue={zip || ''}
 							onChange={event => updateZip(event.target.value ? event.target.value : null)}
-							status={warningForField('zip', idx(enrollment, _ => _.child.family) || null, '')}
+							status={initialLoadErrorGuard(
+								initialLoad,
+								warningForField(
+									'zip',
+									idx(enrollment, _ => _.child.family) || null,
+									''
+								)
+							)}
 						/>
 					</div>
 				</FieldSet>

--- a/src/Hedwig/ClientApp/src/utils/validations/initialLoadErrorGuard.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/initialLoadErrorGuard.ts
@@ -1,0 +1,12 @@
+import { FormStatusProps } from "../../components/FormStatus/FormStatus";
+
+export default function initialLoadErrorGuard(
+  initialLoad: boolean,
+  error?: FormStatusProps
+) {
+  if (initialLoad) {
+    return undefined;
+  } else {
+    return error;
+  }
+}


### PR DESCRIPTION
Should close #589 

This uses the `visitedSections` object that #582 introduced to only show errors after a using has hit save at least once in the section.