### PR TITLE
Attempt read-only properties

### DIFF
--- a/docs/backend/2020_02_05_read-only-entities.md
+++ b/docs/backend/2020_02_05_read-only-entities.md
@@ -20,9 +20,9 @@ EF Core Attribute.
 
 ## Status
 * Proposed
-* __Accepted__
+* Accepted
 * Rejected
-* Superceded
+* __Superceded__
 * Accepted (Partially superceded)
 
 ## Consequences

--- a/docs/backend/2020_02_15_read-only-properties.md
+++ b/docs/backend/2020_02_15_read-only-properties.md
@@ -1,0 +1,26 @@
+# Read Only Properties
+
+## Context
+The previous approach to handling read-only entities was not sufficient to handle the case for author `User` properties on temporal entities.
+While updating fundings with the same ReportingPeriod reference (i.e. same reporting period as first and last) did not cause errors, updating
+nested entities with references to the same user (i.e. Enrollment.Author = Enrollment.Child.Author) results in an [`InvalidOperationException`](https://github.com/ctoec/ecis-experimental/issues/757)
+A hacky fix was implemented to only add the User entity to Enrollment, and not nested temporal entities, but this is likely to cause other problems as we move into other use cases.
+
+## Decision
+The ReadOnlyAttribute has been reimagined as an attribute that should be applied to properties on models, not entire models.
+This gives us more flexibility to enable automated API creation of entities like Users or ReportingPeriods, while ensuring they are
+not updated or created by the creation or mutation of entities with read-only references to these objects.
+
+
+## Status
+* Proposed
+* __Accepted__
+* Rejected
+* Superceded
+* Accepted (Partially superceded)
+(Choose one)
+
+## Consequences
+- Creation or mutation of read-only property on an entity is silently ignored
+- Link to read-only property must be created via Id, as opposed to by linking to the object
+(Adding an author to a temporal entity must be done by populating `AuthorId`; adding `Author` object will be ignored)

--- a/src/Hedwig/Data/DbInitializer.cs
+++ b/src/Hedwig/Data/DbInitializer.cs
@@ -174,8 +174,8 @@ namespace Hedwig.Data
             enrollmentId: enrollment.Id,
             source: FundingSource.CDC,
             time: FundingTime.Full,
-            firstReportingPeriod: entry == "2018-09-03" ? reportingPeriods[14] : reportingPeriods[26],
-            lastReportingPeriod: cells[6] != "" ? reportingPeriods[25] : null
+            firstReportingPeriodId: entry == "2018-09-03" ? reportingPeriods[14].Id : reportingPeriods[26].Id,
+            lastReportingPeriodId: exit != null ? reportingPeriods[25].Id : (int?) null
           );
         }
 
@@ -206,8 +206,8 @@ namespace Hedwig.Data
               enrollmentId: firstEnrollment.Id,
               source: FundingSource.CDC,
               time: FundingTime.Full,
-              firstReportingPeriod: reportingPeriods[2],
-              lastReportingPeriod: reportingPeriods[13]
+              firstReportingPeriodId: reportingPeriods[2].Id,
+              lastReportingPeriodId: reportingPeriods[13].Id
             );
           }
         }
@@ -421,8 +421,8 @@ namespace Hedwig.Data
       string certificateStartDate = null,
       string certificateEndDate = null,
       FundingTime? time = null,
-      ReportingPeriod firstReportingPeriod = null,
-      ReportingPeriod lastReportingPeriod = null,
+      int? firstReportingPeriodId = null,
+      int? lastReportingPeriodId = null,
       int? familyId = null
     )
     {
@@ -431,8 +431,8 @@ namespace Hedwig.Data
         EnrollmentId = enrollmentId,
         Source = source,
         Time = time,
-        FirstReportingPeriod = firstReportingPeriod,
-        LastReportingPeriod = lastReportingPeriod,
+        FirstReportingPeriodId = firstReportingPeriodId,
+        LastReportingPeriodId = lastReportingPeriodId,
         FamilyId = familyId
       };
 
@@ -469,7 +469,7 @@ namespace Hedwig.Data
       };
 
       _context.ReportingPeriods.Add(reportingPeriod);
-      _context.SaveChanges(ignoreReadOnly: true);
+      _context.SaveChanges();
       return reportingPeriod;
     }
 

--- a/src/Hedwig/Models/Attributes/ReadOnlyAttribute.cs
+++ b/src/Hedwig/Models/Attributes/ReadOnlyAttribute.cs
@@ -1,13 +1,14 @@
 using System;
