### PR TITLE
Fixes a bug that breaks enrollment updates

### DIFF
--- a/src/Hedwig/Data/HedwigContext.cs
+++ b/src/Hedwig/Data/HedwigContext.cs
@@ -167,6 +167,7 @@ namespace Hedwig.Data
       }
 
       return Users
+        .AsNoTracking()
         .Where(user => user.WingedKeysId == wingedKeysId)
         .Select(user => user.Id)
         .Cast<int?>()

--- a/src/Hedwig/Repositories/EnrollmentRepository.cs
+++ b/src/Hedwig/Repositories/EnrollmentRepository.cs
@@ -111,6 +111,13 @@ namespace Hedwig.Repositories
 				}
 			}
 
+			/** Author is needed to display metadata about enrollment updates
+				* However, simply including Author via enrollmentQuery.Include(e => e.Author) includes author
+				* on all sub-objects (child, family, familyDetermination, funding). If the same author entity is
+				* associated with multiple objects in a single update, the DB update fails with:
+				* "System.InvalidOperationException: The instance of entity type 'User' cannot be tracked because another instance with the same key value for {'Id'} is already being tracked."
+				* A better solution for this will probably need to be determined, but for now, including un-tracked author on the enrollment ensures there is no clash. 
+				*/
 			var enrollment = enrollmentQuery.FirstOrDefault();
 			var author = _context.Users.AsNoTracking().FirstOrDefault(u => u.Id == enrollment.AuthorId);
 			enrollment.Author = author;


### PR DESCRIPTION
closes #757 in a kind of hacky or at least not the most forward-looking way 

NOTE: this fix is needed b/c references to the same user object in
multiple obejcts in the PUT data (i.e. on enrollment, child, family,
etc) lead to a dbContext error and 500 response. Is this going to be a
problem moving forward? Do we eventually need DTOs ?

(this issue will only be caught by integration test w/ real backend, so will add tests after selenium integration is in. ticket here: 