### PR TITLE
Refactor tests

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.test.tsx
@@ -1,12 +1,25 @@
+// Variables used in jest mockes -- must start with `mock`
+import { mockAllFakeEnrollments, mockSite } from '../../../tests/data';
+import mockUseApi, {
+	mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet,
+	mockApiOrganizationsOrgIdSitesIdGet,
+} from '../../../hooks/__mocks__/useApi';
+
+// Jest mocks must occur before later imports
+jest.mock('../../../hooks/useApi', () =>
+	mockUseApi({
+		apiOrganizationsOrgIdSitesIdGet: mockApiOrganizationsOrgIdSitesIdGet(mockSite),
+		apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet: mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet(
+			mockAllFakeEnrollments
+		),
+	})
+);
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import EnrollmentDetail from './EnrollmentDetail';
-import CommonContextProviderMock from '../../../contexts/__mocks__/CommonContextProviderMock';
-import { enrollmentMissingBirthCertId } from '../../../hooks/__mocks__/useApi';
-import { completeEnrollment } from '../../../tests/data';
-
-jest.mock('../../../hooks/useApi');
-import useApi from '../../../hooks/useApi';
+import TestProvider from '../../../contexts/__mocks__/TestProvider';
+import { mockCompleteEnrollment, mockEnrollmentMissingBirthCertId } from '../../../tests/data';
 import { accessibilityTestHelper } from '../../accessibilityTestHelper';
 
 afterAll(() => {
@@ -16,18 +29,32 @@ afterAll(() => {
 describe('EnrollmentDetail', () => {
 	it('matches snapshot', () => {
 		const { container } = render(
-			<CommonContextProviderMock>
-				<EnrollmentDetail match={{ params: { enrollmentId: completeEnrollment.id } }} />
-			</CommonContextProviderMock>
+			<TestProvider>
+				<EnrollmentDetail
+					match={{
+						params: {
+							siteId: mockCompleteEnrollment.siteId,
+							enrollmentId: mockCompleteEnrollment.id,
+						},
+					}}
+				/>
+			</TestProvider>
 		);
 		expect(container).toMatchSnapshot();
 	});
 
 	it('shows incomplete indications when incomplete information is given', () => {
 		const { getAllByText } = render(
-			<CommonContextProviderMock>
-				<EnrollmentDetail match={{ params: { enrollmentId: enrollmentMissingBirthCertId.id } }} />
-			</CommonContextProviderMock>
+			<TestProvider>
+				<EnrollmentDetail
+					match={{
+						params: {
+							siteId: mockEnrollmentMissingBirthCertId.siteId,
+							enrollmentId: mockEnrollmentMissingBirthCertId.id,
+						},
+					}}
+				/>
+			</TestProvider>
 		);
 
 		const incompleteIcons = getAllByText('(incomplete)');
@@ -35,8 +62,15 @@ describe('EnrollmentDetail', () => {
 	});
 
 	accessibilityTestHelper(
-		<CommonContextProviderMock>
-			<EnrollmentDetail match={{ params: { enrollmentId: enrollmentMissingBirthCertId.id } }} />
-		</CommonContextProviderMock>
+		<TestProvider>
+			<EnrollmentDetail
+				match={{
+					params: {
+						siteId: mockEnrollmentMissingBirthCertId.siteId,
+						enrollmentId: mockEnrollmentMissingBirthCertId.id,
+					},
+				}}
+			/>
+		</TestProvider>
 	);
 });

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
       </div>
       <a
         class="usa-button margin-right-0"
-        href="/roster/sites/undefined/enrollments/1/withdraw"
+        href="/roster/sites/1/enrollments/1/withdraw"
       >
         Withdraw
       </a>
@@ -83,7 +83,7 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
       >
         <a
           class=""
-          href="/roster/sites/undefined/enrollments/1/edit/child-information"
+          href="/roster/sites/1/enrollments/1/edit/child-information"
         >
           Edit
           <span
@@ -120,7 +120,7 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
       >
         <a
           class=""
-          href="/roster/sites/undefined/enrollments/1/edit/family-information"
+          href="/roster/sites/1/enrollments/1/edit/family-information"
         >
           Edit
           <span
@@ -154,7 +154,7 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
       >
         <a
           class=""
-          href="/roster/sites/undefined/enrollments/1/edit/family-income"
+          href="/roster/sites/1/enrollments/1/edit/family-income"
         >
           Edit
           <span
@@ -211,7 +211,7 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
       >
         <a
           class=""
-          href="/roster/sites/undefined/enrollments/1/edit/enrollment-funding"
+          href="/roster/sites/1/enrollments/1/edit/enrollment-funding"
         >
           Edit
           <span

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Edit/EnrollmentEdit.test.tsx
@@ -1,18 +1,35 @@
+// Variables used in jest mockes -- must start with `mock`
+import { mockAllFakeEnrollments, mockSite } from '../../../tests/data';
+import mockUseApi, {
+	mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet,
+	mockApiOrganizationsOrgIdSitesIdGet,
+} from '../../../hooks/__mocks__/useApi';
+
+// Jest mocks must occur before later imports
+jest.mock('../../../hooks/useApi', () =>
+	mockUseApi({
+		apiOrganizationsOrgIdSitesIdGet: mockApiOrganizationsOrgIdSitesIdGet(mockSite),
+		apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet: mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet(
+			mockAllFakeEnrollments
+		),
+	})
+);
+
 import React from 'react';
 import mockdate from 'mockdate';
 import { createBrowserHistory } from 'history';
 import { render, getAllByRole } from '@testing-library/react';
-import CommonContextProviderMock, {
-	defaultCdcReportingPeriods,
-} from '../../../contexts/__mocks__/CommonContextProviderMock';
-import { enrollmentMissingAddress } from '../../../hooks/__mocks__/useApi';
+import 'react-dates/initialize';
+import TestProvider from '../../../contexts/__mocks__/TestProvider';
 import EnrollmentEdit from './EnrollmentEdit';
 import { accessibilityTestHelper } from '../../accessibilityTestHelper';
-import { completeEnrollment } from '../../../tests/data';
+import {
+	mockCompleteEnrollment,
+	cdcReportingPeriods,
+	mockEnrollmentMissingAddress,
+} from '../../../tests/data';
 
 const fakeDate = '2019-03-02';
-
-jest.mock('../../../hooks/useApi');
 
 beforeAll(() => {
 	mockdate.set(fakeDate);
@@ -29,17 +46,18 @@ describe('EnrollmentEdit', () => {
 	describe('family info', () => {
 		it('shows a fieldset warning if there is no address', () => {
 			const { getByRole } = render(
-				<CommonContextProviderMock>
+				<TestProvider>
 					<EnrollmentEdit
 						history={history}
 						match={{
 							params: {
-								enrollmentId: enrollmentMissingAddress.id,
+								siteId: mockEnrollmentMissingAddress.siteId,
+								enrollmentId: mockEnrollmentMissingAddress.id,
 								sectionId: 'family-information',
 							},
 						}}
 					/>
-				</CommonContextProviderMock>
+				</TestProvider>
 			);
 
 			const addressErr = getByRole('status');
@@ -51,17 +69,18 @@ describe('EnrollmentEdit', () => {
 	describe('family income', () => {
 		it('shows an info alert if family income is not disclosed', () => {
 			const { getByText } = render(
-				<CommonContextProviderMock>
+				<TestProvider>
 					<EnrollmentEdit
 						history={history}
 						match={{
 							params: {
-								enrollmentId: completeEnrollment.id,
+								siteId: mockCompleteEnrollment.siteId,
+								enrollmentId: mockCompleteEnrollment.id,
 								sectionId: 'family-income',
 							},
 						}}
 					/>
-				</CommonContextProviderMock>
+				</TestProvider>
 			);
 
 			const infoAlert = getByText(
@@ -75,29 +94,37 @@ describe('EnrollmentEdit', () => {
 	describe('enrollment and funding', () => {
 		it('shows the appropriate number of reporting periods for enrollment funding', () => {
 			const { getByLabelText } = render(
-				<CommonContextProviderMock>
+				<TestProvider>
 					<EnrollmentEdit
 						history={history}
 						match={{
-							params: { enrollmentId: completeEnrollment.id, sectionId: 'enrollment-funding' },
+							params: {
+								siteId: mockCompleteEnrollment.siteId,
+								enrollmentId: mockCompleteEnrollment.id,
+								sectionId: 'enrollment-funding',
+							},
 						}}
 					/>
-				</CommonContextProviderMock>
+				</TestProvider>
 			);
 			const reportingPeriodSelect = getByLabelText('First reporting period');
 			const reportingPeriodOptions = getAllByRole(reportingPeriodSelect, 'option');
-			expect(reportingPeriodOptions.length).toBe(defaultCdcReportingPeriods.length + 1);
+			expect(reportingPeriodOptions.length).toBe(cdcReportingPeriods.length + 1);
 		});
 	});
 
 	accessibilityTestHelper(
-		<CommonContextProviderMock>
+		<TestProvider>
 			<EnrollmentEdit
 				history={history}
 				match={{
-					params: { enrollmentId: completeEnrollment.id, sectionId: 'enrollment-funding' },
+					params: {
+						siteId: mockCompleteEnrollment.siteId,
+						enrollmentId: mockCompleteEnrollment.id,
+						sectionId: 'enrollment-funding',
+					},
 				}}
 			/>
-		</CommonContextProviderMock>
+		</TestProvider>
 	);
 });

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/New/EnrollmentNew.test.tsx
@@ -1,16 +1,36 @@
+// Variables used in jest mockes -- must start with `mock`
+import { mockAllFakeEnrollments, mockSite } from '../../../tests/data';
+import mockUseApi, {
+	mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet,
+	mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdDelete,
+	mockApiOrganizationsOrgIdSitesIdGet,
+} from '../../../hooks/__mocks__/useApi';
+
+// Jest mocks must occur before later imports
+jest.mock('../../../hooks/useApi', () =>
+	mockUseApi({
+		apiOrganizationsOrgIdSitesIdGet: mockApiOrganizationsOrgIdSitesIdGet(mockSite),
+		apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet: mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet(
+			mockAllFakeEnrollments
+		),
+		apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdDelete: mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdDelete(),
+	})
+);
+
 import React from 'react';
-import mockdate from 'mockdate';
 import { createMemoryHistory } from 'history';
 import { render, fireEvent, wait } from '@testing-library/react';
-import CommonContextProviderMock from '../../../contexts/__mocks__/CommonContextProviderMock';
-import { enrollmentWithFoster } from '../../../hooks/__mocks__/useApi';
-import EnrollmentNew from './EnrollmentNew';
 import { Route } from 'react-router';
-import { completeEnrollment } from '../../../tests/data';
+
+import 'react-dates/initialize';
+import mockdate from 'mockdate';
+
+import TestProvider from '../../../contexts/__mocks__/TestProvider';
+import { mockCompleteEnrollment, mockEnrollmentWithFoster } from '../../../tests/data';
+
+import EnrollmentNew from './EnrollmentNew';
 
 const fakeDate = '2019-03-02';
-
-jest.mock('../../../hooks/useApi');
 
 beforeAll(() => {
 	mockdate.set(fakeDate);
@@ -25,18 +45,18 @@ describe('EnrollmentNew', () => {
 	it('does not skip family income section when lives with foster family is not selected', async () => {
 		const history = createMemoryHistory();
 		const { getByText } = render(
-			<CommonContextProviderMock>
+			<TestProvider>
 				<EnrollmentNew
 					history={history}
 					match={{
 						params: {
 							siteId: 1,
-							enrollmentId: completeEnrollment.id,
+							enrollmentId: mockCompleteEnrollment.id,
 							sectionId: 'family-information',
 						},
 					}}
 				/>
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 
 		const saveBtn = getByText(/Save/i);
@@ -49,12 +69,12 @@ describe('EnrollmentNew', () => {
 
 	it('skips family income section when lives with foster family is selected', async () => {
 		const history = createMemoryHistory();
-		const enrollment = enrollmentWithFoster;
+		const enrollment = mockEnrollmentWithFoster;
 		history.push(
 			`/roster/sites/${enrollment.siteId}/enrollments/${enrollment.id}/new/family-information`
 		);
 		const { findByLabelText, getByDisplayValue } = render(
-			<CommonContextProviderMock history={history}>
+			<TestProvider history={history}>
 				<Route
 					path={'/roster/sites/:siteId/enrollments/:enrollmentId/new/:sectionId'}
 					render={props => (
@@ -72,7 +92,7 @@ describe('EnrollmentNew', () => {
 						/>
 					)}
 				/>
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 
 		const fosterCheckbox = await findByLabelText(/Child lives with foster family/i);

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.test.tsx
@@ -66,7 +66,8 @@ describe('ReportDetail', () => {
 
 	describe('when report is ready to be submitted', () => {
 		beforeEach(() => {
-			(mockReport = _mockReport), (mockMutate = jest.fn(() => Promise.resolve()));
+			mockReport = _mockReport;
+			mockMutate = jest.fn(() => Promise.resolve());
 		});
 
 		it('allows the report to be submitted', () => {

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportDetail.test.tsx
@@ -1,13 +1,27 @@
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
-import ReportDetail from './ReportDetail';
-import CommonContextProviderMock from '../../../contexts/__mocks__/CommonContextProviderMock';
-import { CdcReport } from '../../../generated';
-import { mockApi, defaultReport } from '../../../hooks/__mocks__/useApi';
-import { accessibilityTestHelper } from '../../accessibilityTestHelper';
-import { completeEnrollment } from '../../../tests/data';
+// Variables used in jest mockes -- must start with `mock`
+import {
+	mockDefaultReport,
+	mockReport as _mockReport,
+	mockCompleteEnrollment,
+	mockEnrollmentWithFoster,
+} from '../../../tests/data';
+import mockUseApi, {
+	mockApiOrganizationsOrgIdEnrollmentsGet,
+} from '../../../hooks/__mocks__/useApi';
 
-const readyReport = { ...defaultReport, enrollments: [completeEnrollment] };
+let mockReport = mockDefaultReport;
+let mockMutate: any;
+
+// Jest mocks must occur before later imports
+jest.mock('../../../hooks/useApi', () =>
+	mockUseApi({
+		apiOrganizationsOrgIdEnrollmentsGet: mockApiOrganizationsOrgIdEnrollmentsGet([
+			mockCompleteEnrollment,
+			mockEnrollmentWithFoster,
+		]),
+		apiOrganizationsOrgIdReportsIdGet: (_: any) => [false, null, mockReport, mockMutate],
+	})
+);
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -17,33 +31,11 @@ jest.mock('react-router-dom', () => ({
 	}),
 }));
 
-let mockLoading: boolean;
-let mockError: string | null;
-let mockReport: CdcReport;
-let mockMutate: Function;
-
-const defaultLoading = false;
-const defaultError = null;
-const defaultMutate = () => Promise.resolve();
-
-beforeEach(() => {
-	mockLoading = defaultLoading;
-	mockError = defaultError;
-	mockReport = defaultReport;
-	mockMutate = defaultMutate;
-});
-
-jest.mock('../../../hooks/useApi', () => (query: Function) =>
-	query({
-		...mockApi,
-		apiOrganizationsOrgIdReportsIdGet: (params: any) => [
-			mockLoading,
-			mockError,
-			mockReport,
-			mockMutate,
-		],
-	})
-);
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ReportDetail from './ReportDetail';
+import TestProvider from '../../../contexts/__mocks__/TestProvider';
+import { accessibilityTestHelper } from '../../accessibilityTestHelper';
 
 afterAll(() => {
 	jest.resetModules();
@@ -52,9 +44,9 @@ afterAll(() => {
 describe('ReportDetail', () => {
 	it('matches snapshot', () => {
 		const { asFragment } = render(
-			<CommonContextProviderMock>
+			<TestProvider>
 				<ReportDetail />
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 		expect(asFragment()).toMatchSnapshot();
 	});
@@ -62,9 +54,9 @@ describe('ReportDetail', () => {
 	describe('when roster is missing information', () => {
 		it('shows an alert and disables submit', () => {
 			const { getByText, getByRole } = render(
-				<CommonContextProviderMock>
+				<TestProvider>
 					<ReportDetail />
-				</CommonContextProviderMock>
+				</TestProvider>
 			);
 
 			expect(getByRole('alert')).toHaveTextContent('Update roster');
@@ -74,15 +66,14 @@ describe('ReportDetail', () => {
 
 	describe('when report is ready to be submitted', () => {
 		beforeEach(() => {
-			mockReport = readyReport;
-			mockMutate = jest.fn(() => Promise.resolve());
+			(mockReport = _mockReport), (mockMutate = jest.fn(() => Promise.resolve()));
 		});
 
 		it('allows the report to be submitted', () => {
 			const { getByText, getByLabelText } = render(
-				<CommonContextProviderMock>
+				<TestProvider>
 					<ReportDetail />
-				</CommonContextProviderMock>
+				</TestProvider>
 			);
 
 			fireEvent.change(getByLabelText(/Care 4 Kids/), { target: { value: '1234.56' } });
@@ -94,8 +85,8 @@ describe('ReportDetail', () => {
 	});
 
 	accessibilityTestHelper(
-		<CommonContextProviderMock>
+		<TestProvider>
 			<ReportDetail />
-		</CommonContextProviderMock>
+		</TestProvider>
 	);
 });

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.test.tsx
@@ -1,13 +1,31 @@
+// Variables used in jest mockes -- must start with `mock`
+import {
+	mockDefaultReport,
+	mockReport as _mockReport,
+	mockCompleteEnrollment,
+	mockEnrollmentWithFoster,
+} from '../../../tests/data';
+import mockUseApi, {
+	mockApiOrganizationsOrgIdEnrollmentsGet,
+} from '../../../hooks/__mocks__/useApi';
+
+// Jest mocks must occur before later imports
+jest.mock('../../../hooks/useApi', () =>
+	mockUseApi({
+		apiOrganizationsOrgIdEnrollmentsGet: mockApiOrganizationsOrgIdEnrollmentsGet([
+			mockCompleteEnrollment,
+			mockEnrollmentWithFoster,
+		]),
+	})
+);
+
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import ReportSubmitForm from './ReportSubmitForm';
-import CommonContextProviderMock from '../../../contexts/__mocks__/CommonContextProviderMock';
-import { defaultReport } from '../../../hooks/__mocks__/useApi';
+import TestProvider from '../../../contexts/__mocks__/TestProvider';
 import { DeepNonUndefineable } from '../../../utils/types';
 import { CdcReport } from '../../../generated';
 import { accessibilityTestHelper } from '../../accessibilityTestHelper';
-
-jest.mock('../../../hooks/useApi');
 
 afterAll(() => {
 	jest.resetModules();
@@ -16,26 +34,28 @@ afterAll(() => {
 describe('ReportSubmitForm', () => {
 	it('matches snapshot', () => {
 		const { asFragment } = render(
-			<CommonContextProviderMock>
+			<TestProvider>
 				<ReportSubmitForm
-					report={defaultReport as DeepNonUndefineable<CdcReport>}
+					report={mockDefaultReport as DeepNonUndefineable<CdcReport>}
 					mutate={() => Promise.resolve()}
 					canSubmit={true}
+					error={null}
 				/>
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 		expect(asFragment()).toMatchSnapshot();
 	});
 
 	it('updates rates if accreditation is changed', () => {
 		const { getByText, getByLabelText } = render(
-			<CommonContextProviderMock>
+			<TestProvider>
 				<ReportSubmitForm
-					report={defaultReport as DeepNonUndefineable<CdcReport>}
+					report={mockDefaultReport as DeepNonUndefineable<CdcReport>}
 					mutate={() => Promise.resolve()}
 					canSubmit={true}
+					error={null}
 				/>
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 
 		expect(getByText('Preschool').closest('tr')).toHaveTextContent('$165.32');
@@ -47,13 +67,14 @@ describe('ReportSubmitForm', () => {
 
 	it('pretty formats currency values', () => {
 		const { getByLabelText } = render(
-			<CommonContextProviderMock>
+			<TestProvider>
 				<ReportSubmitForm
-					report={defaultReport as DeepNonUndefineable<CdcReport>}
+					report={mockDefaultReport as DeepNonUndefineable<CdcReport>}
 					mutate={() => Promise.resolve()}
 					canSubmit={true}
+					error={null}
 				/>
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 
 		fireEvent.change(getByLabelText('Family Fees'), { target: { value: '12,34a.5' } });
@@ -63,12 +84,13 @@ describe('ReportSubmitForm', () => {
 	});
 
 	accessibilityTestHelper(
-		<CommonContextProviderMock>
+		<TestProvider>
 			<ReportSubmitForm
-				report={defaultReport as DeepNonUndefineable<CdcReport>}
+				report={mockDefaultReport as DeepNonUndefineable<CdcReport>}
 				mutate={() => Promise.resolve()}
 				canSubmit={true}
+				error={null}
 			/>
-		</CommonContextProviderMock>
+		</TestProvider>
 	);
 });

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportDetail.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportDetail.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`ReportDetail matches snapshot 1`] = `
           <td
             class=" oec-table__cell--red"
           >
-            4/2 spaces
+            5/2 spaces
           </td>
           <td>
             $165.32
@@ -218,7 +218,7 @@ exports[`ReportDetail matches snapshot 1`] = `
           <td
             class="oec-table__cell--strong oec-table__cell--red"
           >
-            4/2 spaces
+            5/2 spaces
           </td>
           <td />
           <td

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportSubmitForm.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/__snapshots__/ReportSubmitForm.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`ReportSubmitForm matches snapshot 1`] = `
         <td
           class=" oec-table__cell--red"
         >
-          4/2 spaces
+          5/2 spaces
         </td>
         <td>
           $165.32
@@ -136,7 +136,7 @@ exports[`ReportSubmitForm matches snapshot 1`] = `
         <td
           class="oec-table__cell--strong oec-table__cell--red"
         >
-          4/2 spaces
+          5/2 spaces
         </td>
         <td />
         <td

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportsSummary/ReportsSummary.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportsSummary/ReportsSummary.test.tsx
@@ -1,33 +1,31 @@
+// Variables used in jest mockes -- must start with `mock`
+import {
+	mockDefaultReport,
+	mockReport as _mockReport,
+	mockCompleteEnrollment,
+	mockEnrollmentWithFoster,
+	mockOrganization,
+} from '../../../tests/data';
+import mockUseApi, { mockApiOrganizationsIdGet } from '../../../hooks/__mocks__/useApi';
+
+const submittedReport = { ...mockDefaultReport, submittedAt: new Date('2019-09-14') };
+const defaultReports = [mockDefaultReport, submittedReport];
+
+let mockReports = defaultReports;
+
+// Jest mocks must occur before later imports
+jest.mock('../../../hooks/useApi', () =>
+	mockUseApi({
+		apiOrganizationsIdGet: mockApiOrganizationsIdGet(mockOrganization),
+		apiOrganizationsOrgIdReportsGet: (_: any) => [false, null, mockReports],
+	})
+);
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import ReportsSummary from './ReportsSummary';
-import CommonContextProviderMock from '../../../contexts/__mocks__/CommonContextProviderMock';
-import { CdcReport } from '../../../generated';
-import { mockApi, defaultReport } from '../../../hooks/__mocks__/useApi';
+import CommonContextProviderMock from '../../../contexts/__mocks__/TestProvider';
 import { accessibilityTestHelper } from '../../accessibilityTestHelper';
-
-const submittedReport = { ...defaultReport, submittedAt: new Date('2019-09-14') };
-
-let mockLoading: boolean;
-let mockError: string | null;
-let mockReports: CdcReport[];
-
-const defaultLoading = false;
-const defaultError = null;
-const defaultReports = [defaultReport, submittedReport];
-
-beforeEach(() => {
-	mockLoading = defaultLoading;
-	mockError = defaultError;
-	mockReports = defaultReports;
-});
-
-jest.mock('../../../hooks/useApi', () => (query: Function) =>
-	query({
-		...mockApi,
-		apiOrganizationsOrgIdReportsGet: (params: any) => [mockLoading, mockError, mockReports],
-	})
-);
 
 afterAll(() => {
 	jest.resetModules();

--- a/src/Hedwig/ClientApp/src/containers/Roster/Roster.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/Roster.test.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
-import { render, fireEvent, wait } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
-import mockdate from 'mockdate';
-import CommonContextProviderMock from '../../contexts/__mocks__/CommonContextProviderMock';
-import Roster from './Roster';
-import { accessibilityTestHelper } from '../accessibilityTestHelper';
-import { completeEnrollment } from '../../tests/data';
+// Variables used in jest mockes -- must start with `mock`
+import { mockAllFakeEnrollments, mockOrganization } from '../../tests/data';
+import mockUseApi, {
+	mockApiOrganizationsOrgIdEnrollmentsGet,
+	mockApiOrganizationsIdGet,
+} from '../../hooks/__mocks__/useApi';
 
-// Implicitly reads from the '../../hooks/__mocks__/useApi.ts file
-jest.mock('../../hooks/useApi');
+// Jest mocks must occur before later imports
+jest.mock('../../hooks/useApi', () =>
+	mockUseApi({
+		apiOrganizationsIdGet: mockApiOrganizationsIdGet(mockOrganization),
+		apiOrganizationsOrgIdEnrollmentsGet: mockApiOrganizationsOrgIdEnrollmentsGet(
+			mockAllFakeEnrollments
+		),
+	})
+);
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -16,6 +21,17 @@ jest.mock('react-router-dom', () => ({
 		id: 1,
 	}),
 }));
+
+import React from 'react';
+import { render, fireEvent, wait } from '@testing-library/react';
+
+import 'react-dates/initialize';
+import mockdate from 'mockdate';
+
+import { accessibilityTestHelper } from '../accessibilityTestHelper';
+import TestProvider from '../../contexts/__mocks__/TestProvider';
+
+import Roster from './Roster';
 
 const fakeDate = '2019-09-30';
 
@@ -30,25 +46,19 @@ afterAll(() => {
 
 describe('Roster', () => {
 	it('matches snapshot', () => {
-		const history = createMemoryHistory();
-		const enrollment = completeEnrollment;
-		history.push(`/roster/sites/${enrollment.siteId}`);
 		const { asFragment } = render(
-			<CommonContextProviderMock history={history}>
+			<TestProvider>
 				<Roster />
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 		expect(asFragment()).toMatchSnapshot();
 	});
 
 	it('renders intro text with the correct number of children', async () => {
-		const history = createMemoryHistory();
-		const enrollment = completeEnrollment;
-		history.push(`/roster/sites/${enrollment.siteId}`);
 		const { baseElement } = render(
-			<CommonContextProviderMock history={history}>
+			<TestProvider>
 				<Roster />
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 
 		expect(baseElement).toHaveTextContent(/\d children enrolled/i);
@@ -56,9 +66,9 @@ describe('Roster', () => {
 
 	it('updates the number of children', async () => {
 		const { baseElement, getByText, getByLabelText } = render(
-			<CommonContextProviderMock>
+			<TestProvider>
 				<Roster />
-			</CommonContextProviderMock>
+			</TestProvider>
 		);
 
 		const filterButton = getByText(/view past enrollments/i);
@@ -85,8 +95,8 @@ describe('Roster', () => {
 	});
 
 	accessibilityTestHelper(
-		<CommonContextProviderMock>
+		<TestProvider>
 			<Roster />
-		</CommonContextProviderMock>
+		</TestProvider>
 	);
 });

--- a/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
@@ -41,6 +41,7 @@ export default function Roster() {
 		id: getIdForUser(user, 'org'),
 		include: ['sites', 'funding_spaces'],
 	};
+
 	const [organizationLoading, organizationError, organization] = useApi(
 		api => api.apiOrganizationsIdGet(orgParams),
 		[user],

--- a/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Roster matches snapshot 1`] = `
         <p
           class="intro display-flex flex-row flex-wrap flex-justify-start"
         >
-          4 children enrolled. 
+          5 children enrolled. 
           <button
             class="usa-button usa-button--unstyled"
             type="button"
@@ -75,7 +75,7 @@ exports[`Roster matches snapshot 1`] = `
           <span
             class="text-bold"
           >
-            4/2
+            5/2
           </span>
           <span>
              Child Day Care spaces filled
@@ -118,7 +118,7 @@ exports[`Roster matches snapshot 1`] = `
     <h2
       class="margin-top-6"
     >
-      Preschool (4 children)
+      Preschool (5 children)
     </h2>
     <ul>
       <li>
@@ -379,6 +379,36 @@ exports[`Roster matches snapshot 1`] = `
             class="oec-table__cell--tabular-nums"
           >
             03/01/2019
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            <a
+              class="usa-link print"
+              href="/roster/sites/1/enrollments/6/"
+            >
+              Potter, Lily Luna
+            </a>
+             
+          </th>
+          <td
+            class="oec-table__cell--tabular-nums"
+          >
+            12/12/2016
+          </td>
+          <td>
+            <span
+              class="usa-tag undefined bg-blue-50v"
+            >
+              CDC–FT
+            </span>
+          </td>
+          <td
+            class="oec-table__cell--tabular-nums"
+          >
+            02/03/2018
           </td>
         </tr>
       </tbody>

--- a/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`Roster matches snapshot 1`] = `
         <span
           class="text-bold"
         >
-          4/2
+          5/2
         </span>
         <span>
            full time CDC spaces filled

--- a/src/Hedwig/ClientApp/src/contexts/__mocks__/TestProvider.tsx
+++ b/src/Hedwig/ClientApp/src/contexts/__mocks__/TestProvider.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory, History } from 'history';
+
+import UserContext from '../User/UserContext';
+import ReportingPeriodContext from '../ReportingPeriod/ReportingPeriodContext';
+import { User, ReportingPeriod } from '../../generated';
+import { cdcReportingPeriods as _cdcReportingPeriods, user as _user } from '../../tests/data';
+
+type TestProviderProps = {
+	user?: User;
+	cdcReportingPeriods?: ReportingPeriod[];
+	history?: History<any>;
+};
+
+const TestProvider: React.FC<TestProviderProps> = ({
+	children,
+	user = _user,
+	cdcReportingPeriods = _cdcReportingPeriods,
+	history = createMemoryHistory(),
+}) => {
+	return (
+		<UserContext.Provider value={{ user }}>
+			<ReportingPeriodContext.Provider value={{ cdcReportingPeriods }}>
+				<Router history={history}>{children}</Router>
+			</ReportingPeriodContext.Provider>
+		</UserContext.Provider>
+	);
+};
+
+export default TestProvider;

--- a/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/__mocks__/useApi.ts
@@ -1,185 +1,96 @@
 import moment from 'moment';
 import {
-	CdcReport,
 	Enrollment,
-	FundingSource,
 	ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest,
 	ApiOrganizationsOrgIdEnrollmentsGetRequest,
+	Organization,
+	CdcReport,
+	Site,
+	Child,
 } from '../../generated';
-import { completeEnrollment, child, report, organization } from '../../tests/data';
-import { swapFields } from '../../tests/helpers';
 
-const enrollmentValidationError = [
-	{
-		message: 'Child has validation errors',
-		isSubObjectValidation: true,
-		field: 'Child',
-	},
-];
-
-const site = {
-	id: 1,
-	name: "Children's Adventure Center",
-	organizationId: 1,
-	enrollments: undefined,
-	organization: undefined,
-};
-
-export const enrollmentMissingBirthCertId = swapFields(completeEnrollment, [
-	{ keys: ['child', 'birthCertificateId'], newValue: undefined },
-	{ keys: ['id'], newValue: 2 },
-	{ keys: ['validationErrors'], newValue: enrollmentValidationError },
-]);
-
-export const enrollmentMissingAddress = swapFields(completeEnrollment, [
-	{ keys: ['child', 'family', 'addressLine1'], newValue: undefined },
-	{ keys: ['id'], newValue: 4 },
-	{ keys: ['validationErrors'], newValue: enrollmentValidationError },
-
-	{
-		keys: ['child', 'family', 'validationErrors'],
-		newValue: [
-			{
-				message: 'Street address is required',
-				isSubObjectValidation: false,
-				field: 'AddressLine1',
-			},
-		],
-	},
-]);
-
-export const enrollmentWithLaterStart = swapFields(completeEnrollment, [
-	{ keys: ['entry'], newValue: new Date('2019-03-01') },
-	{ keys: ['id'], newValue: 5 },
-]);
-
-export const enrollmentWithFoster = swapFields(completeEnrollment, [
-	{ keys: ['child', 'foster'], newValue: true },
-	{ keys: ['id'], newValue: 6 },
-	{ keys: ['child', 'family', 'determinations'], newValue: [] },
-]);
-
-export const allFakeEnrollments = [
-	{
-		enrollment: completeEnrollment,
-	},
-	{
-		enrollment: enrollmentMissingBirthCertId,
-	},
-	{
-		enrollment: enrollmentMissingAddress,
-	},
-	{
-		enrollment: enrollmentWithLaterStart,
-	},
-	{
-		doNotIncludeInAllEnrollments: true,
-		enrollment: enrollmentWithFoster,
-	},
-];
-
-export const defaultReport = swapFields(report, [
-	{
-		keys: ['enrollments'],
-		newValue: allFakeEnrollments
-			.filter(e => !e.doNotIncludeInAllEnrollments)
-			.map(e => e.enrollment),
-	},
-]);
-
-export const laterReport: CdcReport = swapFields(defaultReport, [
-	{
-		keys: ['reportingPeriod'],
-		newValue: {
-			id: 1,
-			type: FundingSource.CDC,
-			period: new Date('2019-10-01'),
-			dueAt: new Date('2019-11-15'),
-			periodStart: new Date('2019-10-01'),
-			periodEnd: new Date('2019-10-31'),
-		},
-	},
-	{ keys: ['id'], newValue: 2 },
-]);
-
-export const earlierReport: CdcReport = swapFields(defaultReport, [
-	{
-		keys: ['reportingPeriod'],
-		newValue: {
-			id: 1,
-			type: FundingSource.CDC,
-			period: new Date('2019-08-01'),
-			dueAt: new Date('2019-09-15'),
-			periodStart: new Date('2019-08-01'),
-			periodEnd: new Date('2019-08-31'),
-		},
-	},
-	{ keys: ['id'], newValue: 3 },
-	{ keys: ['submittedAt'], newValue: new Date('2019-09-14') },
-	{ keys: ['validationErrors'], newValue: undefined },
-]);
-
-export const mockApi = {
-	apiOrganizationsOrgIdEnrollmentsGet: (params: ApiOrganizationsOrgIdEnrollmentsGetRequest) => {
-		const enrollments = allFakeEnrollments
-			.filter(e => !e.doNotIncludeInAllEnrollments)
-			.filter(e => !params.siteIds || params.siteIds.includes(e.enrollment.siteId))
-			.filter(({ enrollment: e }) => {
-				return (
-					(!e.entry ? true : moment(e.entry).isBefore(params.endDate)) &&
-					(!e.exit ? true : moment(e.exit).isAfter(moment(params.startDate)))
-				);
-			})
-			.map(e => e.enrollment);
-		return [false, null, enrollments];
-	},
-	apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet: (
-		params: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest
-	) => {
-		const thisEnrollment = allFakeEnrollments.find(e => e.enrollment.id === params.id);
-		let error = null;
-		if (!thisEnrollment) return;
-		const mutate = (_: any) => {
-			return new Promise(resolve => {
-				resolve(thisEnrollment.enrollment);
-			});
-		};
-		return [false, error, thisEnrollment.enrollment, mutate];
-	},
-	apiOrganizationsOrgIdChildrenGet: (params: any) => {
-		const mappedChildToEnrollment = [child].reduce<{ [x: string]: Enrollment[] }>((acc, c) => {
-			acc[c.id] = c.enrollments || [];
-			return acc;
-		}, {});
-		return [false, null, mappedChildToEnrollment];
-	},
-	apiOrganizationsOrgIdSitesIdGet: (params: any) => [false, null, site],
-	apiOrganizationsOrgIdSitesSiteIdEnrollmentsGet: (params: any) => [
-		false,
-		null,
-		[enrollmentWithLaterStart, completeEnrollment].filter(e => {
+export const mockApiOrganizationsOrgIdEnrollmentsGet = (enrollments: Enrollment[]) => (
+	params: ApiOrganizationsOrgIdEnrollmentsGetRequest
+) => {
+	const _enrollments = enrollments
+		.filter(e => !params.siteIds || params.siteIds.includes(e.siteId))
+		.filter(e => {
 			return (
 				(!e.entry ? true : moment(e.entry).isBefore(params.endDate)) &&
 				(!e.exit ? true : moment(e.exit).isAfter(moment(params.startDate)))
 			);
-		}),
-	],
-	apiOrganizationsOrgIdReportsGet: (params: any) => [
-		false,
-		null,
-		[defaultReport, laterReport, earlierReport],
-		(_: any) => {
-			return new Promise((resolve, reject) => {
-				resolve(defaultReport);
-				reject({});
-			});
-		},
-	],
-	apiOrganizationsIdGet: (params: any) => [false, null, organization],
-	apiOrganizationsOrgIdReportsIdGet: (params: any) => [false, null, defaultReport],
-	apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdDelete: (params: any) => [false, null],
+		});
+	return [false, null, _enrollments];
 };
 
-export default (query: (api: any) => any) => {
-	return query(mockApi);
+export const mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet = (enrollments: Enrollment[]) => (
+	params: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest
+) => {
+	const thisEnrollment = enrollments.find(e => e.id === params.id);
+	let error = null;
+	if (!thisEnrollment) return;
+	const mutate = (_: any) => {
+		return new Promise(resolve => {
+			resolve(thisEnrollment);
+		});
+	};
+	return [false, error, thisEnrollment, mutate];
 };
+
+export const mockApiOrganizationsOrgIdChildrenGet = (child: Child) => (params: any) => {
+	const mappedChildToEnrollment = [child].reduce<{ [x: string]: Enrollment[] }>((acc, c) => {
+		acc[c.id] = c.enrollments || [];
+		return acc;
+	}, {});
+	return [false, null, mappedChildToEnrollment];
+};
+
+export const mockApiOrganizationsOrgIdSitesIdGet = (site: Site) => (params: any) => [
+	false,
+	null,
+	site,
+];
+
+export const mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsGet = (enrollments: Enrollment[]) => (
+	params: any
+) => [
+	false,
+	null,
+	enrollments.filter(e => {
+		return (
+			(!e.entry ? true : moment(e.entry).isBefore(params.endDate)) &&
+			(!e.exit ? true : moment(e.exit).isAfter(moment(params.startDate)))
+		);
+	}),
+];
+
+export const mockApiOrganizationsOrgIdReportsGet = (reports: CdcReport[]) => (params: any) => [
+	false,
+	null,
+	reports,
+	(_: any) => {
+		return new Promise((resolve, reject) => {
+			resolve(reports);
+			reject({});
+		});
+	},
+];
+
+export const mockApiOrganizationsIdGet = (organization: Organization) => (params: any) => [
+	false,
+	null,
+	organization,
+];
+
+export const mockApiOrganizationsOrgIdReportsIdGet = (report: CdcReport) => (params: any) => [
+	false,
+	null,
+	report,
+];
+
+export const mockApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdDelete = () => (params: any) => [
+	false,
+	null,
+];
+
+export default (mockApi: any) => (query: (api: any) => any) => query(mockApi);

--- a/src/Hedwig/ClientApp/src/tests/data/child.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/child.ts
@@ -1,6 +1,6 @@
 import { Child, Gender } from '../../generated';
 
-export const child: Child = {
+export const mockChild: Child = {
 	id: '2',
 	firstName: 'Lily',
 	middleName: 'Luna',

--- a/src/Hedwig/ClientApp/src/tests/data/enrollment.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/enrollment.ts
@@ -1,8 +1,16 @@
 import { Enrollment, Age, FundingSource, FundingTime } from '../../generated';
+import { swapFields } from '../helpers';
+import { mockChild } from '.';
 
-import { child } from '.';
+const enrollmentValidationError = [
+	{
+		message: 'Child has validation errors',
+		isSubObjectValidation: true,
+		field: 'Child',
+	},
+];
 
-export const completeEnrollment: Enrollment = {
+export const mockCompleteEnrollment: Enrollment = {
 	id: 1,
 	childId: '2',
 	siteId: 1,
@@ -16,7 +24,7 @@ export const completeEnrollment: Enrollment = {
 		wingedKeysId: '00000000-0000-0000-0000-000000000000',
 	},
 	updatedAt: new Date('2020-01-01'),
-	child: child,
+	child: mockChild,
 	fundings: [
 		{
 			id: 1,
@@ -37,3 +45,45 @@ export const completeEnrollment: Enrollment = {
 		},
 	],
 };
+
+export const mockEnrollmentMissingBirthCertId = swapFields(mockCompleteEnrollment, [
+	{ keys: ['child', 'birthCertificateId'], newValue: undefined },
+	{ keys: ['id'], newValue: 2 },
+	{ keys: ['validationErrors'], newValue: enrollmentValidationError },
+]);
+
+export const mockEnrollmentMissingAddress = swapFields(mockCompleteEnrollment, [
+	{ keys: ['child', 'family', 'addressLine1'], newValue: undefined },
+	{ keys: ['id'], newValue: 4 },
+	{ keys: ['validationErrors'], newValue: enrollmentValidationError },
+
+	{
+		keys: ['child', 'family', 'validationErrors'],
+		newValue: [
+			{
+				message: 'Street address is required',
+				isSubObjectValidation: false,
+				field: 'AddressLine1',
+			},
+		],
+	},
+]);
+
+export const mockEnrollmentWithLaterStart = swapFields(mockCompleteEnrollment, [
+	{ keys: ['entry'], newValue: new Date('2019-03-01') },
+	{ keys: ['id'], newValue: 5 },
+]);
+
+export const mockEnrollmentWithFoster = swapFields(mockCompleteEnrollment, [
+	{ keys: ['child', 'foster'], newValue: true },
+	{ keys: ['id'], newValue: 6 },
+	{ keys: ['child', 'family', 'determinations'], newValue: [] },
+]);
+
+export const mockAllFakeEnrollments = [
+	mockCompleteEnrollment,
+	mockEnrollmentMissingBirthCertId,
+	mockEnrollmentMissingAddress,
+	mockEnrollmentWithLaterStart,
+	mockEnrollmentWithFoster,
+];

--- a/src/Hedwig/ClientApp/src/tests/data/index.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/index.ts
@@ -2,3 +2,6 @@ export * from './child';
 export * from './enrollment';
 export * from './organization';
 export * from './report';
+export * from './reportingPeriod';
+export * from './site';
+export * from './user';

--- a/src/Hedwig/ClientApp/src/tests/data/organization.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/organization.ts
@@ -1,6 +1,6 @@
 import { FundingSource, Age, FundingTime, Region } from '../../generated';
 
-export const organization = {
+export const mockOrganization = {
 	id: 1,
 	name: 'Test Organization',
 	fundingSpaces: [

--- a/src/Hedwig/ClientApp/src/tests/data/report.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/report.ts
@@ -1,5 +1,6 @@
 import { CdcReport, FundingSource } from '../../generated';
-import { organization } from '.';
+import { mockOrganization, mockAllFakeEnrollments } from '.';
+import { swapFields } from '../helpers';
 
 const reportEnrollmentValidationError = [
 	{
@@ -9,7 +10,7 @@ const reportEnrollmentValidationError = [
 	},
 ];
 
-export const report: CdcReport = {
+export const mockReport: CdcReport = {
 	id: 1,
 	organizationId: 1,
 	accredited: true,
@@ -23,7 +24,46 @@ export const report: CdcReport = {
 		periodStart: new Date('2019-09-01'),
 		periodEnd: new Date('2019-09-28'),
 	},
-	organization: organization,
+	organization: mockOrganization,
 	familyFeesRevenue: 1000,
 	validationErrors: reportEnrollmentValidationError,
 };
+
+export const mockDefaultReport = swapFields(mockReport, [
+	{
+		keys: ['enrollments'],
+		newValue: mockAllFakeEnrollments,
+	},
+]);
+
+export const laterReport: CdcReport = swapFields(mockDefaultReport, [
+	{
+		keys: ['reportingPeriod'],
+		newValue: {
+			id: 1,
+			type: FundingSource.CDC,
+			period: new Date('2019-10-01'),
+			dueAt: new Date('2019-11-15'),
+			periodStart: new Date('2019-10-01'),
+			periodEnd: new Date('2019-10-31'),
+		},
+	},
+	{ keys: ['id'], newValue: 2 },
+]);
+
+export const earlierReport: CdcReport = swapFields(mockDefaultReport, [
+	{
+		keys: ['reportingPeriod'],
+		newValue: {
+			id: 1,
+			type: FundingSource.CDC,
+			period: new Date('2019-08-01'),
+			dueAt: new Date('2019-09-15'),
+			periodStart: new Date('2019-08-01'),
+			periodEnd: new Date('2019-08-31'),
+		},
+	},
+	{ keys: ['id'], newValue: 3 },
+	{ keys: ['submittedAt'], newValue: new Date('2019-09-14') },
+	{ keys: ['validationErrors'], newValue: undefined },
+]);

--- a/src/Hedwig/ClientApp/src/tests/data/reportingPeriod.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/reportingPeriod.ts
@@ -1,0 +1,28 @@
+import { ReportingPeriod, FundingSource } from '../../generated';
+
+export const cdcReportingPeriods: ReportingPeriod[] = [
+	{
+		id: 1,
+		type: FundingSource.CDC,
+		period: new Date('2019-03-01'),
+		periodStart: new Date('2019-03-01'),
+		periodEnd: new Date('2019-03-31'),
+		dueAt: new Date('2019-04-15'),
+	},
+	{
+		id: 2,
+		type: FundingSource.CDC,
+		period: new Date('2019-04-01'),
+		periodStart: new Date('2019-04-01'),
+		periodEnd: new Date('2019-04-30'),
+		dueAt: new Date('2019-05-15'),
+	},
+	{
+		id: 3,
+		type: FundingSource.CDC,
+		period: new Date('2019-05-01'),
+		periodStart: new Date('2019-05-01'),
+		periodEnd: new Date('2019-05-31'),
+		dueAt: new Date('2019-06-15'),
+	},
+];

--- a/src/Hedwig/ClientApp/src/tests/data/reportingPeriod.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/reportingPeriod.ts
@@ -1,28 +1,39 @@
 import { ReportingPeriod, FundingSource } from '../../generated';
 
+const defaultCdcReportingPeriod = { type: FundingSource.CDC };
+
+const marchFirst = new Date('2019-03-01');
+const marchReportingPeriod = {
+	...defaultCdcReportingPeriod,
+	id: 1,
+	period: marchFirst,
+	periodStart: marchFirst,
+	periodEnd: new Date('2019-03-31'),
+	dueAt: new Date('2019-04-15'),
+};
+
+const aprilFirst = new Date('2019-04-01');
+const aprilReportingPeriod = {
+	...defaultCdcReportingPeriod,
+	id: 2,
+	period: aprilFirst,
+	periodStart: aprilFirst,
+	periodEnd: new Date('2019-04-30'),
+	dueAt: new Date('2019-05-15'),
+};
+
+const mayFirst = new Date('2019-05-01');
+const mayReportingPeriod = {
+	...defaultCdcReportingPeriod,
+	id: 3,
+	period: mayFirst,
+	periodStart: mayFirst,
+	periodEnd: new Date('2019-05-31'),
+	dueAt: new Date('2019-06-15'),
+};
+
 export const cdcReportingPeriods: ReportingPeriod[] = [
-	{
-		id: 1,
-		type: FundingSource.CDC,
-		period: new Date('2019-03-01'),
-		periodStart: new Date('2019-03-01'),
-		periodEnd: new Date('2019-03-31'),
-		dueAt: new Date('2019-04-15'),
-	},
-	{
-		id: 2,
-		type: FundingSource.CDC,
-		period: new Date('2019-04-01'),
-		periodStart: new Date('2019-04-01'),
-		periodEnd: new Date('2019-04-30'),
-		dueAt: new Date('2019-05-15'),
-	},
-	{
-		id: 3,
-		type: FundingSource.CDC,
-		period: new Date('2019-05-01'),
-		periodStart: new Date('2019-05-01'),
-		periodEnd: new Date('2019-05-31'),
-		dueAt: new Date('2019-06-15'),
-	},
+	marchReportingPeriod,
+	aprilReportingPeriod,
+	mayReportingPeriod,
 ];

--- a/src/Hedwig/ClientApp/src/tests/data/site.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/site.ts
@@ -1,0 +1,11 @@
+import { Site, Region } from '../../generated';
+
+export const mockSite: Site = {
+	id: 1,
+	name: "Children's Adventure Center",
+	organizationId: 1,
+	enrollments: undefined,
+	organization: undefined,
+	titleI: false,
+	region: Region.East,
+};

--- a/src/Hedwig/ClientApp/src/tests/data/user.ts
+++ b/src/Hedwig/ClientApp/src/tests/data/user.ts
@@ -1,0 +1,30 @@
+import emptyGuid from '../../utils/emptyGuid';
+import { User, Region } from '../../generated';
+
+export const user: User = {
+	id: 1,
+	wingedKeysId: emptyGuid(),
+	firstName: 'Minerva',
+	lastName: 'McGonagall',
+	orgPermissions: [
+		{
+			organizationId: 1,
+			organization: {
+				id: 1,
+				name: "Children's Adventure Center",
+				sites: [
+					{
+						id: 1,
+						name: "Children's Adventure Center",
+						organizationId: 1,
+						region: Region.East,
+						titleI: false,
+					},
+				],
+			},
+			id: 1,
+			userId: 1,
+		},
+	],
+	sitePermissions: [],
+};


### PR DESCRIPTION
Simplifies `CommonContextMockProvider` and `useApi` mock. Mostly addresses the issue that Chris identified in the report tests -- I think this is much cleaner.

Does have the downside that import order matters but I am comfortable with that tradeoff