### PR TITLE
introduces a hook to deal with catchall error alerts, and updates new…

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../../utils/validations/messageStrings';
 import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
 import idx from 'idx';
+import useCatchallErrorAlert from '../../../hooks/useCatchallErrorAlert';
 
 const ChildInfo: Section = {
 	key: 'child-information',
@@ -86,6 +87,7 @@ const ChildInfo: Section = {
 		// set up form state
 		const initialLoad = touchedSections ? !touchedSections[ChildInfo.key] : false;
 		const [_error, setError] = useState<ApiError | null>(error);
+		const errorAlertState = useCatchallErrorAlert(_error);
 		useFocusFirstError([_error]);
 		useEffect(() => {
 			if (_error) {
@@ -227,6 +229,7 @@ const ChildInfo: Section = {
 										response: _error,
 										type: 'error',
 										message: REQUIRED_FOR_ENROLLMENT,
+										errorAlertState
 									},
 								])
 							)}
@@ -260,6 +263,7 @@ const ChildInfo: Section = {
 											response: _error,
 											type: 'error',
 											message: REQUIRED_FOR_ENROLLMENT,
+											errorAlertState
 										},
 									])
 								)}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
@@ -64,6 +64,7 @@ import {
 	REQUIRED_FOR_OEC_REPORTING,
 } from '../../../utils/validations/messageStrings';
 import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
+import useCatchallErrorAlert from '../../../hooks/useCatchallErrorAlert';
 
 type UtilizationRate = {
 	capacity: number;
@@ -157,17 +158,7 @@ const EnrollmentFunding: Section = {
 		const initialLoad = touchedSections ? !touchedSections[EnrollmentFunding.key] : false;
 		const [error, setError] = useState<ApiError | null>(inputError);
 		useFocusFirstError([error]);
-		useEffect(() => {
-			if (error) {
-				if (initialLoad) {
-					setAlerts([validationErrorAlert]);
-				} else {
-					if (!isBlockingValidationError(error)) {
-						throw new Error(error.title || 'Unknown api error');
-					}
-				}
-			}
-		}, [error, initialLoad, setAlerts]);
+		const errorAlertState = useCatchallErrorAlert(error);
 
 		const { user } = useContext(UserContext);
 		const { cdcReportingPeriods: reportingPeriods } = useContext(ReportingPeriodContext);
@@ -653,11 +644,13 @@ const EnrollmentFunding: Section = {
 													response: error,
 													field: 'fundings.fundingSpaceId',
 													message: REQUIRED_FOR_OEC_REPORTING,
+													errorAlertState
 												},
 												{
 													type: 'error',
 													response: error,
 													field: 'fundings.fundingspace',
+													errorAlertState
 												},
 											])
 										)}
@@ -694,11 +687,13 @@ const EnrollmentFunding: Section = {
 											response: error,
 											field: 'fundings.firstReportingPeriodId',
 											message: REQUIRED_FOR_OEC_REPORTING,
+											errorAlertState
 										},
 										{
 											type: 'error',
 											response: error,
 											field: 'fundings',
+											errorAlertState
 										},
 									])
 								)}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo.tsx
@@ -25,6 +25,7 @@ import {
 	REQUIRED_FOR_ENROLLMENT,
 } from '../../../utils/validations/messageStrings';
 import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
+import useCatchallErrorAlert from '../../../hooks/useCatchallErrorAlert';
 
 const FamilyInfo: Section = {
 	key: 'family-information',
@@ -81,15 +82,7 @@ const FamilyInfo: Section = {
 		const [error, setError] = useState<ApiError | null>(inputError);
 
 		useFocusFirstError([error]);
-		useEffect(() => {
-			if (error) {
-				if (initialLoad) {
-					setAlerts([validationErrorAlert]);
-				} else if (!isBlockingValidationError(error)) {
-					throw new Error(error.title || 'Unknown api error');
-				}
-			}
-		}, [error]);
+		useCatchallErrorAlert(error);
 
 		const [_enrollment, updateEnrollment] = useReducer<
 			FormReducer<DeepNonUndefineable<Enrollment>>

--- a/src/Hedwig/ClientApp/src/hooks/useCatchallErrorAlert.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useCatchallErrorAlert.ts
@@ -1,0 +1,31 @@
+import { ApiError } from "./useApi";
+import { useState, useEffect, useContext } from "react";
+import { isBlockingValidationError } from "../utils/validations";
+import AlertContext from "../contexts/Alert/AlertContext";
+import { validationErrorAlert } from "../utils/stringFormatters/alertTextMakers";
+
+const useCatchallErrorAlert = (error: ApiError | null) => {
+	const { setAlerts } = useContext(AlertContext);
+	const [hasAlertedOnError, setHasAlertedOnError] = useState(false);
+
+	useEffect(() => {
+		if(!error) return;
+
+		if(!hasAlertedOnError) {
+			if(!isBlockingValidationError(error)) {
+				throw new Error(error.title || "Unknown API error");
+			}
+			setAlerts([validationErrorAlert]);
+		} else {
+			setAlerts([]);
+		}
+	}, [error, hasAlertedOnError]);
+
+	const alert = () => setHasAlertedOnError(true)
+	return { 
+		hasAlerted: hasAlertedOnError,
+		alert
+	};
+};
+
+export default useCatchallErrorAlert;


### PR DESCRIPTION
… displayValidationStatus to correctly handle error alert state

does NOT update the familyIncome section because i'd rather only do it for the refactored code.


> My understanding as I was walking through this code is that it was only ever triggered on based on the result of error in the section container. So, I got rid of it, and just had a check on initial load in the error useEffect. As in, the error message would show iff the GET request returned a non-200 status code.

the above is not correct, but i didn't see it. my b! The catchall error alert is displayed when the PUT/POST fails, but we don't surface any field-specific alert. We want to display to the user that _something_ went wrong, and thats why their save didn't happen. 