+using System.Reflection;
 
 namespace Hedwig.Models.Attributes
 {
   public class ReadOnlyAttribute : Attribute
   { 
 
-    public static bool IsReadOnly(object entity)
+    public static bool IsReadOnly(PropertyInfo property)
     {
-      ReadOnlyAttribute attribute = (ReadOnlyAttribute) Attribute.GetCustomAttribute(entity.GetType(), typeof(ReadOnlyAttribute));
+      ReadOnlyAttribute attribute = (ReadOnlyAttribute) Attribute.GetCustomAttribute(property, typeof(ReadOnlyAttribute));
       return attribute != null;
     }
   }

--- a/src/Hedwig/Models/Funding.cs
+++ b/src/Hedwig/Models/Funding.cs
@@ -6,6 +6,7 @@ using Hedwig.Validations;
 using Hedwig.Validations.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Hedwig.Models.Attributes;
 
 
 namespace Hedwig.Models
@@ -31,8 +32,10 @@ namespace Hedwig.Models
 
     // CDC funding fields
     public int? FirstReportingPeriodId {get; set; }
+    [ReadOnly]
     public ReportingPeriod FirstReportingPeriod { get; set; }
     public int? LastReportingPeriodId { get; set; }
+    [ReadOnly]
     [LastReportingPeriodAfterFirst]
     public ReportingPeriod LastReportingPeriod { get; set; }
     [RequiredForFundingSource(FundingSource.CDC)]

--- a/src/Hedwig/Models/ReportingPeriod.cs
+++ b/src/Hedwig/Models/ReportingPeriod.cs
@@ -7,7 +7,6 @@ using Hedwig.Models.Attributes;
 
 namespace Hedwig.Models
 {
-  [ReadOnly]
   public class ReportingPeriod : IHedwigIdEntity<int>
   {
     [Required]

--- a/src/Hedwig/Models/TemporalEntity.cs
+++ b/src/Hedwig/Models/TemporalEntity.cs
@@ -1,10 +1,12 @@
 using System;
+using Hedwig.Models.Attributes;
 
 namespace Hedwig.Models
 {
     public abstract class TemporalEntity
     {
         public int? AuthorId { get; set; }
+        [ReadOnly]
         public User Author { get; set; }
         public DateTime? UpdatedAt { get; set; }
     }

--- a/test/HedwigTests/Data/HedwigContextTests.cs
+++ b/test/HedwigTests/Data/HedwigContextTests.cs
@@ -76,92 +76,64 @@ namespace HedwigTests.Data
    }
 
     [Fact]
-    public void SaveChanges_DoesNotAddReadOnlyEntity()
-    {
-      using(var context = new TestHedwigContextProvider().Context)
-      {
-        // If a read-only entity is created
-        var now = DateTime.Now;
-        var reportingPeriod = new ReportingPeriod {
-          Type = FundingSource.CDC,
-          Period = now,
-          PeriodStart = now,
-          PeriodEnd = now,
-          DueAt = now
-        };
-        context.Add(reportingPeriod);
-        
-        // When context changes are saved
-        context.SaveChanges();
-
-        // Then the changes are not persisted to the DB
-        var res = context.ReportingPeriods.Where(rp => rp.Period == now);
-        Assert.Empty(res);
-      }
-    }
-
-    [Fact]
-    public void SaveChanges_DoesNotUpdateReadOnlyEntity()
+    public void Add_ReadOnlyProperty_DoesNotCreateNewEntity()
     {
       using (var context = new TestHedwigContextProvider().Context)
       {
-        // If a read-only entity is updated
-        var reportingPeriod = ReportingPeriodHelper.CreateReportingPeriod(context, type: FundingSource.CDC);
-        var updatedType = FundingSource.C4K;
-        reportingPeriod.Type = updatedType;
-        context.Update(reportingPeriod);
-        
-        // When context changes are saved
+        // If entity is created with read-only property
+        var org = OrganizationHelper.CreateOrganization(context);
+        var child = new Child {
+          FirstName = "First",
+          LastName = "Last",
+          Birthdate = DateTime.Now,
+          Gender = Gender.Unknown,
+          OrganizationId = org.Id
+        };
+
+        var nowString = DateTime.Now.ToString();
+        var user = new User{ FirstName = nowString };
+        child.Author = user;
+
+        // When entity is added to context
+        context.Add(child);
         context.SaveChanges();
 
-        // Then the changes are not persisted to the DB
-        var res = context.ReportingPeriods.AsNoTracking().First(period => period.Id == reportingPeriod.Id);
-        Assert.NotEqual(updatedType, res.Type);
+        // Then the change is not persisted
+        var childRes = context.Children.AsNoTracking().First(c => c.Id == child.Id);
+        Assert.Null(childRes.Author);
+        var userRes = context.Users.FirstOrDefault(u => u.FirstName == nowString);
+        Assert.Null(userRes);
       }
     }
 
     [Fact]
-    public async Task SaveChangesAsync_DoesNotAddReadOnlyEntity()
+    public void Update_ReadOnlyProperty_DoesNotUpdateEntity()
     {
+      Child child;
+      var nowString = DateTime.Now.ToString();
       using(var context = new TestHedwigContextProvider().Context)
       {
-        // If a read-only entity is created
-        var now = DateTime.Now;
-        var reportingPeriod = new ReportingPeriod {
-          Type = FundingSource.CDC,
-          Period = now,
-          PeriodStart = now,
-          PeriodEnd = now,
-          DueAt = now
-        };
-        context.Add(reportingPeriod);
-        
-        // When context changes are saved
-        await context.SaveChangesAsync();
-
-        // Then the changes are not persisted to the DB
-        var res = context.ReportingPeriods.Where(rp => rp.Period == now);
-        Assert.Empty(res);
+        // If an entity with read-only property exists
+        child = ChildHelper.CreateChild(context);
+        var author = UserHelper.CreateUser(context, firstName: nowString);
+        // And read-only property has a value
+        child.Author = author;
+        context.SaveChanges();
       }
-    }
 
-    [Fact]
-    public async Task SaveChangesAsync_DoesNotUpdateReadOnlyEntity()
-    {
-      using (var context = new TestHedwigContextProvider().Context)
+      // When the read-only property is updated
+      child.Author.FirstName = DateTime.Now.AddDays(3).ToString();
+      // NOTE: Necessary to avoid inifite loop self reference (which does not happen in real useage)
+      child.Family.Children = null;
+
+      using(var context = new TestHedwigContextProvider().Context)
       {
-        // If a read-only entity is updated
-        var reportingPeriod = ReportingPeriodHelper.CreateReportingPeriod(context, type: FundingSource.CDC);
-        var updatedType = FundingSource.C4K;
-        reportingPeriod.Type = updatedType;
-        context.Update(reportingPeriod);
-        
-        // When context changes are saved
-        await context.SaveChangesAsync();
+        context.Update(child);
+        context.SaveChanges();
 
-        // Then the changes are not persisted to the DB
-        var res = context.ReportingPeriods.AsNoTracking().First(period => period.Id == reportingPeriod.Id);
-        Assert.NotEqual(updatedType, res.Type);
+        // Then the change is not persisted
+        var childRes = context.Children.AsNoTracking().First(c => c.Id == child.Id);
+        Assert.Equal(nowString, childRes.Author.FirstName);
       }
     }
   }

--- a/test/HedwigTests/Helpers/ChildHelper.cs
+++ b/test/HedwigTests/Helpers/ChildHelper.cs
@@ -31,7 +31,7 @@ namespace HedwigTests.Helpers
 				OrganizationId = organization.Id
 			};
 
-			context.Add<Child>(child);
+			context.Add(child);
 			context.SaveChanges();
 			return child;
 		}

