### PR TITLE
Clean up some react warnings and errors

### DIFF
--- a/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
@@ -5819,7 +5819,6 @@ exports[`Storyshots ProcessList Default 1`] = `
       >
         A long, long, long, long, long heading
       </div>
-       
       <span
         className="usa-tag bg-theme-color-primary"
       >
@@ -5841,7 +5840,6 @@ exports[`Storyshots ProcessList Default 1`] = `
       >
         Step heading
       </div>
-       
       <span
         className="usa-tag bg-theme-color-primary"
       >
@@ -5863,7 +5861,6 @@ exports[`Storyshots ProcessList Default 1`] = `
       >
         A long, long, long, long, long heading
       </div>
-       
       <br />
       <span
         className="usa-hint text-italic"
@@ -5880,7 +5877,6 @@ exports[`Storyshots ProcessList Default 1`] = `
       >
         Step heading
       </div>
-       
       <br />
       <span
         className="usa-hint text-italic"

--- a/src/Hedwig/ClientApp/src/components/ButtonWithDropdown/ButtonWithDrowdown.tsx
+++ b/src/Hedwig/ClientApp/src/components/ButtonWithDropdown/ButtonWithDrowdown.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import { Link } from 'react-router-dom';
 import useHideOnLostFocus from '../../hooks/useHideOnLostFocus';
