### PR TITLE
Add references for reporting periods in validations

### DIFF
--- a/src/Hedwig/Repositories/ReportingPeriodRepository.cs
+++ b/src/Hedwig/Repositories/ReportingPeriodRepository.cs
@@ -27,11 +27,19 @@ namespace Hedwig.Repositories
 				.OrderByDescending(period => period.Period)
 				.FirstOrDefault();
 		}
+
+		public ReportingPeriod GetById(int id)
+		{
+			return _context.ReportingPeriods
+				.FirstOrDefault(period => period.Id == id);
+		}
 	}
 
 	public interface IReportingPeriodRepository : IHedwigRepository
 	{
 		Task<List<ReportingPeriod>> GetReportingPeriodsByFundingSourceAsync(FundingSource source);
 		ReportingPeriod GetLastReportingPeriodBeforeDate(FundingSource source, DateTime compareDate);
+
+		ReportingPeriod GetById(int id);
 	}
 }

--- a/src/Hedwig/Validations/Rules/FamilyDetermination/IfEnrollmentFunded_DeterminationDateValid.cs
+++ b/src/Hedwig/Validations/Rules/FamilyDetermination/IfEnrollmentFunded_DeterminationDateValid.cs
@@ -8,12 +8,15 @@ namespace Hedwig.Validations.Rules
 	public class IfEnrollmentFunded_DeterminationDateValid : IValidationRule<FamilyDetermination>
 	{
 		private readonly IFundingRepository _fundings;
+		private readonly IReportingPeriodRepository _reportingPeriods;
 
 		public IfEnrollmentFunded_DeterminationDateValid(
-			IFundingRepository fundings
+			IFundingRepository fundings,
+			IReportingPeriodRepository reportingPeriods
 		)
 		{
 			_fundings = fundings;
+			_reportingPeriods = reportingPeriods;
 		}
 
 		public ValidationError Execute(FamilyDetermination determination, NonBlockingValidationContext context)
@@ -32,7 +35,9 @@ namespace Hedwig.Validations.Rules
 				var report = context.GetParentEntity<CdcReport>();
 				if (report != null)
 				{
-					compareDate = report.ReportingPeriod.PeriodEnd;
+					compareDate = report.ReportingPeriod != null
+						? report.ReportingPeriod.PeriodEnd
+						: _reportingPeriods.GetById(report.ReportingPeriodId).PeriodEnd;
 				}
 
 				if (determination.DeterminationDate < compareDate.AddYears(-1))

--- a/test/HedwigTests/Validations/Rules/FamilyDetermination/IfEnrollmentFunded_DeterminationDateValidTests.cs
+++ b/test/HedwigTests/Validations/Rules/FamilyDetermination/IfEnrollmentFunded_DeterminationDateValidTests.cs
@@ -40,7 +40,8 @@ namespace HedwigTests.Validations.Rules
 
 			// when
 			var fundings = new Mock<IFundingRepository>();
-			var rule = new IfEnrollmentFunded_DeterminationDateValid(fundings.Object);
+			var reportingPeriods = new Mock<IReportingPeriodRepository>();
+			var rule = new IfEnrollmentFunded_DeterminationDateValid(fundings.Object, reportingPeriods.Object);
 
 			var context = new NonBlockingValidationContext();
 			context.AddParentEntity(enrollment);
@@ -87,7 +88,8 @@ namespace HedwigTests.Validations.Rules
 
 			// when
 			var fundings = new Mock<IFundingRepository>();
-			var rule = new IfEnrollmentFunded_DeterminationDateValid(fundings.Object);
+			var reportingPeriods = new Mock<IReportingPeriodRepository>();
+			var rule = new IfEnrollmentFunded_DeterminationDateValid(fundings.Object, reportingPeriods.Object);
 
 			var context = new NonBlockingValidationContext();
 			context.AddParentEntity(enrollment);


### PR DESCRIPTION
this is a not-nice outcome of un-setting read only properties before validation time.. however, I'm in the process of turning validation into a filter as well, which can run before the unset ! and then we can undo this. 

this fixes the existing reporting submissing failure in staging blocking prod deploy 