### PR TITLE
publish test on success or failure (#745)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ jobs:
 
   - task: PublishTestResults@2
     displayName: "Publish test results"
+    condition: succeededOrFailed()
     inputs:
       testResultsFormat: "VSTest"
       testResultsFiles: "**/*.trx"


### PR DESCRIPTION
In the azure pipeline, test results are not published on failure.

May be due to the test task exiting with exit code from container. This was implemented to ensure that if the application build orchestrated by docker before running the tests failed, the whole pipeline failed.

AC:

test results are published on success or failure
somewhere in the pipeline, a failed app build causes pipeline failure