### PR TITLE
Past enrollments

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
@@ -45,7 +45,7 @@ export default function EnrollmentDetail({
 		id: enrollmentId ? enrollmentId : 0,
 		orgId: getIdForUser(user, 'org'),
 		siteId: validatePermissions(user, 'site', siteId) ? siteId : 0,
-		include: ['child', 'family', 'determinations', 'fundings', 'sites'],
+		include: ['child', 'family', 'determinations', 'fundings', 'sites', 'past_enrollments'],
 	};
 	const [loading, error, enrollment, mutate] = useApi<Enrollment>(
 		api => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet(params),

--- a/src/Hedwig/ClientApp/src/generated/apis/HedwigApi.ts
+++ b/src/Hedwig/ClientApp/src/generated/apis/HedwigApi.ts
@@ -48,14 +48,6 @@ export interface ApiOrganizationsIdGetRequest {
 	include?: Array<string>;
 }
 
-export interface ApiOrganizationsOrgIdChildrenGetRequest {
-	orgId: number;
-	reportId?: number;
-	include?: Array<string>;
-	startDate?: Date;
-	endDate?: Date;
-}
-
 export interface ApiOrganizationsOrgIdEnrollmentsGetRequest {
 	orgId: number;
 	siteIds?: Array<number>;
@@ -177,64 +169,6 @@ export class HedwigApi extends runtime.BaseAPI {
 		requestParameters: ApiOrganizationsIdGetRequest
 	): Promise<Organization> {
 		const response = await this.apiOrganizationsIdGetRaw(requestParameters);
-		return await response.value();
-	}
-
-	/**
-	 */
-	async apiOrganizationsOrgIdChildrenGetRaw(
-		requestParameters: ApiOrganizationsOrgIdChildrenGetRequest
-	): Promise<runtime.ApiResponse<{ [key: string]: Array<Enrollment> }>> {
-		if (requestParameters.orgId === null || requestParameters.orgId === undefined) {
-			throw new runtime.RequiredError(
-				'orgId',
-				'Required parameter requestParameters.orgId was null or undefined when calling apiOrganizationsOrgIdChildrenGet.'
-			);
-		}
-
-		const queryParameters: runtime.HTTPQuery = {};
-
-		if (requestParameters.reportId !== undefined) {
-			queryParameters['reportId'] = requestParameters.reportId;
-		}
-
-		if (requestParameters.include) {
-			queryParameters['include[]'] = requestParameters.include;
-		}
-
-		if (requestParameters.startDate !== undefined) {
-			queryParameters['startDate'] = (requestParameters.startDate as any).toISOString();
-		}
-
-		if (requestParameters.endDate !== undefined) {
-			queryParameters['endDate'] = (requestParameters.endDate as any).toISOString();
-		}
-
-		const headerParameters: runtime.HTTPHeaders = {};
-
-		if (this.configuration && this.configuration.apiKey) {
-			headerParameters['Authorization'] = this.configuration.apiKey('Authorization'); // Bearer authentication
-		}
-
-		const response = await this.request({
-			path: `/api/organizations/{orgId}/Children`.replace(
-				`{${'orgId'}}`,
-				encodeURIComponent(String(requestParameters.orgId))
-			),
-			method: 'GET',
-			headers: headerParameters,
-			query: queryParameters,
-		});
-
-		return new runtime.JSONApiResponse<any>(response);
-	}
-
-	/**
-	 */
-	async apiOrganizationsOrgIdChildrenGet(
-		requestParameters: ApiOrganizationsOrgIdChildrenGetRequest
-	): Promise<{ [key: string]: Array<Enrollment> }> {
-		const response = await this.apiOrganizationsOrgIdChildrenGetRaw(requestParameters);
 		return await response.value();
 	}
 

--- a/src/Hedwig/ClientApp/src/generated/models/Enrollment.ts
+++ b/src/Hedwig/ClientApp/src/generated/models/Enrollment.ts
@@ -108,6 +108,12 @@ export interface Enrollment {
 	fundings?: Array<Funding> | null;
 	/**
 	 *
+	 * @type {Array<Enrollment>}
+	 * @memberof Enrollment
+	 */
+	pastEnrollments?: Array<Enrollment> | null;
+	/**
+	 *
 	 * @type {Array<ValidationError>}
 	 * @memberof Enrollment
 	 */
@@ -159,6 +165,11 @@ export function EnrollmentFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 			: json['fundings'] === null
 			? null
 			: (json['fundings'] as Array<any>).map(FundingFromJSON),
+		pastEnrollments: !exists(json, 'pastEnrollments')
+			? undefined
+			: json['pastEnrollments'] === null
+			? null
+			: (json['pastEnrollments'] as Array<any>).map(EnrollmentFromJSON),
 		validationErrors: !exists(json, 'validationErrors')
 			? undefined
 			: json['validationErrors'] === null
@@ -203,6 +214,12 @@ export function EnrollmentToJSON(value?: Enrollment | null): any {
 				: value.fundings === null
 				? null
 				: (value.fundings as Array<any>).map(FundingToJSON),
+		pastEnrollments:
+			value.pastEnrollments === undefined
+				? undefined
+				: value.pastEnrollments === null
+				? null
+				: (value.pastEnrollments as Array<any>).map(EnrollmentToJSON),
 		validationErrors:
 			value.validationErrors === undefined
 				? undefined

--- a/src/Hedwig/Controllers/ChildrenController.cs
+++ b/src/Hedwig/Controllers/ChildrenController.cs
@@ -1,13 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authorization;
-using Hedwig.Models;
 using Hedwig.Repositories;
-using Hedwig.Validations;
 using Hedwig.Security;
 
 namespace Hedwig.Controllers
@@ -17,30 +10,12 @@ namespace Hedwig.Controllers
 	[Route("api/organizations/{orgId:int}/[controller]")]
 	public class ChildrenController : ControllerBase
 	{
-		private readonly INonBlockingValidator _validator;
 		private readonly IChildRepository _children;
 		public ChildrenController(
-			INonBlockingValidator validator,
 			IChildRepository children
 		)
 		{
-			_validator = validator;
 			_children = children;
-		}
-
-		[HttpGet]
-		[ProducesResponseType(StatusCodes.Status200OK)]
-		[ProducesResponseType(StatusCodes.Status204NoContent)]
-		public async Task<ActionResult<IDictionary<Guid, ICollection<Enrollment>>>> Get(
-			int orgId,
-			[FromQuery(Name = "reportId")] int reportId,
-			[FromQuery(Name = "include[]")] string[] include,
-			[FromQuery(Name = "startDate")] DateTime? from = null,
-			[FromQuery(Name = "endDate")] DateTime? to = null
-		)
-		{
-			var children = await _children.GetChildrenIdToEnrollmentsForOrganizationAsync(orgId, reportId, from, to, include);
-			return Ok(children);
 		}
 	}
 }

--- a/src/Hedwig/Models/Attributes/PropertyInfoExtensions.cs
+++ b/src/Hedwig/Models/Attributes/PropertyInfoExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Reflection;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Hedwig.Models.Attributes
+{
+	public static class PropertyInfoExtensions
+	{
+		public static bool IsReadOnly(this PropertyInfo property)
+		{
+			ReadOnlyAttribute attribute = (ReadOnlyAttribute)Attribute.GetCustomAttribute(property, typeof(ReadOnlyAttribute));
+			return attribute != null;
+		}
+
+		public static bool IsNotMapped(this PropertyInfo property)
+		{
+			NotMappedAttribute attribute = (NotMappedAttribute)Attribute.GetCustomAttribute(property, typeof(NotMappedAttribute));
+			return attribute != null;
+		}
+	}
+}

--- a/src/Hedwig/Models/Enrollment.cs
+++ b/src/Hedwig/Models/Enrollment.cs
@@ -42,6 +42,9 @@ namespace Hedwig.Models
 		public ICollection<Funding> Fundings { get; set; }
 
 		[NotMapped]
+		public ICollection<Enrollment> PastEnrollments { get; set; }
+
+		[NotMapped]
 		public List<ValidationError> ValidationErrors { get; set; }
 	}
 }

--- a/src/Hedwig/Repositories/ChildRepository.cs
+++ b/src/Hedwig/Repositories/ChildRepository.cs
@@ -34,60 +34,6 @@ namespace Hedwig.Repositories
 			return await children.ToListAsync();
 		}
 
-		public async Task<IDictionary<Guid, ICollection<Enrollment>>> GetChildrenIdToEnrollmentsForOrganizationAsync(
-			int organizationId,
-			int reportId,
-			DateTime? from = null,
-			DateTime? to = null,
-			string[] include = null
-		)
-		{
-			var childrenSet = _context.Children;
-			var enrollmentsSet = _context.Enrollments;
-			var children = childrenSet.AsQueryable();
-			var enrollments = enrollmentsSet.AsQueryable();
-
-			// Prepare asOf if necessary
-			var report = _context.Reports.Where(r => r.Id == reportId).SingleOrDefault();
-			if (report != null && report.SubmittedAt.HasValue)
-			{
-				children = childrenSet.AsOf(report.SubmittedAt.Value);
-				enrollments = enrollmentsSet.AsOf(report.SubmittedAt.Value);
-			}
-
-			// Get IDs of children in given Organization
-			var childrenIdsForOrganization = await children
-				.Where(c => c.OrganizationId == organizationId)
-				.Select(c => c.Id)
-				.ToListAsync();
-
-			// Get IDs of children with
-			// enrollments in any sites in the given organization
-			// filtered by given dates
-			var childIds = await enrollments
-				.FilterByDates(from, to)
-				.Where(e => childrenIdsForOrganization.Contains(e.ChildId))
-				.Select(e => e.ChildId)
-				.ToListAsync();
-
-			var childrenQuery = children
-				.Include(c => c.Enrollments)
-				.ThenInclude(e => e.Fundings)
-				.Where(c => childIds.Contains(c.Id));
-
-			include = include ?? new string[] { };
-			if (include.Contains(INCLUDE_FAMILY))
-			{
-				childrenQuery = childrenQuery.Include(c => c.Family);
-
-				if (include.Contains(INCLUDE_DETERMINATIONS))
-				{
-					childrenQuery = ((IIncludableQueryable<Child, Family>)childrenQuery).ThenInclude(f => f.Determinations);
-				}
-			}
-			return await childrenQuery.ToDictionaryAsync(c => c.Id, c => c.Enrollments);
-		}
-
 		public Task<Child> GetChildForOrganizationAsync(Guid id, int organizationId, string[] include = null)
 		{
 			var child = _context.Children
@@ -119,13 +65,6 @@ namespace Hedwig.Repositories
 	{
 		Task<List<Child>> GetChildrenForOrganizationAsync(
 			int organizationId,
-			string[] include = null
-		);
-		Task<IDictionary<Guid, ICollection<Enrollment>>> GetChildrenIdToEnrollmentsForOrganizationAsync(
-			int organizationId,
-			int reportId,
-			DateTime? from = null,
-			DateTime? to = null,
 			string[] include = null
 		);
 		Task<Child> GetChildForOrganizationAsync(Guid id, int organizationId, string[] include);

--- a/src/Hedwig/Repositories/HedwigRepository.cs
+++ b/src/Hedwig/Repositories/HedwigRepository.cs
@@ -14,6 +14,7 @@ namespace Hedwig.Repositories
 		public const string INCLUDE_CHILD = "child";
 		public const string INCLUDE_FUNDINGS = "fundings";
 		public const string INCLUDE_ENROLLMENTS = "enrollments";
+		public const string INCLUDE_PAST_ENROLLMENTS = "past_enrollments";
 		public const string INCLUDE_SITES = "sites";
 		public const string INCLUDE_ORGANIZATIONS = "organizations";
 		public const string INCLUDE_FUNDING_SPACES = "funding_spaces";

--- a/src/Hedwig/Validations/NonBlockingValidationContext.cs
+++ b/src/Hedwig/Validations/NonBlockingValidationContext.cs
@@ -37,5 +37,16 @@ namespace Hedwig.Validations
 			ParentEntities.TryGetValue(typeof(T), out value);
 			return (T)value;
 		}
+
+		/// <summary>
+		/// Removes entry with key of Type T from ParentEntities dictionary.
+		/// Returns the result of the Dictionary.Remove() call.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <returns></returns>
+		public bool RemoveParentEntity<T>()
+		{
+			return ParentEntities.Remove(typeof(T));
+		}
 	}
 }

