### PR TITLE
781: Fixes enrollment save bug

### DIFF
--- a/src/Hedwig/Repositories/EnrollmentRepository.cs
+++ b/src/Hedwig/Repositories/EnrollmentRepository.cs
@@ -90,8 +90,8 @@ namespace Hedwig.Repositories
 				* A better solution for this will probably need to be determined, but for now, including un-tracked author on the enrollment ensures there is no clash. 
 				*/
 			var enrollment = enrollmentQuery.FirstOrDefault();
-			var author = _context.Users.AsNoTracking().FirstOrDefault(u => u.Id == enrollment.AuthorId);
-			enrollment.Author = author;
+			// var author = _context.Users.AsNoTracking().FirstOrDefault(u => u.Id == enrollment.AuthorId);
+			// enrollment.Author = author;
 			return Task.FromResult(enrollment);
 		}
 


### PR DESCRIPTION
Unblocks creating and updating enrollments by removing the conflicting
author User entity

This is a temporary fix until DTOs are implemented

NOTE: This results in the enrollment update metadata info missing from
UI, however all the parts are still there and we will get this feature
back once author User references are back

needs: e2e tests to confirm each enrollment section can be saved

closes #781 