### PR TITLE
Use sentence case for privacy policy link

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/App/App.tsx
+++ b/src/Hedwig/ClientApp/src/containers/App/App.tsx
@@ -50,7 +50,7 @@ const App: React.FC = () => {
 					: 'Reports',
 			path: '/reports',
 		},
-		{ type: 'secondary', title: 'Privacy Policy', path: '/privacy-policy' },
+		{ type: 'secondary', title: 'Privacy policy', path: '/privacy-policy' },
 		// { type: 'secondary', title: 'Help', path: '/help' },
 	];
 

--- a/src/Hedwig/ClientApp/src/containers/App/__snapshots__/App.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/App/__snapshots__/App.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`matches snapshot 1`] = `
                   <a
                     href="/privacy-policy"
                   >
-                    Privacy Policy
+                    Privacy policy
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
Sorry I didn't catch this on the PR. As a general rule, we're using sentence case everywhere in the app (ironically, the policy itself is the only exception I can think of).