--- a/src/Hedwig/Validations/NonBlockingValidator.cs
+++ b/src/Hedwig/Validations/NonBlockingValidator.cs
@@ -37,6 +37,8 @@ namespace Hedwig.Validations
 				if (error != null) errors.Add(error);
 			}
 
+			_validationContext.RemoveParentEntity<T>();
+
 			entity.ValidationErrors = errors;
 		}
 

--- a/test/HedwigTests/Repositories/ChildRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/ChildRepositoryTests.cs
@@ -45,54 +45,6 @@ namespace HedwigTests.Repositories
 		}
 
 		[Theory]
-		[InlineData(1, 2, 1)]
-		[InlineData(0, 0, 1)]
-		[InlineData(2, 4, 1)]
-		public async Task GetChildrenIdToEnrollmentsForOrganization(
-			int child1EnrollmentsCount,
-			int child2EnrollmentsCount,
-			int child3EnrollmentsCount
-		)
-		{
-			Guid[] ids = new Guid[] { };
-			int organizationId;
-			Report report;
-			using (var context = new TestHedwigContextProvider().Context)
-			{
-				var organization = OrganizationHelper.CreateOrganization(context);
-				report = ReportHelper.CreateCdcReport(context, null, organization, null);
-				var children = ChildHelper.CreateChildren(context, 3, organization: organization);
-				var child1Enrollments = EnrollmentHelper.CreateEnrollments(context, child1EnrollmentsCount, children[0]);
-				var child2Enrollments = EnrollmentHelper.CreateEnrollments(context, child2EnrollmentsCount, children[1]);
-				var child3Enrollments = EnrollmentHelper.CreateEnrollments(context, child3EnrollmentsCount, children[2]);
-				if (child1EnrollmentsCount > 0)
-				{
-					ids = ids.Append(children[0].Id).ToArray();
-				}
-				if (child2EnrollmentsCount > 0)
-				{
-					ids = ids.Append(children[1].Id).ToArray();
-				}
-				if (child3EnrollmentsCount > 0)
-				{
-					ids = ids.Append(children[2].Id).ToArray();
-				}
-				organizationId = organization.Id;
-			}
-
-			using (var context = new TestHedwigContextProvider().Context)
-			{
-				var childRepo = new ChildRepository(context);
-				var res = await childRepo.GetChildrenIdToEnrollmentsForOrganizationAsync(organizationId, report.Id, null, null, new string[] { });
-				var values = res.Values;
-				var enrollments = values.SelectMany(v => v).ToList();
-				Assert.Equal(ids.OrderBy(id => id), res.Select(c => c.Key).OrderBy(id => id));
-				Assert.Equal(ids.Length, res.Values.Count);
-				Assert.Equal(child1EnrollmentsCount + child2EnrollmentsCount + child3EnrollmentsCount, enrollments.Count());
-			}
-		}
-
-		[Theory]
 		[InlineData(new string[] { }, false, false)]
 		[InlineData(new string[] { "family" }, true, false)]
 		[InlineData(new string[] { "determinations" }, false, false)]

