### PR TITLE
Update mutate error return

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
@@ -179,7 +179,7 @@ const ChildInfo: Section = {
 				};
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsPost(postParams))
 					.then(res => {
-						if (successCallback && res && !error) successCallback(res);
+						if (successCallback && res) successCallback(res);
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(ChildInfo);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
@@ -401,7 +401,7 @@ const EnrollmentFunding: Section = {
 
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
 					.then(res => {
-						if (successCallback && res && !error) successCallback(res);
+						if (successCallback && res) successCallback(res);
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(EnrollmentFunding);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome.tsx
@@ -153,7 +153,7 @@ const FamilyIncome: Section = {
 				};
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
 					.then(res => {
-						if (successCallback && res && !error) successCallback(res);
+						if (successCallback && res) successCallback(res);
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(FamilyIncome);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
@@ -118,8 +118,7 @@ const FamilyInfo: Section = {
 				};
 				return mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(params))
 					.then(res => {
-						// console.log(res);
-						if (successCallback && res && !error) successCallback(res);
+						if (successCallback && res) successCallback(res);
 					})
 					.finally(() => {
 						finallyCallback && finallyCallback(FamilyInfo);

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
@@ -180,7 +180,7 @@ export default function Withdrawal({
 			},
 		};
 
-		mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(putParams)).then((res) => {
+		mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(putParams)).then(res => {
 			if (res) {
 				setAlerts([childWithdrawnAlert(nameFormatter(enrollment.child))]);
 				history.push(`/roster`);

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
@@ -137,14 +137,6 @@ export default function Withdrawal({
 		}
 	}, [enrollment, isMissingInformation, history, setAlerts, siteId]);
 
-	const [withdrawnAttempted, setWithdrawnAttempted] = useState(false);
-	useEffect(() => {
-		if (withdrawnAttempted && !error) {
-			setAlerts([childWithdrawnAlert(nameFormatter(enrollment.child))]);
-			history.push(`/roster`);
-		}
-	}, [withdrawnAttempted, enrollment, history, setAlerts, error]);
-
 	if (loading || !enrollment || !enrollment.site) {
 		return <div className="Withdrawl"></div>;
 	}
@@ -188,8 +180,11 @@ export default function Withdrawal({
 			},
 		};
 
-		mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(putParams)).then(res => {
-			setWithdrawnAttempted(true);
+		mutate(api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut(putParams)).then((res) => {
+			if (res) {
+				setAlerts([childWithdrawnAlert(nameFormatter(enrollment.child))]);
+				history.push(`/roster`);
+			}
 		});
 	};
 

--- a/src/Hedwig/ClientApp/src/hooks/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useApi.ts
@@ -17,6 +17,7 @@ export type Mutate<TData> = (
 	query: Query<TData>,
 	reducer?: Reducer<TData | undefined>
 ) => Promise<TData | null>;
+// Null is the return value if the mutation fails
 
 interface ApiParamOpts<T> {
 	defaultValue?: T;
@@ -121,11 +122,12 @@ export default function useApi<TData>(
 					setState(_state => {
 						return { ..._state, loading: false, error: null, data: reducer(data, result) };
 					});
-					return result; // is there a reason we return the result?
+					return result;
 				})
 				.catch(async apiError => {
 					await handleError(apiError);
 					return null;
+					// If there was an error, return null
 				});
 		},
 		[api, data]

--- a/src/Hedwig/ClientApp/src/hooks/useApi.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useApi.ts
@@ -16,7 +16,7 @@ export type Query<TData> = (api: HedwigApi) => Promise<TData>;
 export type Mutate<TData> = (
 	query: Query<TData>,
 	reducer?: Reducer<TData | undefined>
-) => Promise<TData | void>;
+) => Promise<TData | null>;
 
 interface ApiParamOpts<T> {
 	defaultValue?: T;
@@ -125,6 +125,7 @@ export default function useApi<TData>(
 				})
 				.catch(async apiError => {
 					await handleError(apiError);
+					return null;
 				});
 		},
 		[api, data]


### PR DESCRIPTION
@jlhogan you were right that this would fix #834 -- the error check in the child info promise was getting the old error from the first save attempt.