### PR TITLE
startup.cs - fixed app settings reference for database

### DIFF
--- a/src/Hedwig/Startup.cs
+++ b/src/Hedwig/Startup.cs
@@ -40,7 +40,7 @@ namespace Hedwig
 
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 		{
-			var isAutomaticallyApplyMigrations = EnvironmentConfiguration.GetEnvironmentVariableFromAppSettings("AutomaticallyApplyMigrations") == "true";
+			var isAutomaticallyApplyMigrations = EnvironmentConfiguration.GetEnvironmentVariableFromAppSettings("Database:AutomaticallyApplyMigrations") == "true";
 			if (isAutomaticallyApplyMigrations)
 			{
 				app.UpdateDatabase();


### PR DESCRIPTION
Fix issue (#1017)

Startup.cs contains the following line:
- var isAutomaticallyApplyMigrations = EnvironmentConfiguration.GetEnvironmentVariableFromAppSettings("AutomaticallyApplyMigrations")

This line should be:
- var isAutomaticallyApplyMigrations = EnvironmentConfiguration.GetEnvironmentVariableFromAppSettings("Database:AutomaticallyApplyMigrations")