### PR TITLE
777: Quick fix to improve performance

### DIFF
--- a/src/Hedwig/Controllers/EnrollmentsController.cs
+++ b/src/Hedwig/Controllers/EnrollmentsController.cs
@@ -63,6 +63,10 @@ namespace Hedwig.Controllers
 			var enrollment = await _enrollments.GetEnrollmentForSiteAsync(id, siteId, include);
 			if (enrollment == null) return NotFound();
 
+			// quick fix until we implement more robust solution (DTO or other serialization rules)
+			enrollment.Child.Enrollments = null;
+			enrollment.Site.Enrollments = null;
+
 			_validator.Validate(enrollment);
 
 			return enrollment;
@@ -103,6 +107,13 @@ namespace Hedwig.Controllers
 			// If no sites are specified, get all enrollments for the organization
 			{
 				enrollments = await _enrollments.GetEnrollmentsForOrganizationAsync(orgId, from, to, include, asOf);
+			}
+
+			// quick fix until we implement more robust solution (DTO or other serialization rules)
+			foreach (var enrollment in enrollments)
+			{
+				enrollment.Child.Enrollments = null;
+				enrollment.Site.Enrollments = null;
 			}
 
 			_validator.Validate(enrollments);


### PR DESCRIPTION
before change enrollments query size: 1.6MB
after change: 55.4MB

before change enrollments query time: ~1000ms
after change: ~600ms