-import { Button, ButtonProps, InlineIcon } from '..';
+import { Button, ButtonProps } from '../Button/Button';
 import styles from './ButtonWithDropdown.module.scss';
 
 const {

--- a/src/Hedwig/ClientApp/src/components/Card/Card.tsx
+++ b/src/Hedwig/ClientApp/src/components/Card/Card.tsx
@@ -5,6 +5,7 @@ import React, {
 	isValidElement,
 	PropsWithChildren,
 	createContext,
+	useCallback,
 } from 'react';
 import cx from 'classnames';
 import { Tag } from '..';
@@ -43,23 +44,26 @@ export function Card({
 }: PropsWithChildren<CardProps>) {
 	const [previousIsExpanded, setPreviousIsExpanded] = useState<boolean>();
 	const [isExpanded, setIsExpanded] = useState(expanded);
-	const updateExpanded = (_: boolean) => {
-		setPreviousIsExpanded(isExpanded);
-		setIsExpanded(_);
-	};
+	const updateExpanded = useCallback(
+		(_: boolean) => {
+			setPreviousIsExpanded(isExpanded);
+			setIsExpanded(_);
+		},
+		[setPreviousIsExpanded, setIsExpanded, isExpanded]
+	);
 	const toggleExpanded = () => updateExpanded(!isExpanded);
 
 	useEffect(() => {
 		if (onExpansionChange && previousIsExpanded !== undefined) {
 			onExpansionChange(isExpanded);
 		}
-	}, [isExpanded]);
+	}, [isExpanded, previousIsExpanded]);
 
 	useEffect(() => {
 		if (forceClose) {
 			updateExpanded(false);
 		}
-	}, [forceClose]);
+	}, [forceClose, updateExpanded]);
 
 	return (
 		<CardProvider

--- a/src/Hedwig/ClientApp/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/Hedwig/ClientApp/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -59,7 +59,7 @@ const InternalCheckboxGroup: React.FC<InternalCheckboxGroupProps> = ({
 		<div className={className}>
 			{/* Map over the options and invoke the render call back as a React component */}
 			{options.map(({ render: Render, value, expansion }) => (
-				<>
+				<React.Fragment key={`${value}-expansion`}>
 					<Render
 						id={`${id}-${value}`}
 						key={`${id}-${value}`}
@@ -71,7 +71,7 @@ const InternalCheckboxGroup: React.FC<InternalCheckboxGroupProps> = ({
 					{expansion && selectedItems.includes(value) && (
 						<div className="oec-itemchooser-expansion">{expansion}</div>
 					)}
-				</>
+				</React.Fragment>
 			))}
 		</div>
 	);

--- a/src/Hedwig/ClientApp/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/Hedwig/ClientApp/src/components/ChoiceList/ChoiceList.tsx
@@ -247,11 +247,11 @@ export const ChoiceList: React.FC<ChoiceListProps> = ({
 				{options.map((option) => {
 					const expansion = option.expansion;
 					return (
-						<>
+						<React.Fragment key={`${option.value}-expansion`}>
 							{expansion && selectedItems.includes(option.value) && (
 								<div className="oec-choicelist-expansion">{option.expansion}</div>
 							)}
-						</>
+						</React.Fragment>
 					);
 				})}
 			</div>

--- a/src/Hedwig/ClientApp/src/components/Form/Form.tsx
+++ b/src/Hedwig/ClientApp/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useReducer, PropsWithChildren, useState } from 'react';
+import React, { createContext, useEffect, useReducer, PropsWithChildren } from 'react';
 import { FormReducer, formReducer, updateData, InputField } from '../../utils/forms/form';
 import { HTMLChoiceElement } from '..';
 

--- a/src/Hedwig/ClientApp/src/components/Form/FormField.tsx
+++ b/src/Hedwig/ClientApp/src/components/Form/FormField.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { FormContext, GenericFormContextType } from './Form';
 import useContext from '../../utils/useContext';
-import { Moment } from 'moment';
 
 /**
  * Helper type to exclude null or undefined from the type

--- a/src/Hedwig/ClientApp/src/components/ProcessList/ProcessStep.tsx
+++ b/src/Hedwig/ClientApp/src/components/ProcessList/ProcessStep.tsx
@@ -7,21 +7,13 @@ export type ProcessStepProps = {
 	isNew?: boolean;
 };
 
-type InternalProcessStepProps = { key: string } & ProcessStepProps;
-
-export function ProcessStep({ key, heading, body, isNew = false }: InternalProcessStepProps) {
+export const ProcessStep: React.FC<ProcessStepProps> = ({ heading, body, isNew = false }) => {
 	return (
-		<li key={key} className="process-step">
-			<div className="display-inline-block">{heading}</div> {isNew ? newTag() : undefined}
+		<li className="process-step">
+			<div className="display-inline-block">{heading}</div>
+			{isNew ? <Tag text="NEW" color="theme-color-primary" /> : undefined}
 			<br />
 			{body ? <span className="usa-hint text-italic"> {body}</span> : undefined}
 		</li>
 	);
-}
-
-function newTag() {
-	return Tag({
-		text: 'NEW',
-		color: 'theme-color-primary',
-	});
-}
+};

--- a/src/Hedwig/ClientApp/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/Hedwig/ClientApp/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -46,7 +46,7 @@ const InternalRadioButtonGroup: React.FC<InternalRadioButtonGroupProps> = ({
 		<div className={className}>
 			{/* Map over the options and invoke the render call back as a React component */}
 			{options.map(({ render: Render, value, expansion }) => (
-				<>
+				<React.Fragment key={`${value}-expansion`}>
 					<Render
 						key={`${id}-${value}-${selectedItems.includes(value)}`}
 						onChange={_onChange}
@@ -57,7 +57,7 @@ const InternalRadioButtonGroup: React.FC<InternalRadioButtonGroupProps> = ({
 					{expansion && selectedItems.includes(value) && (
 						<div className="oec-itemchooser-expansion">{expansion}</div>
 					)}
-				</>
+				</React.Fragment>
 			))}
 		</div>
 	);

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { SideNavItem, SideNavItemProps } from './SideNavItem';
-import styles from './SideNav.module.scss';
 
 export type SideNavProps = {
 	items: SideNavItemProps[];

--- a/src/Hedwig/ClientApp/src/containers/App/App.tsx
+++ b/src/Hedwig/ClientApp/src/containers/App/App.tsx
@@ -11,7 +11,6 @@ import { useCacheInvalidator, AppProvider } from '../../contexts/App/AppContext'
 import { AlertProvider } from '../../contexts/Alert/AlertContext';
 import { DeepNonUndefineable } from '../../utils/types';
 import { ErrorBoundary, Header, NavItemProps } from '../../components';
-
 import cx from 'classnames';
 import styles from './App.module.scss';
 

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
@@ -216,7 +216,6 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
           >
             Switched funding to CDC - full time
           </div>
-           
           <br />
           <span
             class="usa-hint text-italic"
@@ -232,7 +231,6 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
           >
             Enrolled in Children's Adventure Center
           </div>
-           
           <br />
           <span
             class="usa-hint text-italic"

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo.tsx
@@ -99,7 +99,7 @@ const ChildInfo: Section = {
 					}
 				}
 			}
-		}, [_error, initialLoad]);
+		}, [_error, initialLoad, setAlerts]);
 
 		const [_enrollment, updateEnrollment] = useReducer<
 			FormReducer<DeepNonUndefineable<Enrollment>>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding.tsx