--- a/test/HedwigTests/Helpers/FundingHelper.cs
+++ b/test/HedwigTests/Helpers/FundingHelper.cs
@@ -22,10 +22,10 @@ namespace HedwigTests.Helpers
 				EnrollmentId = enrollment.Id,
 				Source = source,
 				Time = time,
-        FirstReportingPeriod = firstReportingPeriod
 			};
 
-			if (lastReportingPeriod != null) funding.LastReportingPeriod = lastReportingPeriod;
+			if (firstReportingPeriod != null) funding.FirstReportingPeriodId = firstReportingPeriod.Id;
+			if (lastReportingPeriod != null) funding.LastReportingPeriodId = lastReportingPeriod.Id;
 
 			context.Fundings.Add(funding);
 			context.SaveChanges();

--- a/test/HedwigTests/Helpers/ReportingPeriodHelper.cs
+++ b/test/HedwigTests/Helpers/ReportingPeriodHelper.cs
@@ -48,7 +48,7 @@ namespace HedwigTests.Helpers
 			};
 
 			context.Add(reportingPeriod);
-			context.SaveChanges(ignoreReadOnly: true);
+			context.SaveChanges();
 			return reportingPeriod;
 		}
 	}

--- a/test/HedwigTests/Models/Attributes/ReadOnlyAttributeTests.cs
+++ b/test/HedwigTests/Models/Attributes/ReadOnlyAttributeTests.cs
@@ -7,8 +7,11 @@ using HedwigTests.Fixtures;
 
 namespace HedwigTests.Models.Attributes
 {
-  [ReadOnly]
-  public class ReadOnlyEntity {}
+  public class Entity {
+    [ReadOnly]
+    public string ReadOnlyProperty { get; set; }
+    public string WriteableProperty { get; set; }
+  }
   public class ReadOnlyAttributeTests
   {
     [Theory]
@@ -19,10 +22,10 @@ namespace HedwigTests.Models.Attributes
     )
     {
       // if 
-      var entity = isReadOnly ? new ReadOnlyEntity() : new object();
+      var property = isReadOnly ? typeof(Entity).GetProperty("ReadOnlyProperty") : typeof(Entity).GetProperty("WriteableProperty");
 
       // when
-      var res = ReadOnlyAttribute.IsReadOnly(entity);
+      var res = ReadOnlyAttribute.IsReadOnly(property);
 
       // then
       Assert.Equal(isReadOnly, res);

--- a/test/HedwigTests/Repositories/EnrollmentRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/EnrollmentRepositoryTests.cs
@@ -19,12 +19,22 @@ namespace HedwigTests.Repositories
     public void UpdateEnrollment_UpdatesFundings()
     {
       Enrollment enrollment;
-      Funding funding;
       using (var context = new TestHedwigContextProvider().Context)
       {
         enrollment = EnrollmentHelper.CreateEnrollment(context);
-        funding = FundingHelper.CreateFunding(context, enrollment: enrollment);
+        FundingHelper.CreateFunding(context, enrollment: enrollment);
       }
+
+      // Unset recursive cyclical references
+      enrollment.Site.Organization.Sites = null;
+      enrollment.Site.Enrollments = null;
+      enrollment.Child.Enrollments = null;
+      enrollment.Child.Family.Children = null;
+      foreach(var funding in enrollment.Fundings)
+      {
+        funding.Enrollment = null;
+      }
+
       using (var context = new TestHedwigContextProvider().Context)
       {
         var enrollmentRepo = new EnrollmentRepository(context);
@@ -46,6 +56,15 @@ namespace HedwigTests.Repositories
         funding = FundingHelper.CreateFunding(context, enrollment: enrollment);
       }
 
+      // Unset recursive cyclical references
+      enrollment.Site.Organization.Sites = null;
+      enrollment.Site.Enrollments = null;
+      enrollment.Child.Enrollments = null;
+      enrollment.Child.Family.Children = null;
+      foreach(var _funding in enrollment.Fundings)
+      {
+        _funding.Enrollment = null;
+      }
       enrollment.Fundings = new List<Funding>();
 
       using (var contextProvider = new TestHedwigContextProvider()) 
@@ -67,6 +86,16 @@ namespace HedwigTests.Repositories
       {
         enrollment = EnrollmentHelper.CreateEnrollment(context);
         FundingHelper.CreateFunding(context, enrollment: enrollment);
+      }
+
+      // Unset recursive cyclical references
+      enrollment.Site.Organization.Sites = null;
+      enrollment.Site.Enrollments = null;
+      enrollment.Child.Enrollments = null;
+      enrollment.Child.Family.Children = null;
+      foreach(var funding in enrollment.Fundings)
+      {
+        funding.Enrollment = null;
       }
 
       enrollment.Fundings = new List<Funding>{

--- a/test/HedwigTests/Repositories/PermissionRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/PermissionRepositoryTests.cs
@@ -33,8 +33,8 @@ namespace HedwigTests.Repositories
             using( var context = new TestHedwigContextProvider().Context) {
                 // If user exists with organization permission that includes site
                 var user = UserHelper.CreateUser(context);
-                var site = SiteHelper.CreateSite(context);
-                var organization = OrganizationHelper.CreateOrganization(context, sites: new Site[]{site});
+                var organization = OrganizationHelper.CreateOrganization(context);
+                var site = SiteHelper.CreateSite(context, organization: organization);
                 PermissionHelper.CreateOrganizationPermission(context, user, organization);
 
                 // When repository is queried for user access to site


### PR DESCRIPTION
This is by no means a done deal. Interested in all yalls thoughts about this. Also there is a small mystery: 
When updating enrollment with duplicative  references to author (enrollment.Author = enrollment.Child.Author), I was seeing the bug described in #757 
HOWEVER, when trying to recreate the bug by having a funding point to the same reporting period twice (funding.FirstReportingPeriod = funding.LastReportingPeriod), I could not repro the error
So, not sure what's different between these two cases that leads to one causing a dbContext error and the other NOT.... But this feels like a more robust fix than https://github.com/ctoec/ecis-experimental/pull/759, and allows us to build programmatic processes to create Users/ReportingPeriods via Db context 