### PR TITLE
700: Adds ReadOnly entity and applies to ReportingPeriod

### DIFF
--- a/src/Hedwig/Data/DbInitializer.cs
+++ b/src/Hedwig/Data/DbInitializer.cs
@@ -456,7 +456,7 @@ namespace Hedwig.Data
       };
 
       _context.ReportingPeriods.Add(reportingPeriod);
-      _context.SaveChanges();
+      _context.SaveChanges(ignoreReadOnly: true);
       return reportingPeriod;
     }
 

--- a/src/Hedwig/Models/Attributes/ReadOnlyAttribute.cs
+++ b/src/Hedwig/Models/Attributes/ReadOnlyAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Hedwig.Models.Attributes
+{
+  public class ReadOnlyAttribute : Attribute
+  { 
+
+    public static bool IsReadOnly(object entity)
+    {
+      ReadOnlyAttribute attribute = (ReadOnlyAttribute) Attribute.GetCustomAttribute(entity.GetType(), typeof(ReadOnlyAttribute));
+      return attribute != null;
+    }
+  }
+}

--- a/src/Hedwig/Models/ReportingPeriod.cs
+++ b/src/Hedwig/Models/ReportingPeriod.cs
@@ -3,9 +3,11 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Hedwig.Models.Attributes;
 
 namespace Hedwig.Models
 {
+  [ReadOnly]
   public class ReportingPeriod : IHedwigIdEntity<int>
   {
     [Required]

--- a/test/HedwigTests/Data/HedwigContextTests.cs
+++ b/test/HedwigTests/Data/HedwigContextTests.cs
@@ -5,6 +5,10 @@ using Moq.Protected;
 using Hedwig.Models;
 using Microsoft.EntityFrameworkCore;
 using HedwigTests.Fixtures;
+using HedwigTests.Helpers;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace HedwigTests.Data
 {
@@ -62,6 +66,96 @@ namespace HedwigTests.Data
       // Then author is added to the entity
       Assert.Equal(userId, child.AuthorId.Value);
       Assert.Equal(userId, child.Family.AuthorId.Value);
+    }
+
+    [Fact]
+    public void SaveChanges_DoesNotAddReadOnlyEntity()
+    {
+      using(var context = new TestHedwigContextProvider().Context)
+      {
+        var totalReportingPeriods = context.ReportingPeriods.AsNoTracking().Count();
+        // If a read-only entity is created
+        var reportingPeriod = new ReportingPeriod {
+          Type = FundingSource.CDC,
+          Period = DateTime.Now,
+          PeriodStart = DateTime.Now,
+          PeriodEnd = DateTime.Now,
+          DueAt = DateTime.Now
+        };
+        context.Add(reportingPeriod);
+        
+        // When context changes are saved
+        context.SaveChanges();
+
+        // Then the changes are not persisted to the DB
+        var res = context.ReportingPeriods.AsNoTracking().Count();
+        Assert.Equal(totalReportingPeriods, res);
+      }
+    }
+
+    [Fact]
+    public void SaveChanges_DoesNotUpdateReadOnlyEntity()
+    {
+      using (var context = new TestHedwigContextProvider().Context)
+      {
+        // If a read-only entity is updated
+        var reportingPeriod = ReportingPeriodHelper.CreateReportingPeriod(context, type: FundingSource.CDC);
+        var updatedType = FundingSource.C4K;
+        reportingPeriod.Type = updatedType;
+        context.Update(reportingPeriod);
+        
+        // When context changes are saved
+        context.SaveChanges();
+
+        // Then the changes are not persisted to the DB
+        var res = context.ReportingPeriods.AsNoTracking().First(period => period.Id == reportingPeriod.Id);
+        Assert.NotEqual(updatedType, res.Type);
+      }
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_DoesNotAddReadOnlyEntity()
+    {
+      using(var context = new TestHedwigContextProvider().Context)
+      {
+        var totalReportingPeriods = context.ReportingPeriods.AsNoTracking().Count();
+        // If a read-only entity is created
+        var reportingPeriod = new ReportingPeriod {
+          Type = FundingSource.CDC,
+          Period = DateTime.Now,
+          PeriodStart = DateTime.Now,
+          PeriodEnd = DateTime.Now,
+          DueAt = DateTime.Now
+        };
+        context.Add(reportingPeriod);
+        
+        // When context changes are saved
+        await context.SaveChangesAsync();
+
+        // Then the changes are not persisted to the DB
+        var res = context.ReportingPeriods.AsNoTracking().Count();
+        Assert.Equal(totalReportingPeriods, res);
+      }
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_DoesNotUpdateReadOnlyEntity()
+    {
+      using (var context = new TestHedwigContextProvider().Context)
+      {
+        // If a read-only entity is updated
+        var reportingPeriod = ReportingPeriodHelper.CreateReportingPeriod(context, type: FundingSource.CDC);
+        var updatedType = FundingSource.C4K;
+        reportingPeriod.Type = updatedType;
+        context.Update(reportingPeriod);
+        
+        // When context changes are saved
+        await context.SaveChangesAsync();
+
+        // Then the changes are not persisted to the DB
+        var res = context.ReportingPeriods.AsNoTracking().First(period => period.Id == reportingPeriod.Id);
+        Assert.NotEqual(updatedType, res.Type);
+      }
     }
   }
 }

--- a/test/HedwigTests/Helpers/ReportingPeriodHelper.cs
+++ b/test/HedwigTests/Helpers/ReportingPeriodHelper.cs
@@ -48,7 +48,7 @@ namespace HedwigTests.Helpers
 			};
 
 			context.Add(reportingPeriod);
-			context.SaveChanges();
+			context.SaveChanges(ignoreReadOnly: true);
 			return reportingPeriod;
 		}
 	}

--- a/test/HedwigTests/Models/Attributes/ReadOnlyAttributeTests.cs
+++ b/test/HedwigTests/Models/Attributes/ReadOnlyAttributeTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+using Moq;
+using Hedwig.Models.Attributes;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using HedwigTests.Fixtures;
+
+namespace HedwigTests.Models.Attributes
+{
+  [ReadOnly]
+  public class ReadOnlyEntity {}
+  public class ReadOnlyAttributeTests
+  {
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsReadOnly_ReturnsTrueIfEntityHasReadOnlyAttribute(
+      bool isReadOnly
+    )
+    {
+      // if 
+      var entity = isReadOnly ? new ReadOnlyEntity() : new object();
+
+      // when
+      var res = ReadOnlyAttribute.IsReadOnly(entity);
+
+      // then
+      Assert.Equal(isReadOnly, res);
+    }
+  }
+}


### PR DESCRIPTION
closes #700 

NOTE: With this impl, updates to read-only fields fail silently. I think this is pref to a failed POST/PUT, but interested in other's thoughts. I have not found a way to add warnings to an arbitrary API response (looked into this when thinking thru the non-blocking model validations) that seems idiomatic or not overly cumbersome. But can revisit if others think silently throwing away updates to read only is not acceptable. 