@@ -38,7 +38,6 @@ import { DeepNonUndefineable, DeepNonUndefineableArray } from '../../../utils/ty
 import {
 	initialLoadErrorGuard,
 	useFocusFirstError,
-	isBlockingValidationError,
 	hasValidationErrors,
 } from '../../../utils/validations';
 import ReportingPeriodContext from '../../../contexts/ReportingPeriod/ReportingPeriodContext';
@@ -54,15 +53,10 @@ import {
 	currentReportingPeriod,
 } from '../../../utils/models';
 import { FormReducer, formReducer, updateData, toFormString } from '../../../utils/forms/form';
-import { validationErrorAlert } from '../../../utils/stringFormatters/alertTextMakers';
-import AlertContext from '../../../contexts/Alert/AlertContext';
 import useApi, { ApiError } from '../../../hooks/useApi';
 import { dateSorter, propertyDateSorter } from '../../../utils/dateSorter';
 import { propertyBetweenDates, propertyBeforeDate } from '../../../utils/dateFilter';
-import {
-	REQUIRED_FOR_ENROLLMENT,
-	REQUIRED_FOR_OEC_REPORTING,
-} from '../../../utils/validations/messageStrings';
+import { REQUIRED_FOR_OEC_REPORTING } from '../../../utils/validations/messageStrings';
 import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
 import useCatchallErrorAlert from '../../../hooks/useCatchallErrorAlert';
 
