### PR TITLE
710 uncaught api error

### DIFF
--- a/src/Hedwig/ClientApp/src/components/Alert/Alert.tsx
+++ b/src/Hedwig/ClientApp/src/components/Alert/Alert.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+export type AlertType = 'success' | 'warning' | 'error' | 'info';
 export type AlertProps = {
-	type: 'success' | 'warning' | 'error' | 'info';
+	type: AlertType;
 	text: string | JSX.Element;
 	heading?: string;
 	actionItem?: JSX.Element;

--- a/src/Hedwig/ClientApp/src/containers/App/App.tsx
+++ b/src/Hedwig/ClientApp/src/containers/App/App.tsx
@@ -27,10 +27,13 @@ const App: React.FC = () => {
 		orgId: getIdForUser(user, 'org'),
 	};
 
-	const [loading, error, reports] = useApi(api => api.apiOrganizationsOrgIdReportsGet(params), [
-		user,
-		cacheInvalidator,
-	]);
+	const [loading, error, reports] = useApi(
+		api => api.apiOrganizationsOrgIdReportsGet(params),
+		[user, cacheInvalidator],
+		{
+			skip: !user,
+		}
+	);
 
 	const pendingReportsCount =
 		!loading &&

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
@@ -55,7 +55,7 @@ export default function EnrollmentDetail({
 		}
 	);
 
-	if (loading || error || !enrollment) {
+	if (loading || !enrollment) {
 		return <div className="EnrollmentDetail"></div>;
 	}
 
@@ -84,7 +84,7 @@ export default function EnrollmentDetail({
 					/>
 				</div>
 				{sections.map(section => {
-					var props: SectionProps = { siteId, enrollment, mutate };
+					var props: SectionProps = { siteId, enrollment, mutate, error };
 					const familyIncomeForFosterChild = section.key === 'family-income' && child.foster;
 					return (
 						<section key={section.key} className="oec-enrollment-details-section">

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.test.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import mockdate from 'mockdate';
 import { createBrowserHistory } from 'history';
-import { render, fireEvent, waitForElement, getAllByRole } from '@testing-library/react';
+import { render, getAllByRole } from '@testing-library/react';
 import 'react-dates/initialize';
 import CommonContextProviderMock, {
 	defaultCdcReportingPeriods,
 } from '../../../contexts/__mocks__/CommonContextProviderMock';
-import {
-	enrollmentMissingFirstName,
-	enrollmentMissingAddress,
-} from '../../../hooks/__mocks__/useApi';
+import { enrollmentMissingAddress } from '../../../hooks/__mocks__/useApi';
 import EnrollmentEdit from './EnrollmentEdit';
 import { accessibilityTestHelper } from '../../accessibilityTestHelper';
 import { completeEnrollment } from '../../../tests/data';
+import ChildInfo from '../_sections/ChildInfo';
+import { DeepNonUndefineable } from '../../../utils/types';
+import { Enrollment } from '../../../generated';
 
 const fakeDate = '2019-03-02';
 
@@ -30,36 +30,6 @@ afterAll(() => {
 const history = createBrowserHistory();
 
 describe('EnrollmentEdit', () => {
-	describe('child info', () => {
-		it('shows an error if rendered without a child first name', async () => {
-			const { getByText } = render(
-				<CommonContextProviderMock>
-					<EnrollmentEdit
-						history={history}
-						match={{
-							params: {
-								enrollmentId: enrollmentMissingFirstName.id,
-								sectionId: 'child-information',
-							},
-						}}
-					/>
-				</CommonContextProviderMock>
-			);
-
-			// Save without entering any data
-			fireEvent.click(getByText('Save'));
-			// TODO: also try with keyboard event?
-
-			const firstNameErr = await waitForElement(() =>
-				getByText('This information is required for enrollment')
-			);
-
-			expect(firstNameErr).toBeInTheDocument();
-			// TODO: the id needs to be updated-- this will probably mess things up
-			expect(firstNameErr.id).toBe('child-firstname-error');
-		});
-	});
-
 	describe('family info', () => {
 		it('shows a fieldset warning if there is no address', () => {
 			const { getByRole } = render(

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
@@ -110,7 +110,7 @@ export default function EnrollmentEdit({
 						siteId={siteId}
 						enrollment={enrollment}
 						mutate={mutate}
-					    error={error}
+					  error={error}
 						successCallback={afterSave}
 					/>
 				</ErrorBoundary>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
@@ -110,7 +110,7 @@ export default function EnrollmentEdit({
 						siteId={siteId}
 						enrollment={enrollment}
 						mutate={mutate}
-					  error={error}
+						error={error}
 						successCallback={afterSave}
 					/>
 				</ErrorBoundary>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
@@ -74,7 +74,7 @@ export default function EnrollmentEdit({
 		return <PageNotFound />;
 	}
 
-	if (loading || error || !enrollment) {
+	if (loading || !enrollment) {
 		return <div className="EnrollmentEdit"></div>;
 	}
 
@@ -110,6 +110,7 @@ export default function EnrollmentEdit({
 						siteId={siteId}
 						enrollment={enrollment}
 						mutate={mutate}
+					    error={error}
 						successCallback={afterSave}
 					/>
 				</ErrorBoundary>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.tsx
@@ -105,7 +105,7 @@ export default function EnrollmentEdit({
 			<div className="grid-container">
 				<h1>Edit {section.name.toLowerCase()}</h1>
 				<p className="usa-intro">{nameFormatter(enrollment.child)}</p>
-				<ErrorBoundary alertProps={editSaveFailAlert as AlertProps}>
+				<ErrorBoundary alertProps={editSaveFailAlert}>
 					<section.Form
 						siteId={siteId}
 						enrollment={enrollment}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.tsx
@@ -168,7 +168,7 @@ export default function EnrollmentNew({
 			<div className="grid-container">
 				<h1>Enroll child</h1>
 				<div className="margin-top-2 margin-bottom-5">
-					<ErrorBoundary alertProps={stepListSaveFailAlert as AlertProps}>
+					<ErrorBoundary alertProps={stepListSaveFailAlert}>
 						<StepList steps={steps} activeStep={sectionId} props={props} />
 					</ErrorBoundary>
 				</div>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.tsx
@@ -146,7 +146,7 @@ export default function EnrollmentNew({
 		}
 	};
 
-	if (loading || error || !user) {
+	if (loading || !user) {
 		// Need to add user here so that a refresh after partial enrollment doesn't crash
 		return <div className="EnrollmentNew"></div>;
 	}
@@ -156,6 +156,7 @@ export default function EnrollmentNew({
 	const props: SectionProps = {
 		enrollment: enrollment,
 		mutate: mutate,
+		error: error,
 		successCallback: afterSave,
 		finallyCallback: visitSection,
 		siteId,

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ChildInfo from './ChildInfo';
+import { DeepNonUndefineable } from '../../../utils/types';
+import { Enrollment } from '../../../generated';
+
+jest.mock('../../../hooks/useApi');
+
+describe('enrollment sections', () => {
+	describe('ChildInfo', () => {
+		it('shows an error if rendered without a child first name', async () => {
+			const { findByText } = render(
+				<ChildInfo.Form
+					siteId={1}
+					enrollment={{} as DeepNonUndefineable<Enrollment>}
+					mutate={async () => {}}
+					error={{
+						errors: { 'Child.FirstName': ['error'] },
+						status: 400,
+					}}
+				/>
+			);
+
+			// TODO: the id needs to be updated-- this will probably mess things up
+			const firstNameErr = await findByText('This information is required for enrollment');
+			expect(firstNameErr.id).toBe('child-firstname-error');
+		});
+
+		it('shows an error if rendered without a child last name', async () => {
+			const { findByText } = render(
+				<ChildInfo.Form
+					siteId={1}
+					enrollment={{} as DeepNonUndefineable<Enrollment>}
+					mutate={async () => {}}
+					error={{
+						errors: { 'Child.LastName': ['error'] },
+						status: 400,
+					}}
+				/>
+			);
+
+			const lastNameErr = await findByText('This information is required for enrollment');
+			expect(lastNameErr.id).toBe('child-lastname-error');
+		});
+	});
+});

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.test.tsx
@@ -21,9 +21,8 @@ describe('enrollment sections', () => {
 				/>
 			);
 
-			// TODO: the id needs to be updated-- this will probably mess things up
-			const firstNameErr = await findByText('This information is required for enrollment');
-			expect(firstNameErr.id).toBe('child-firstname-error');
+			const firstNameInput = (await findByText('First name')).closest('div');
+			expect(firstNameInput).toHaveTextContent('This information is required for enrollment');
 		});
 
 		it('shows an error if rendered without a child last name', async () => {
@@ -39,8 +38,8 @@ describe('enrollment sections', () => {
 				/>
 			);
 
-			const lastNameErr = await findByText('This information is required for enrollment');
-			expect(lastNameErr.id).toBe('child-lastname-error');
+			const lastNameInput = (await findByText('Last name')).closest('div');
+			expect(lastNameInput).toHaveTextContent('This information is required for enrollment');
 		});
 	});
 });

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
@@ -58,7 +58,7 @@ const ChildInfo: Section = {
 		);
 	},
 
-	Form: ({ enrollment, siteId, mutate, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
 		if (!enrollment && !siteId) {
 			throw new Error('ChildInfo rendered without an enrollment or a siteId');
 		}
@@ -151,9 +151,7 @@ const ChildInfo: Section = {
 			...childRaceArgs,
 		};
 
-		const [apiError, setApiError] = useState<ValidationProblemDetails>();
-
-		useFocusFirstError([apiError]);
+		useFocusFirstError([error]);
 
 		const _save = () => {
 			if (enrollment) {
@@ -173,9 +171,6 @@ const ChildInfo: Section = {
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(putParams))
 					.then(res => {
 						if (successCallback && res) successCallback(res);
-					})
-					.catch(error => {
-						setApiError(ValidationProblemDetailsFromJSON(error));
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(ChildInfo);
@@ -197,10 +192,7 @@ const ChildInfo: Section = {
 				};
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsPost(postParams))
 					.then(res => {
-						if (successCallback && res) successCallback(res);
-					})
-					.catch(error => {
-						setApiError(ValidationProblemDetailsFromJSON(error));
+						if (successCallback && res && !error) successCallback(res);
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(ChildInfo);
@@ -237,7 +229,7 @@ const ChildInfo: Section = {
 								initialLoad,
 								serverErrorForField(
 									'child.firstname',
-									apiError,
+									error,
 									'This information is required for enrollment'
 								)
 							)}
@@ -265,7 +257,7 @@ const ChildInfo: Section = {
 									initialLoad,
 									serverErrorForField(
 										'child.lastname',
-										apiError,
+										error,
 										'This information is required for enrollment'
 									)
 								)}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
@@ -29,7 +29,7 @@ import {
 	warningForField,
 	serverErrorForField,
 	initialLoadErrorGuard,
-	isBlockingValidationError 
+	isBlockingValidationError,
 } from '../../../utils/validations';
 import usePromiseExecution from '../../../hooks/usePromiseExecution';
 import { validationErrorAlert } from '../../../utils/stringFormatters/alertTextMakers';
@@ -59,7 +59,15 @@ const ChildInfo: Section = {
 		);
 	},
 
-	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({
+		enrollment,
+		siteId,
+		mutate,
+		error,
+		successCallback,
+		finallyCallback,
+		visitedSections,
+	}) => {
 		if (!enrollment && !siteId) {
 			throw new Error('ChildInfo rendered without an enrollment or a siteId');
 		}
@@ -70,9 +78,9 @@ const ChildInfo: Section = {
 		const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
 		useFocusFirstError([error]);
 		useEffect(() => {
-			if(error && !hasAlertedOnError) {
-				if(!isBlockingValidationError(error)) {
-						throw new Error(error.title || 'Unknown api error');
+			if (error && !hasAlertedOnError) {
+				if (!isBlockingValidationError(error)) {
+					throw new Error(error.title || 'Unknown api error');
 				}
 				setAlerts([validationErrorAlert]);
 			}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
@@ -140,7 +140,15 @@ const EnrollmentFunding: Section = {
 		);
 	},
 
-	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({
+		enrollment,
+		siteId,
+		mutate,
+		error,
+		successCallback,
+		finallyCallback,
+		visitedSections,
+	}) => {
 		if (!enrollment) {
 			throw new Error('EnrollmentFunding rendered without an enrollment');
 		}
@@ -151,8 +159,8 @@ const EnrollmentFunding: Section = {
 		const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
 		useFocusFirstError([error]);
 		useEffect(() => {
-			if(error && !hasAlertedOnError) {
-				if(!isBlockingValidationError(error)) {
+			if (error && !hasAlertedOnError) {
+				if (!isBlockingValidationError(error)) {
 					throw new Error(error.title || 'Unknown api error');
 				}
 				setAlerts([validationErrorAlert]);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
@@ -138,7 +138,7 @@ const EnrollmentFunding: Section = {
 		);
 	},
 
-	Form: ({ enrollment, siteId, mutate, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
 		if (!enrollment) {
 			throw new Error('EnrollmentFunding rendered without an enrollment');
 		}
@@ -219,8 +219,6 @@ const EnrollmentFunding: Section = {
 			updateReportingPeriodOptions([...periods].sort(periodSorter));
 		}, [enrollment.entry, entry, reportingPeriods]);
 
-		const [apiError, setApiError] = useState<ValidationProblemDetails>();
-
 		const _save = () => {
 			let updatedFundings: Funding[] = [...fundings]
 				.filter(funding => funding.id !== (sourcelessFunding && sourcelessFunding.id))
@@ -298,10 +296,7 @@ const EnrollmentFunding: Section = {
 
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
 					.then(res => {
-						if (successCallback && res) successCallback(res);
-					})
-					.catch(error => {
-						setApiError(ValidationProblemDetailsFromJSON(error));
+						if (successCallback && res && !error) successCallback(res);
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(EnrollmentFunding);
@@ -484,7 +479,7 @@ const EnrollmentFunding: Section = {
 							selected={toFormString(cdcReportingPeriod ? cdcReportingPeriod.id : undefined)}
 							status={initialLoadErrorGuard(
 								initialLoad,
-								serverErrorForField('fundings', apiError) ||
+								serverErrorForField('fundings', error) ||
 									warningForField(
 										'firstReportingPeriod',
 										cdcFunding || null,

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
@@ -95,7 +95,15 @@ const FamilyIncome: Section = {
 		return <div className="FamilyIncomeSummary">{elementToReturn}</div>;
 	},
 
-	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({
+		enrollment,
+		siteId,
+		mutate,
+		error,
+		successCallback,
+		finallyCallback,
+		visitedSections,
+	}) => {
 		if (!enrollment || !enrollment.child || !enrollment.child.family) {
 			throw new Error('FamilyIncome rendered without enrollment.child.family');
 		}
@@ -105,8 +113,8 @@ const FamilyIncome: Section = {
 		const initialLoad = visitedSections ? !visitedSections[FamilyIncome.key] : false;
 		const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
 		useEffect(() => {
-			if(error && !hasAlertedOnError) {
-				if(!isBlockingValidationError(error)) {
+			if (error && !hasAlertedOnError) {
+				if (!isBlockingValidationError(error)) {
 					throw new Error(error.title || 'Unknown api error');
 				}
 				setAlerts([validationErrorAlert]);
@@ -169,15 +177,13 @@ const FamilyIncome: Section = {
 						},
 					},
 				};
-				return (
-					mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
-						.then(res => {
-							if (successCallback && res && !error) successCallback(res);
-						})
-						.finally(() => {
-							finallyCallback && finallyCallback(FamilyIncome);
-						})
-				);
+				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
+					.then(res => {
+						if (successCallback && res && !error) successCallback(res);
+					})
+					.finally(() => {
+						finallyCallback && finallyCallback(FamilyIncome);
+					});
 			}
 			return new Promise(() => {});
 			// TODO: what should happen if there is no enrollment, child, or family?  See also family info and enrollment funding

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
@@ -92,7 +92,7 @@ const FamilyIncome: Section = {
 		return <div className="FamilyIncomeSummary">{elementToReturn}</div>;
 	},
 
-	Form: ({ enrollment, siteId, mutate, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
 		if (!enrollment || !enrollment.child || !enrollment.child.family) {
 			throw new Error('FamilyIncome rendered without enrollment.child.family');
 		}
@@ -158,10 +158,8 @@ const FamilyIncome: Section = {
 				return (
 					mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
 						.then(res => {
-							if (successCallback && res) successCallback(res);
+							if (successCallback && res && !error) successCallback(res);
 						})
-						// TODO deal with error from server
-						.catch()
 						.finally(() => {
 							finallyCallback && finallyCallback(FamilyIncome);
 						})

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import idx from 'idx';
 import { Section } from '../enrollmentTypes';
 import { Button, TextInput, ChoiceList, FieldSet } from '../../../components';
@@ -9,10 +9,14 @@ import {
 	sectionHasValidationErrors,
 	warningForFieldSet,
 	warningForField,
+	initialLoadErrorGuard, 
+	useFocusFirstError
 } from '../../../utils/validations';
 import { addressFormatter, homelessnessText, fosterText } from '../../../utils/models';
-import initialLoadErrorGuard from '../../../utils/validations/initialLoadErrorGuard';
 import usePromiseExecution from '../../../hooks/usePromiseExecution';
+import { isBlockingValidationError } from '../../../utils/validations/isBlockingValidationError';
+import { validationErrorAlert } from '../../../utils/stringFormatters/alertTextMakers';
+import AlertContext from '../../../contexts/Alert/AlertContext';
 
 const FamilyInfo: Section = {
 	key: 'family-information',
@@ -49,7 +53,20 @@ const FamilyInfo: Section = {
 			throw new Error('FamilyInfo rendered without a child');
 		}
 
+		// set up form state
+		const { setAlerts } = useContext(AlertContext);
 		const initialLoad = visitedSections ? !visitedSections[FamilyInfo.key] : false;
+		const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
+		useFocusFirstError([error]);
+		useEffect(() => {
+			if(error && !hasAlertedOnError) {
+				if(!isBlockingValidationError(error)) {
+					throw new Error(error.title || 'Unknown api error');
+				}
+				setAlerts([validationErrorAlert]);
+			}
+		}, [error, hasAlertedOnError]);
+
 
 		const child = enrollment.child;
 		const { user } = useContext(UserContext);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
@@ -9,8 +9,8 @@ import {
 	sectionHasValidationErrors,
 	warningForFieldSet,
 	warningForField,
-	initialLoadErrorGuard, 
-	useFocusFirstError
+	initialLoadErrorGuard,
+	useFocusFirstError,
 } from '../../../utils/validations';
 import { addressFormatter, homelessnessText, fosterText } from '../../../utils/models';
 import usePromiseExecution from '../../../hooks/usePromiseExecution';
@@ -48,7 +48,15 @@ const FamilyInfo: Section = {
 		);
 	},
 
-	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({
+		enrollment,
+		siteId,
+		mutate,
+		error,
+		successCallback,
+		finallyCallback,
+		visitedSections,
+	}) => {
 		if (!enrollment || !enrollment.child) {
 			throw new Error('FamilyInfo rendered without a child');
 		}
@@ -59,14 +67,13 @@ const FamilyInfo: Section = {
 		const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
 		useFocusFirstError([error]);
 		useEffect(() => {
-			if(error && !hasAlertedOnError) {
-				if(!isBlockingValidationError(error)) {
+			if (error && !hasAlertedOnError) {
+				if (!isBlockingValidationError(error)) {
 					throw new Error(error.title || 'Unknown api error');
 				}
 				setAlerts([validationErrorAlert]);
 			}
 		}, [error, hasAlertedOnError]);
-
 
 		const child = enrollment.child;
 		const { user } = useContext(UserContext);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
@@ -44,7 +44,7 @@ const FamilyInfo: Section = {
 		);
 	},
 
-	Form: ({ enrollment, siteId, mutate, successCallback, finallyCallback, visitedSections }) => {
+	Form: ({ enrollment, siteId, mutate, error, successCallback, finallyCallback, visitedSections }) => {
 		if (!enrollment || !enrollment.child) {
 			throw new Error('FamilyInfo rendered without a child');
 		}
@@ -105,7 +105,7 @@ const FamilyInfo: Section = {
 				};
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
 					.then(res => {
-						if (successCallback && res) successCallback(res);
+						if (successCallback && res && !error) successCallback(res);
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(FamilyInfo);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/enrollmentTypes.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/enrollmentTypes.tsx
@@ -2,10 +2,12 @@ import { StepStatus } from '../../components/StepList/StepList';
 import { Enrollment } from '../../generated';
 import { Mutate } from '../../hooks/useApi';
 import { DeepNonUndefineable } from '../../utils/types';
+import { ApiError } from '../../hooks/useApi';
 
 export type SectionProps = {
 	enrollment: DeepNonUndefineable<Enrollment> | null;
 	mutate: Mutate<Enrollment>;
+	error: ApiError | null;
 	successCallback?: (e: Enrollment) => void;
 	finallyCallback?: (s: Section) => void;
 	siteId: number;

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/enrollmentTypes.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/enrollmentTypes.tsx
@@ -3,6 +3,7 @@ import { Enrollment } from '../../generated';
 import { Mutate } from '../../hooks/useApi';
 import { DeepNonUndefineable } from '../../utils/types';
 import { ApiError } from '../../hooks/useApi';
+import { AlertProps } from '../../components';
 
 export type SectionProps = {
 	enrollment: DeepNonUndefineable<Enrollment> | null;

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/enrollmentTypes.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/enrollmentTypes.tsx
@@ -3,7 +3,6 @@ import { Enrollment } from '../../generated';
 import { Mutate } from '../../hooks/useApi';
 import { DeepNonUndefineable } from '../../utils/types';
 import { ApiError } from '../../hooks/useApi';
-import { AlertProps } from '../../components';
 
 export type SectionProps = {
 	enrollment: DeepNonUndefineable<Enrollment> | null;

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.tsx
@@ -77,6 +77,7 @@ export default function ReportDetail() {
 				<ReportSubmitForm
 					report={report}
 					mutate={mutate}
+					error={error}
 					canSubmit={numEnrollmentsMissingInfo === 0}
 				/>
 			</div>

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.tsx
@@ -34,14 +34,6 @@ export default function ReportDetail() {
 
 	let additionalAlerts: AlertProps[] = [];
 
-	if (error) {
-		additionalAlerts.push({
-			type: 'error',
-			heading: 'Something went wrong',
-			text: 'There was an error loading the report',
-		});
-	}
-
 	if (numEnrollmentsMissingInfo) {
 		additionalAlerts.push(updateRosterAlert(numEnrollmentsMissingInfo));
 	}

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
@@ -26,7 +26,7 @@ import {
 	useFocusFirstError,
 	serverErrorForField,
 	clientErrorForField,
-    isBlockingValidationError,
+	isBlockingValidationError,
 } from '../../../utils/validations';
 import usePromiseExecution from '../../../hooks/usePromiseExecution';
 import { reportSubmittedAlert, reportSubmitFailAlert } from '../../../utils/stringFormatters';
@@ -40,7 +40,12 @@ export type ReportSubmitFormProps = {
 	canSubmit: boolean;
 };
 
-export default function ReportSubmitForm({ report, mutate, error, canSubmit }: ReportSubmitFormProps) {
+export default function ReportSubmitForm({
+	report,
+	mutate,
+	error,
+	canSubmit,
+}: ReportSubmitFormProps) {
 	const history = useHistory();
 	const asOf = report.submittedAt ? report.submittedAt : undefined;
 	const [accredited, setAccredited] = useState(report.accredited);
@@ -91,8 +96,8 @@ export default function ReportSubmitForm({ report, mutate, error, canSubmit }: R
 	useFocusFirstError([error]);
 	const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
 	useEffect(() => {
-		if(error && !hasAlertedOnError) {
-			if(!isBlockingValidationError(error)) {
+		if (error && !hasAlertedOnError) {
+			if (!isBlockingValidationError(error)) {
 				throw new Error(error.title || 'Unknown api error');
 			}
 			setAlerts([validationErrorAlert]);
@@ -116,16 +121,15 @@ export default function ReportSubmitForm({ report, mutate, error, canSubmit }: R
 				...params,
 				cdcReport: updatedReport(),
 			})
-		)
-			.then(res => {
-				if (res) {
-					const newAlert = reportSubmittedAlert(report.reportingPeriod);
-					const newAlerts = [...alerts, newAlert];
-					setAlerts(newAlerts);
-					invalidateAppCache(); // Updates the count of unsubmitted reports in the nav bar
-					history.push('/reports', newAlerts);
-				}
-			})
+		).then(res => {
+			if (res) {
+				const newAlert = reportSubmittedAlert(report.reportingPeriod);
+				const newAlerts = [...alerts, newAlert];
+				setAlerts(newAlerts);
+				invalidateAppCache(); // Updates the count of unsubmitted reports in the nav bar
+				history.push('/reports', newAlerts);
+			}
+		});
 	}
 	const { isExecuting: isMutating, setExecuting: onSubmit } = usePromiseExecution(_onSubmit);
 

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, FormEvent } from 'react';
 import {
 	CdcReport,
 	ApiOrganizationsOrgIdReportsIdPutRequest,
 	ApiOrganizationsOrgIdEnrollmentsGetRequest,
 } from '../../../generated';
-import useApi, { Mutate } from '../../../hooks/useApi';
+import useApi, { Mutate, ApiError } from '../../../hooks/useApi';
 import UserContext from '../../../contexts/User/UserContext';
 import {
 	Button,
@@ -35,10 +35,11 @@ import pluralize from 'pluralize';
 export type ReportSubmitFormProps = {
 	report: DeepNonUndefineable<CdcReport>;
 	mutate: Mutate<CdcReport>;
+	error: ApiError | null;
 	canSubmit: boolean;
 };
 
-export default function ReportSubmitForm({ report, mutate, canSubmit }: ReportSubmitFormProps) {
+export default function ReportSubmitForm({ report, mutate, error, canSubmit }: ReportSubmitFormProps) {
 	const history = useHistory();
 	const asOf = report.submittedAt ? report.submittedAt : undefined;
 	const [accredited, setAccredited] = useState(report.accredited);
@@ -85,9 +86,7 @@ export default function ReportSubmitForm({ report, mutate, canSubmit }: ReportSu
 		}
 	}, [allEnrollments]);
 
-	const [apiError, setApiError] = useState<ValidationProblemDetails>();
-
-	useFocusFirstError([apiError]);
+	useFocusFirstError([error]);
 
 	function updatedReport(): CdcReport {
 		return {
@@ -116,9 +115,6 @@ export default function ReportSubmitForm({ report, mutate, canSubmit }: ReportSu
 					history.push('/reports', newAlerts);
 				}
 			})
-			.catch(error => {
-				setApiError(ValidationProblemDetailsFromJSON(error));
-			});
 	}
 	const { isExecuting: isMutating, setExecuting: onSubmit } = usePromiseExecution(_onSubmit);
 
@@ -168,8 +164,8 @@ export default function ReportSubmitForm({ report, mutate, canSubmit }: ReportSu
 						optional={true}
 						disabled={!!report.submittedAt}
 						status={serverErrorForField(
-							'c4krevenue',
-							apiError,
+							'report.c4krevenue',
+							error,
 							'This information is required for the report'
 						)}
 					/>
@@ -200,7 +196,7 @@ export default function ReportSubmitForm({ report, mutate, canSubmit }: ReportSu
 						disabled={!!report.submittedAt}
 						status={serverErrorForField(
 							'familyfeesrevenue',
-							apiError,
+							error,
 							'This information is required'
 						)}
 					/>

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, FormEvent } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import {
 	CdcReport,
 	ApiOrganizationsOrgIdReportsIdPutRequest,
@@ -6,14 +6,7 @@ import {
 } from '../../../generated';
 import useApi, { Mutate, ApiError } from '../../../hooks/useApi';
 import UserContext from '../../../contexts/User/UserContext';
-import {
-	Button,
-	TextInput,
-	ChoiceList,
-	AlertProps,
-	FieldSet,
-	ErrorBoundary,
-} from '../../../components';
+import { Button, TextInput, ChoiceList, FieldSet, ErrorBoundary } from '../../../components';
 import AppContext from '../../../contexts/App/AppContext';
 import currencyFormatter from '../../../utils/currencyFormatter';
 import parseCurrencyFromString from '../../../utils/parseCurrencyFromString';
@@ -25,7 +18,6 @@ import { DeepNonUndefineable } from '../../../utils/types';
 import {
 	useFocusFirstError,
 	serverErrorForField,
-	clientErrorForField,
 	isBlockingValidationError,
 } from '../../../utils/validations';
 import usePromiseExecution from '../../../hooks/usePromiseExecution';
@@ -134,7 +126,7 @@ export default function ReportSubmitForm({
 	const { isExecuting: isMutating, setExecuting: onSubmit } = usePromiseExecution(_onSubmit);
 
 	return (
-		<ErrorBoundary alertProps={reportSubmitFailAlert as AlertProps}>
+		<ErrorBoundary alertProps={reportSubmitFailAlert}>
 			{report.submittedAt && (
 				<p>
 					<b>Submitted:</b> {report.submittedAt.toLocaleDateString()}{' '}

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportDetail.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportDetail.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ReportDetail matches snapshot 1`] = `
           <p
             class="usa-alert__text"
           >
-            There are 3 enrollments missing information required to submit this report.
+            There are 2 enrollments missing information required to submit this report.
           </p>
         </div>
         <div
@@ -193,7 +193,7 @@ exports[`ReportDetail matches snapshot 1`] = `
           <td
             class=" oec-table__cell--red"
           >
-            5/2 spaces
+            4/2 spaces
           </td>
           <td>
             $165.32
@@ -218,7 +218,7 @@ exports[`ReportDetail matches snapshot 1`] = `
           <td
             class="oec-table__cell--strong oec-table__cell--red"
           >
-            5/2 spaces
+            4/2 spaces
           </td>
           <td />
           <td

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportSubmitForm.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportSubmitForm.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`ReportSubmitForm matches snapshot 1`] = `
         <td
           class=" oec-table__cell--red"
         >
-          5/2 spaces
+          4/2 spaces
         </td>
         <td>
           $165.32
@@ -136,7 +136,7 @@ exports[`ReportSubmitForm matches snapshot 1`] = `
         <td
           class="oec-table__cell--strong oec-table__cell--red"
         >
-          5/2 spaces
+          4/2 spaces
         </td>
         <td />
         <td

--- a/src/Hedwig/ClientApp/src/containers/Roster/Roster.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/Roster.test.tsx
@@ -54,7 +54,7 @@ describe('Roster', () => {
 			</CommonContextProviderMock>
 		);
 
-		expect(baseElement).toHaveTextContent(/5 children enrolled/i);
+		expect(baseElement).toHaveTextContent(/\d children enrolled/i);
 	});
 
 	it('updates the number of children', async () => {
@@ -80,7 +80,7 @@ describe('Roster', () => {
 
 		await wait(() => {
 			expect(baseElement).toHaveTextContent(
-				/4 children were enrolled between January 1, 2018 and February 1, 2019/i
+				/\d children were enrolled between January 1, 2018 and February 1, 2019/i
 			);
 		});
 	});

--- a/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
@@ -44,7 +44,8 @@ export default function Roster() {
 	};
 	const [organizationLoading, organizationError, organization] = useApi(
 		api => api.apiOrganizationsIdGet(orgParams),
-		[user]
+		[user],
+		{ skip: !user }
 	);
 
 	const sites = organization && organization.sites;
@@ -59,9 +60,11 @@ export default function Roster() {
 		startDate: (dateRange && dateRange.startDate && dateRange.startDate.toDate()) || undefined,
 		endDate: (dateRange && dateRange.endDate && dateRange.endDate.toDate()) || undefined,
 	};
+
 	const [enrollmentLoading, enrollmentError, _enrollments] = useApi(
 		api => api.apiOrganizationsOrgIdEnrollmentsGet(enrollmentParams),
-		[user, dateRange, organization]
+		[user, dateRange, organization],
+		{ skip: !user || !siteIds.length }
 	);
 
 	if (

--- a/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Roster matches snapshot 1`] = `
         <p
           class="intro display-flex flex-row flex-wrap flex-justify-start"
         >
-          5 children enrolled. 
+          4 children enrolled. 
           <button
             class="usa-button usa-button--unstyled"
             type="button"
@@ -75,7 +75,7 @@ exports[`Roster matches snapshot 1`] = `
           <span
             class="text-bold"
           >
-            5/2
+            4/2
           </span>
           <span>
              Child Day Care spaces filled
@@ -107,7 +107,7 @@ exports[`Roster matches snapshot 1`] = `
           <span
             class="text-bold"
           >
-            3
+            2
           </span>
           <span>
              missing information
@@ -118,7 +118,7 @@ exports[`Roster matches snapshot 1`] = `
     <h2
       class="margin-top-6"
     >
-      Preschool (5 children)
+      Preschool (4 children)
     </h2>
     <ul />
     <table
@@ -368,48 +368,6 @@ exports[`Roster matches snapshot 1`] = `
             class="oec-table__cell--tabular-nums"
           >
             03/01/2019
-          </td>
-        </tr>
-        <tr>
-          <th
-            scope="row"
-          >
-            <a
-              class="usa-link print"
-              href="/roster/sites/1/enrollments/3/"
-            >
-              Potter, undefined Luna
-            </a>
-             
-            <span
-              class="oec-inline-icon oec-inline-icon--incomplete"
-            >
-              <svg>
-                error.svg
-              </svg>
-              <span
-                class="usa-sr-only"
-              >
-                (incomplete)
-              </span>
-            </span>
-          </th>
-          <td
-            class="oec-table__cell--tabular-nums"
-          >
-            12/12/2016
-          </td>
-          <td>
-            <span
-              class="usa-tag undefined bg-blue-50v"
-            >
-              CDC–FT
-            </span>
-          </td>
-          <td
-            class="oec-table__cell--tabular-nums"
-          >
-            02/03/2018
           </td>
         </tr>
       </tbody>

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
@@ -34,7 +34,10 @@ import {
 import ReportingPeriodContext from '../../contexts/ReportingPeriod/ReportingPeriodContext';
 import { processBlockingValidationErrors } from '../../utils/validations/processBlockingValidationErrors';
 import AlertContext from '../../contexts/Alert/AlertContext';
-import { validationErrorAlert, missingInformationForWithdrawalAlert } from '../../utils/stringFormatters/alertTextMakers';
+import {
+	validationErrorAlert,
+	missingInformationForWithdrawalAlert,
+} from '../../utils/stringFormatters/alertTextMakers';
 
 type WithdrawalProps = {
 	history: History;
@@ -93,8 +96,8 @@ export default function Withdrawal({
 	useFocusFirstError([error]);
 	const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
 	useEffect(() => {
-		if(error && !hasAlertedOnError) {
-			if(!isBlockingValidationError(error)) {
+		if (error && !hasAlertedOnError) {
+			if (!isBlockingValidationError(error)) {
 				throw new Error(error.title || 'Unknown api error');
 			}
 			setAlerts([validationErrorAlert]);
@@ -117,7 +120,6 @@ export default function Withdrawal({
 			history.push(`/roster/sites/${siteId}/enrollments/${enrollment.id}`);
 		}
 	}, [enrollment, isMissingInformation, history, setAlerts]);
-
 
 	if (loading || !enrollment) {
 		return <div className="Withdrawl"></div>;
@@ -165,13 +167,12 @@ export default function Withdrawal({
 			},
 		};
 
-		mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(putParams))
-			.then(() => {
-				if(!error) {
-				    setAlerts([childWithdrawnAlert(nameFormatter(enrollment.child))]);
-					history.push(`/roster`);
-				}
-			});
+		mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(putParams)).then(() => {
+			if (!error) {
+				setAlerts([childWithdrawnAlert(nameFormatter(enrollment.child))]);
+				history.push(`/roster`);
+			}
+		});
 	};
 
 	return (
@@ -221,7 +222,11 @@ export default function Withdrawal({
 										message:
 											'ECE Reporter only contains data for fiscal year 2020 and later. Please do not add children who withdrew prior to July 2019.',
 								  }
-								: error && processBlockingValidationErrors('exit', (error as ValidationProblemDetails).errors)
+								: error &&
+								  processBlockingValidationErrors(
+										'exit',
+										(error as ValidationProblemDetails).errors
+								  )
 								? serverErrorForField(hasAlertedOnError, setHasAlertedOnError, 'exit', error)
 								: clientErrorForField(
 										'exit',

--- a/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
@@ -147,10 +147,10 @@ export const mockApi = {
 		let error = null;
 		if (!thisEnrollment) return;
 		const mutate = (_: any) => {
-			return new Promise((resolve) => {
-				if(thisEnrollment.mutationError) {
+			return new Promise(resolve => {
+				if (thisEnrollment.mutationError) {
 					error = thisEnrollment.mutationError;
-					return; 
+					return;
 				}
 				resolve(thisEnrollment.enrollment);
 			});

--- a/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
@@ -23,12 +23,6 @@ export const enrollmentMissingBirthCertId = swapFields(completeEnrollment, [
 	{ keys: ['validationErrors'], newValue: enrollmentValidationError },
 ]);
 
-export const enrollmentMissingFirstName = swapFields(completeEnrollment, [
-	{ keys: ['child', 'firstName'], newValue: undefined },
-	{ keys: ['id'], newValue: 3 },
-	{ keys: ['validationErrors'], newValue: enrollmentValidationError },
-]);
-
 export const enrollmentMissingAddress = swapFields(completeEnrollment, [
 	{ keys: ['child', 'family', 'addressLine1'], newValue: undefined },
 	{ keys: ['id'], newValue: 4 },
@@ -63,15 +57,6 @@ export const allFakeEnrollments = [
 	},
 	{
 		enrollment: enrollmentMissingBirthCertId,
-	},
-	{
-		enrollment: enrollmentMissingFirstName,
-		mutationError: {
-			errors: { 'Child.FirstName': ['The FirstName field is required.'] },
-			type: 'https://tools.ietf.org/html/rfc7231#section-6.5.1',
-			title: 'One or more validation errors occurred.',
-			status: 400,
-		},
 	},
 	{
 		enrollment: enrollmentMissingAddress,
@@ -148,10 +133,6 @@ export const mockApi = {
 		if (!thisEnrollment) return;
 		const mutate = (_: any) => {
 			return new Promise(resolve => {
-				if (thisEnrollment.mutationError) {
-					error = thisEnrollment.mutationError;
-					return;
-				}
 				resolve(thisEnrollment.enrollment);
 			});
 		};

--- a/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
@@ -144,15 +144,18 @@ export const mockApi = {
 		params: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest
 	) => {
 		const thisEnrollment = allFakeEnrollments.find(e => e.enrollment.id === params.id);
+		let error = null;
 		if (!thisEnrollment) return;
 		const mutate = (_: any) => {
-			return new Promise((resolve, reject) => {
-				thisEnrollment.mutationError
-					? reject(thisEnrollment.mutationError)
-					: resolve(thisEnrollment.enrollment);
+			return new Promise((resolve) => {
+				if(thisEnrollment.mutationError) {
+					error = thisEnrollment.mutationError;
+					return; 
+				}
+				resolve(thisEnrollment.enrollment);
 			});
 		};
-		return [false, null, thisEnrollment.enrollment, mutate];
+		return [false, error, thisEnrollment.enrollment, mutate];
 	},
 	apiOrganizationsOrgIdChildrenGet: (params: any) => {
 		const mappedChildToEnrollment = [child].reduce<{ [x: string]: Enrollment[] }>((acc, c) => {

--- a/src/Hedwig/ClientApp/src/hooks/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useApi.ts
@@ -82,10 +82,10 @@ export default function useApi<TData>(
 
 		let apiError: ApiError | null = null;
 		if(jsonResponse) {
-			if (error.state === 400) {
-				apiError = ValidationProblemDetailsFromJSON(await error.json()) || null;
+			if (error.status === 400) {
+				apiError = ValidationProblemDetailsFromJSON(jsonResponse) || null;
 			} else {
-				apiError = ProblemDetailsFromJSON(await error.json()) || null;
+				apiError = ProblemDetailsFromJSON(jsonResponse) || null;
 			}
 		}
 

--- a/src/Hedwig/ClientApp/src/hooks/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useApi.ts
@@ -1,5 +1,18 @@
-import { useContext, useEffect, useState, DependencyList, useCallback, Dispatch, SetStateAction } from 'react';
-import { Configuration, HedwigApi, ValidationProblemDetailsFromJSON, ProblemDetailsFromJSON } from '../generated';
+import {
+	useContext,
+	useEffect,
+	useState,
+	DependencyList,
+	useCallback,
+	Dispatch,
+	SetStateAction,
+} from 'react';
+import {
+	Configuration,
+	HedwigApi,
+	ValidationProblemDetailsFromJSON,
+	ProblemDetailsFromJSON,
+} from '../generated';
 import getCurrentHost from '../utils/getCurrentHost';
 import AuthenticationContext from '../contexts/Authentication/AuthenticationContext';
 import { DeepNonUndefineable } from '../utils/types';
@@ -12,7 +25,7 @@ export type Query<TData> = (api: HedwigApi) => Promise<TData>;
 export type Mutate<TData> = (
 	query: Query<TData>,
 	reducer?: Reducer<TData | undefined>
-) => Promise<TData | void>
+) => Promise<TData | void>;
 
 interface ApiParamOpts<T> {
 	defaultValue?: T;
@@ -22,14 +35,14 @@ interface ApiParamOpts<T> {
 
 interface ApiState<T> {
 	loading: boolean;
-	error: ApiError | null,
+	error: ApiError | null;
 	data?: T;
 	skip: boolean;
 }
 
 export type ApiResult<TData> = [
 	boolean,
-	(ApiError | null),
+	ApiError | null,
 	DeepNonUndefineable<TData>,
 	Mutate<TData>
 ];
@@ -73,7 +86,7 @@ export default function useApi<TData>(
 		  )
 		: null;
 
-  // Create error parsing function
+	// Create error parsing function
 	const handleError = async (error: any) => {
 		let jsonResponse: Object | null = null;
 		try {
@@ -81,7 +94,7 @@ export default function useApi<TData>(
 		} catch {}
 
 		let apiError: ApiError | null = null;
-		if(jsonResponse) {
+		if (jsonResponse) {
 			if (error.status === 400) {
 				apiError = ValidationProblemDetailsFromJSON(jsonResponse) || null;
 			} else {
@@ -89,10 +102,10 @@ export default function useApi<TData>(
 			}
 		}
 
-		setState((state) => {
-			return {...state, error: apiError}
+		setState(state => {
+			return { ...state, error: apiError };
 		});
-	}
+	};
 
 	// Create mutate function
 	const mutate = useCallback<Mutate<TData>>(
@@ -102,7 +115,7 @@ export default function useApi<TData>(
 				setState(_state => {
 					return { ..._state, loading: false };
 				});
-				return result;
+				return Promise.reject('No api!');
 			}
 
 			// Invoke the supplied API method and update state with reducer
@@ -113,11 +126,12 @@ export default function useApi<TData>(
 					});
 					return result;
 				})
-			})
-			.catch(async (error) => {
-				await handleError(error);
-			});
-	}, [api, data]);
+				.catch(async error => {
+					await handleError(error);
+				});
+		},
+		[api, data]
+	);
 
 	// Rerun query whenever deps or accessToken changes
 	useEffect(() => {
@@ -141,7 +155,7 @@ export default function useApi<TData>(
 					callback(result);
 				}
 			})
-			.catch(async (error) => {
+			.catch(async error => {
 				await handleError(error);
 			});
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Hedwig/ClientApp/src/utils/stringFormatters/alertTextMakers.tsx
+++ b/src/Hedwig/ClientApp/src/utils/stringFormatters/alertTextMakers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AlertProps, Button } from '../../components';
+import { AlertProps, Button, AlertType } from '../../components';
 import { ReportingPeriod } from '../../generated';
 import { reportingPeriodFormatter } from '../models';
 import pluralize from 'pluralize';
@@ -58,11 +58,11 @@ const MailToLink = () => (
 		oec-data-pilot@skylight.digital
 	</a>
 );
-const saveFailAlertProps = {
+const saveFailAlertProps: { type: AlertType, heading: string } = {
 	type: 'error',
 	heading: 'Something went wrong',
 };
-export const reportSubmitFailAlert = {
+export const reportSubmitFailAlert: AlertProps = {
 	...saveFailAlertProps,
 	text: (
 		<span>
@@ -71,7 +71,7 @@ export const reportSubmitFailAlert = {
 		</span>
 	),
 };
-export const editSaveFailAlert = {
+export const editSaveFailAlert: AlertProps = {
 	...saveFailAlertProps,
 	text: (
 		<span>
@@ -80,7 +80,7 @@ export const editSaveFailAlert = {
 		</span>
 	),
 };
-export const stepListSaveFailAlert = {
+export const stepListSaveFailAlert: AlertProps = {
 	// new enrollments
 	...saveFailAlertProps,
 	text: (
@@ -96,4 +96,17 @@ export const missingInformationForWithdrawalAlert: AlertProps = {
 	heading: 'Information needed to withdraw child',
 	text:
 		'To withdraw a child from a funded space in your program, they cannot have any missing information. Please enter all missing information indicated below to withdraw this child.',
+};
+
+export const validationErrorAlert: AlertProps = {
+	...saveFailAlertProps,
+	text: (
+		<span>
+    We couldn't save your changes because we detected a potential inconsistency in the data. 
+		This shouldn't have happened. Our team has been notified of the problem.
+		<br/>
+    You may still be able to update other children on your roster. 
+		Please wait to submit a report to OEC until the problem is fixed. For updates, contact {<MailToLink />}.
+		</span>
+	)
 };

--- a/src/Hedwig/ClientApp/src/utils/stringFormatters/alertTextMakers.tsx
+++ b/src/Hedwig/ClientApp/src/utils/stringFormatters/alertTextMakers.tsx
@@ -58,7 +58,7 @@ const MailToLink = () => (
 		oec-data-pilot@skylight.digital
 	</a>
 );
-const saveFailAlertProps: { type: AlertType, heading: string } = {
+const saveFailAlertProps: { type: AlertType; heading: string } = {
 	type: 'error',
 	heading: 'Something went wrong',
 };
@@ -102,11 +102,11 @@ export const validationErrorAlert: AlertProps = {
 	...saveFailAlertProps,
 	text: (
 		<span>
-    We couldn't save your changes because we detected a potential inconsistency in the data. 
-		This shouldn't have happened. Our team has been notified of the problem.
-		<br/>
-    You may still be able to update other children on your roster. 
-		Please wait to submit a report to OEC until the problem is fixed. For updates, contact {<MailToLink />}.
+			We couldn't save your changes because we detected a potential inconsistency in the data. This
+			shouldn't have happened. Our team has been notified of the problem.
+			<br />
+			You may still be able to update other children on your roster. Please wait to submit a report
+			to OEC until the problem is fixed. For updates, contact {<MailToLink />}.
 		</span>
-	)
+	),
 };

--- a/src/Hedwig/ClientApp/src/utils/validations/errorForField.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/errorForField.ts
@@ -41,10 +41,13 @@ export function serverErrorForField(
 ): FormStatusProps | undefined {
 	if (!error || !isBlockingValidationError(error)) return;
 
-	const fieldError = processBlockingValidationErrors(fieldId, (error as ValidationProblemDetails).errors);
+	const fieldError = processBlockingValidationErrors(
+		fieldId,
+		(error as ValidationProblemDetails).errors
+	);
 
 	if (fieldError) {
-		if(!hasAlertedOnError) {
+		if (!hasAlertedOnError) {
 			setHasAlertedOnError(true);
 		}
 		return {

--- a/src/Hedwig/ClientApp/src/utils/validations/errorForField.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/errorForField.ts
@@ -5,6 +5,7 @@ import { FormStatusProps } from '../../components/FormStatus/FormStatus';
 import { processBlockingValidationErrors } from './processBlockingValidationErrors';
 import { ValidationProblemDetails } from '../../generated';
 import { elementIdFormatter } from '../stringFormatters';
+import { ApiError } from '../../hooks/useApi';
 
 export function warningForField<T extends Validatable>(
 	fieldId: string,
@@ -31,12 +32,13 @@ export function warningForField<T extends Validatable>(
  */
 export function serverErrorForField(
 	fieldId: string,
-	error?: ValidationProblemDetails,
+	error: ApiError | null,
 	message?: string
 ): FormStatusProps | undefined {
-	if (!error) return;
+	const validationError = error as ValidationProblemDetails;
+	if (!validationError || !validationError.errors) return;
 
-	const fieldError = processBlockingValidationErrors(fieldId, error.errors);
+	const fieldError = processBlockingValidationErrors(fieldId, validationError.errors);
 
 	if (fieldError) {
 		return {

--- a/src/Hedwig/ClientApp/src/utils/validations/index.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/index.ts
@@ -5,3 +5,5 @@ export * from './sectionHasValidationErrors';
 export * from './errorForFieldSet';
 export * from './errorForField';
 export * from './useFocusFirstError';
+export * from './initialLoadErrorGuard';
+export * from './isBlockingValidationError';

--- a/src/Hedwig/ClientApp/src/utils/validations/initialLoadErrorGuard.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/initialLoadErrorGuard.ts
@@ -1,12 +1,9 @@
 import { FormStatusProps } from '../../components/FormStatus/FormStatus';
 
-export function initialLoadErrorGuard(
-  initialLoad: boolean,
-  error?: FormStatusProps
-) {
-  if (initialLoad) {
-    return undefined;
-  } else {
-    return error;
-  }
+export function initialLoadErrorGuard(initialLoad: boolean, error?: FormStatusProps) {
+	if (initialLoad) {
+		return undefined;
+	} else {
+		return error;
+	}
 }

--- a/src/Hedwig/ClientApp/src/utils/validations/initialLoadErrorGuard.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/initialLoadErrorGuard.ts
@@ -1,9 +1,12 @@
 import { FormStatusProps } from '../../components/FormStatus/FormStatus';
 
-export default function initialLoadErrorGuard(initialLoad: boolean, error?: FormStatusProps) {
-	if (initialLoad) {
-		return undefined;
-	} else {
-		return error;
-	}
+export function initialLoadErrorGuard(
+  initialLoad: boolean,
+  error?: FormStatusProps
+) {
+  if (initialLoad) {
+    return undefined;
+  } else {
+    return error;
+  }
 }

--- a/src/Hedwig/ClientApp/src/utils/validations/isBlockingValidationError.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/isBlockingValidationError.ts
@@ -1,6 +1,6 @@
-import { ApiError } from "../../hooks/useApi";
-import { ValidationProblemDetails } from "../../generated";
+import { ApiError } from '../../hooks/useApi';
+import { ValidationProblemDetails } from '../../generated';
 
 export function isBlockingValidationError(error: ApiError): boolean {
-  return !!(error as ValidationProblemDetails).errors;
+	return !!(error as ValidationProblemDetails).errors;
 }

--- a/src/Hedwig/ClientApp/src/utils/validations/isBlockingValidationError.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/isBlockingValidationError.ts
@@ -1,0 +1,6 @@
+import { ApiError } from "../../hooks/useApi";
+import { ValidationProblemDetails } from "../../generated";
+
+export function isBlockingValidationError(error: ApiError): boolean {
+  return !!(error as ValidationProblemDetails).errors;
+}


### PR DESCRIPTION
Repurposes the `error` entity of `ApiState` from `useApi` to pass around errors for pages using the associated apistate entity and api mutate function for that entity. 

Adds handling for un-UI-handled errors 

closes #710 