### PR TITLE
fix pull request auto-trigger issue (#869)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,11 @@
 trigger:
   - master
 
+pr:
+  branches:
+    include:
+    - '*'
+
 pool:
   vmImage: "ubuntu-latest"
 


### PR DESCRIPTION
Microsoft has broken its own product via an update. As a result, the PR and CI builds are not automatically triggering. As a workaround, they must be manually started. To resolve the issue Microsoft recommends to explicitly identify the triggers in the YAML file.

For more information, see https://developercommunity.visualstudio.com/content/problem/948871/github-is-not-able-to-trigger-ado-pipeline-builds.html