@@ -81,7 +75,8 @@ const EnrollmentFunding: Section = {
 			? 'incomplete'
 			: 'complete',
 
-	Summary: ({ enrollment }) => {
+	Summary: ({ enrollment: _enrollment }) => {
+		const enrollment = _enrollment as DeepNonUndefineable<Enrollment>;
 		if (!enrollment) return <></>;
 		const child = enrollment.child;
 		const fundings = enrollment.fundings || [];
@@ -142,19 +137,19 @@ const EnrollmentFunding: Section = {
 	},
 
 	Form: ({
-		enrollment,
+		enrollment: __enrollment,
 		siteId,
 		error: inputError,
 		successCallback,
 		onSectionTouch,
 		touchedSections,
 	}) => {
+		const enrollment = __enrollment as DeepNonUndefineable<Enrollment>;
 		if (!enrollment) {
 			throw new Error('EnrollmentFunding rendered without an enrollment');
 		}
 
 		// set up form state
-		const { setAlerts } = useContext(AlertContext);
 		const initialLoad = touchedSections ? !touchedSections[EnrollmentFunding.key] : false;
 		const [error, setError] = useState<ApiError | null>(inputError);
 		useFocusFirstError([error]);
@@ -371,7 +366,7 @@ const EnrollmentFunding: Section = {
 			);
 
 			// If there is only one funding space option, update selected fundingSpaceId accordingly
-			if (matchingFundingSpaces.length == 1) {
+			if (matchingFundingSpaces.length === 1) {
 				updateFundingSpace(matchingFundingSpaces[0]);
 				// TODO: Remove this client-side check and allow users to submit with previously entered
 				// invalid data and process the validation error
@@ -616,7 +611,7 @@ const EnrollmentFunding: Section = {
 					>
 						<ChoiceListExpansion showOnValue={'CDC'}>
 							{fundingSpaceOpts.length ? (
-								fundingSpaceOpts.length == 1 ? (
+								fundingSpaceOpts.length === 1 ? (
 									<div>
 										<span className="usa-hint text-italic">{fundingSpaceOpts[0].text}</span>
 									</div>

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
@@ -109,7 +109,7 @@ export default function ReportSubmitForm({
 			});
 			setCare4KidsCount(childIds.length);
 		}
-	}, [allEnrollments]);
+	}, [allEnrollments, submittedAt]);
 
 	const [error, setError] = useState(inputError);
 
@@ -123,7 +123,7 @@ export default function ReportSubmitForm({
 			}
 			setAlerts([validationErrorAlert]);
 		}
-	}, [error, hasAlertedOnError]);
+	}, [error, hasAlertedOnError, setAlerts]);
 
 	const [attemptingSave, setAttemptingSave] = useState(false);
 	const { loading, error: saveError, data: saveData } = useApi<CdcReport>(
@@ -155,7 +155,17 @@ export default function ReportSubmitForm({
 			invalidateAppCache(); // Updates the count of unsubmitted reports in the nav bar
 			history.push('/reports', newAlerts);
 		}
-	}, [saveData, saveError]);
+	}, [
+		saveData,
+		saveError,
+		history,
+		setAlerts,
+		invalidateAppCache,
+		report,
+		setError,
+		setHasAlertedOnError,
+		alerts,
+	]);
 
 	const reportingPeriodWeeks = getReportingPeriodWeeks(report.reportingPeriod);
 	const splitTimeFundingSpaces = getFundingSpaces(report.organization.fundingSpaces, {

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportsSummary/ReportsSummary.test.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportsSummary/ReportsSummary.test.tsx
@@ -9,12 +9,14 @@ import mockUseApi, {
 	mockApiOrganizationsOrgIdReportsGet,
 } from '../../../hooks/useApi/__mocks__/useApi';
 
-const pendingReports = cdcReportingPeriods.map((reportingPeriod) => ({
+const pendingReports = cdcReportingPeriods.map((reportingPeriod, index) => ({
 	...mockDefaultReport,
+	id: index,
 	reportingPeriod,
 }));
-const submittedReports = pendingReports.map((pendingReport) => ({
+const submittedReports = pendingReports.map((pendingReport, index) => ({
 	...pendingReport,
+	id: index + pendingReports.length,
 	submittedAt: new Date('2019-09-14'),
 }));
 const defaultReports = [...pendingReports, ...submittedReports];

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportsSummary/__snapshots__/ReportsSummary.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportsSummary/__snapshots__/ReportsSummary.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`ReportsSummary matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/reports/1"
+                href="/reports/0"
               >
                 March 2019
               </a>
@@ -174,7 +174,7 @@ exports[`ReportsSummary matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/reports/1"
+                href="/reports/2"
               >
                 May 2019
               </a>
@@ -311,7 +311,7 @@ exports[`ReportsSummary matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/reports/1"
+                href="/reports/5"
               >
                 May 2019
               </a>
@@ -334,7 +334,7 @@ exports[`ReportsSummary matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/reports/1"
+                href="/reports/4"
               >
                 April 2019
               </a>
@@ -357,7 +357,7 @@ exports[`ReportsSummary matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/reports/1"
+                href="/reports/3"
               >
                 March 2019
               </a>

--- a/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/Roster.tsx
@@ -7,7 +7,6 @@ import useApi, { paginate } from '../../hooks/useApi';
 import {
 	Age,
 	Enrollment,
-	FundingSpace,
 	ApiOrganizationsOrgIdEnrollmentsGetRequest,
 	ApiOrganizationsIdGetRequest,
 	Organization,
@@ -18,7 +17,6 @@ import { DeepNonUndefineable, DeepNonUndefineableArray } from '../../utils/types
 import { getObjectsByAgeGroup } from '../../utils/models';
 import CommonContainer from '../CommonContainer';
 import RosterHeader from './RosterHeader';
-
 import getDefaultDateRange from '../../utils/getDefaultDateRange';
 import { Suspend } from '../../components/Suspend/Suspend';
 

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
@@ -75,7 +75,7 @@ export default function Withdrawal({
 			orgId: getIdForUser(user, 'org'),
 			siteId: siteId,
 		});
-	}, [enrollmentId, user, siteId]);
+	}, [enrollmentId, user, siteId, setRequestParams]);
 
 	const { error: getRequestError, data: getRequestData } = useApi<Enrollment>(
 		(api) =>
@@ -107,7 +107,7 @@ export default function Withdrawal({
 				lastNReportingPeriods(reportingPeriods, enrollmentEndDate || moment().toDate(), 5)
 			);
 		}
-	}, [reportingPeriods, enrollmentEndDate]);
+	}, [reportingPeriods, enrollmentEndDate, setReportingPeriodOptions]);
 
 	// set up form state
 	const [error, setError] = useState<ApiError | null>(getRequestError);
@@ -195,7 +195,7 @@ export default function Withdrawal({
 				throw new Error(putRequestError.title || 'Unknown api error');
 			}
 		}
-	}, [putRequestData, putRequestError]);
+	}, [putRequestData, putRequestError, history, setAlerts, setError, enrollment, site]);
 
 	// save function
 	const save = () => {

--- a/src/Hedwig/ClientApp/src/hooks/useApi/query.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useApi/query.ts
@@ -111,7 +111,7 @@ export default function useApi<TData>(
 
 	useEffect(() => {
 		if (callback && !skip && !state.loading) callback(state.data);
-	}, [state, skip]);
+	}, [state, skip, callback]);
 
 	return { ...state, data: state.data as DeepNonUndefineable<TData> };
 }

--- a/src/Hedwig/ClientApp/src/hooks/useCatchallErrorAlert.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useCatchallErrorAlert.ts
@@ -24,7 +24,7 @@ const useCatchallErrorAlert: (error: ApiError | null) => ErrorAlertState = (erro
 		} else {
 			setAlerts([]);
 		}
-	}, [error, hasAlertedOnError]);
+	}, [error, hasAlertedOnError, setAlerts]);
 
 	const alert = () => setHasAlertedOnError(true);
 	return {

--- a/src/Hedwig/ClientApp/src/utils/fundingType.tsx
+++ b/src/Hedwig/ClientApp/src/utils/fundingType.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Funding, FundingSpace, FundingTime, FundingSource } from '../generated';
+import { FundingTime, FundingSource } from '../generated';
 import { Tag } from '../components';
-import { getFundingTime } from './models';
 
 function ptOrFT(fundingTime?: FundingTime) {
 	if (fundingTime === FundingTime.Split) {

--- a/src/Hedwig/ClientApp/src/utils/models/family.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/family.ts
@@ -1,6 +1,5 @@
 import { Family } from '../../generated';
 import { InlineIcon } from '../../components';
-import { DeepNonUndefineable } from '../types';
 
 export function createEmptyFamily(orgId: number, familyId = 0) {
 	return {

--- a/src/Hedwig/ClientApp/src/utils/models/funding.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/funding.ts
@@ -1,13 +1,6 @@
 import { DeepNonUndefineable } from '../types';
 import { DateRange } from '../../components';
-import {
-	Funding,
-	FundingSource,
-	ReportingPeriod,
-	Enrollment,
-	FundingSpace,
-	FundingTime,
-} from '../../generated';
+import { Funding, FundingSource, ReportingPeriod, FundingSpace } from '../../generated';
 import moment from 'moment';
 import { dateSorter } from '../dateSorter';
 

--- a/src/Hedwig/ClientApp/src/utils/validations/displayValidationStatus.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/displayValidationStatus.ts
@@ -133,6 +133,7 @@ const getValidationError: ProcessErrorFunction<ValidationError[]> = (errors, fie
 			else if (error.fields) {
 				return error.fields.map((f) => f.toUpperCase()).includes(upperCaseField);
 			}
+			return false;
 		});
 		if (!error) {
 			return undefined;

--- a/src/Hedwig/ClientApp/yarn.lock
+++ b/src/Hedwig/ClientApp/yarn.lock
@@ -2090,9 +2090,9 @@
     wait-for-expect "^3.0.2"
 
 "@testing-library/jest-dom@^5.0.2":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.8.0.tgz#815e830129c4dda6c8e9a725046397acec523669"
-  integrity sha512-9Y4FxYIxfwHpUyJVqI8EOfDP2LlEBqKwXE3F+V8ightji0M2rzQB+9kqZ5UJxNs+9oXJIgvYj7T3QaXLNHVDMw==
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.9.0.tgz#86464c66cbe75e632b8adb636f539bfd0efc2c9c"
+  integrity sha512-uZ68dyILuM2VL13lGz4ehFEAgxzvLKRu8wQxyAZfejWnyMhmipJ60w4eG81NQikJHBfaYXx+Or8EaPQTDwGfPA==
   dependencies:
     "@babel/runtime" "^7.9.2"
     "@types/testing-library__jest-dom" "^5.0.2"
@@ -11606,9 +11606,9 @@ react-error-overlay@^6.0.3, react-error-overlay@^6.0.7:
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
 react-fast-compare@^3.0.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.1.1.tgz#0becf31e3812fa70dc231e259f40d892d4767900"
-  integrity sha512-SCsAORWK59BvauR2L1BTdjQbJcSGJJz03U0awektk2hshLKrITDDFTlgGCqIZpTDlPC/NFlZee6xTMzXPVLiHw==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
 react-focus-lock@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
Addresses some easy wins for clean up.

Most of the warnings in the enrollment sections are left so as to not conflict with the refactor.

Some other warnings are left because they may require larger overhead to fix, namely most of the remaining useEffects dependencies issues.