### PR TITLE
Change column widths to be consistent across empty tables

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/Roster/AgeGroupSection.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Roster/AgeGroupSection.tsx
@@ -75,7 +75,7 @@ export default function AgeGroupSection({
 				</td>
 			)) || <></>,
 		sort: (row: Enrollment) => ((row.child && row.child.birthdate) || new Date(0)).getTime(),
-		width: '20%',
+		width: '17%',
 	};
 
 	const fundingColumn = {
@@ -105,16 +105,21 @@ export default function AgeGroupSection({
 			);
 		},
 		sort: (row: Enrollment) => idx(row, (_) => _.fundings[0].source) || '',
-		width: '20%',
+		width: '18%',
 	};
 
 	const siteColumn = {
 		name: 'Site',
 		cell: ({ row }: { row: DeepNonUndefineable<Enrollment> }) => (
-			<td className="ellipsis-wrap-text ellipsis-wrap-text--tight">{row.site.name}</td>
+			<td
+				className="ellipsis-wrap-text ellipsis-wrap-text--tight"
+				title={row.site.name || undefined}
+			>
+				{row.site.name}
+			</td>
 		),
 		sort: (row: DeepNonUndefineable<Enrollment>) => (row.site.name || '').toLowerCase(),
-		width: '15%',
+		width: '20%',
 	};
 
 	const enrollmentDateColumn = {

--- a/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`Roster matches snapshot 1`] = `
             class="oec-table__column-header oec-sortable"
             role="columnheader"
             scope="col"
-            style="width: 20%;"
+            style="width: 17%;"
           >
             <button
               aria-label="Sort table by Birthdate in ascending order"
@@ -239,7 +239,7 @@ exports[`Roster matches snapshot 1`] = `
             class="oec-table__column-header oec-sortable"
             role="columnheader"
             scope="col"
-            style="width: 20%;"
+            style="width: 18%;"
           >
             <button
               aria-label="Sort table by Funding in ascending order"
@@ -447,7 +447,7 @@ exports[`Roster matches snapshot 1`] = `
             class="oec-table__column-header oec-sortable"
             role="columnheader"
             scope="col"
-            style="width: 20%;"
+            style="width: 17%;"
           >
             <button
               aria-label="Sort table by Birthdate in ascending order"
@@ -471,7 +471,7 @@ exports[`Roster matches snapshot 1`] = `
             class="oec-table__column-header oec-sortable"
             role="columnheader"
             scope="col"
-            style="width: 20%;"
+            style="width: 18%;"
           >
             <button
               aria-label="Sort table by Funding in ascending order"


### PR DESCRIPTION
Should close #1082 

A stop gap measure to make the column consistent. I think the issue is that the table width percentages are not fully deterministic and influenced by the full string of the site name (before truncation). So the site column steals space from other columns, making them smaller and pushing the columns out of alignment. Not really sure how to fix that.

Rider: Adds title attribute so hovering over the text shows the full name