--- a/test/HedwigTests/Repositories/EnrollmentRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/EnrollmentRepositoryTests.cs
@@ -188,23 +188,25 @@ namespace HedwigTests.Repositories
 		}
 
 		[Theory]
-		[InlineData(new string[] { }, false, false, false, false)]
-		[InlineData(new string[] { "fundings" }, true, false, false, false)]
-		[InlineData(new string[] { "child" }, false, true, false, false)]
-		[InlineData(new string[] { "family" }, false, false, false, false)]
-		[InlineData(new string[] { "determinations" }, false, false, false, false)]
-		[InlineData(new string[] { "child", "family" }, false, true, true, false)]
-		[InlineData(new string[] { "child", "determinations" }, false, true, false, false)]
-		[InlineData(new string[] { "child", "family", "determinations" }, false, true, true, true)]
-		[InlineData(new string[] { "child", "family", "determinations", "fundings" }, true, true, true, true)]
-		[InlineData(new string[] { "family", "determinations" }, false, false, false, false)]
-		[InlineData(new string[] { "family", "determinations", "fundings" }, true, false, false, false)]
+		[InlineData(new string[] { }, false, false, false, false, false)]
+		[InlineData(new string[] { "fundings" }, true, false, false, false, false)]
+		[InlineData(new string[] { "child" }, false, true, false, false, false)]
+		[InlineData(new string[] { "family" }, false, false, false, false, false)]
+		[InlineData(new string[] { "determinations" }, false, false, false, false, false)]
+		[InlineData(new string[] { "past_enrollments" }, false, false, false, false, true)]
+		[InlineData(new string[] { "child", "family" }, false, true, true, false, false)]
+		[InlineData(new string[] { "child", "determinations" }, false, true, false, false, false)]
+		[InlineData(new string[] { "child", "family", "determinations" }, false, true, true, true, false)]
+		[InlineData(new string[] { "child", "family", "determinations", "fundings" }, true, true, true, true, false)]
+		[InlineData(new string[] { "family", "determinations" }, false, false, false, false, false)]
+		[InlineData(new string[] { "family", "determinations", "fundings" }, true, false, false, false, false)]
 		public async Task GetEnrollmentForSite_ReturnsEnrollmentWithIdAndSiteId_IncludesEntities(
 			string[] include,
 			bool includeFundings,
 			bool includeChild,
 			bool includeFamily,
-			bool includeDeterminations
+			bool includeDeterminations,
+			bool includePastEnrollments
 			)
 		{
 			int id;
@@ -212,6 +214,7 @@ namespace HedwigTests.Repositories
 			using (var context = new TestHedwigContextProvider().Context)
 			{
 				var enrollment = EnrollmentHelper.CreateEnrollment(context);
+				EnrollmentHelper.CreateEnrollment(context, child: enrollment.Child);
 				id = enrollment.Id;
 				siteId = enrollment.SiteId;
 			}
@@ -226,6 +229,7 @@ namespace HedwigTests.Repositories
 				Assert.Equal(includeChild, res.Child != null);
 				Assert.Equal(includeFamily, res.Child != null && res.Child.Family != null);
 				Assert.Equal(includeDeterminations, res.Child != null && res.Child.Family != null && res.Child.Family.Determinations != null);
+				Assert.Equal(includePastEnrollments, res.PastEnrollments != null);
 			}
 		}
 


### PR DESCRIPTION
Altho I think it'll ultimately be better to use child as the root object in the enrollment detail flow, it was snowballing into a bigger change. This unblocks creating frontend utils to create enrollment history, which will still be mostly applicable when/if we decide to do the refactor. 

closes #908 