### PR TITLE
Refactor Withdrawal page to use new form

### DIFF
--- a/src/Hedwig/ClientApp/src/components/Form_New/Form.tsx
+++ b/src/Hedwig/ClientApp/src/components/Form_New/Form.tsx
@@ -1,7 +1,6 @@
 import React, { FormHTMLAttributes, PropsWithChildren, useState, useEffect } from 'react';
 import { FormProvider } from './FormContext';
 import { ObjectDriller } from './ObjectDriller';
-import cx from 'classnames';
 
 type FormProps<T> = {
 	onSubmit: (_: T) => void;

--- a/src/Hedwig/ClientApp/src/components/Form_New/Form.tsx
+++ b/src/Hedwig/ClientApp/src/components/Form_New/Form.tsx
@@ -1,6 +1,7 @@
 import React, { FormHTMLAttributes, PropsWithChildren, useState, useEffect } from 'react';
 import { FormProvider } from './FormContext';
 import { ObjectDriller } from './ObjectDriller';
+import cx from 'classnames';
 
 type FormProps<T> = {
 	onSubmit: (_: T) => void;

--- a/src/Hedwig/ClientApp/src/components/Form_New/FormContext.ts
+++ b/src/Hedwig/ClientApp/src/components/Form_New/FormContext.ts
@@ -25,6 +25,10 @@ type FormContextType = {
 export type GenericFormContextType<T> = {
 	data: T;
 	dataDriller: ObjectDriller<T>;
+	// Allows for function style update (setState(s => s) as opposed to setState(s))
+	// Needed for components that make multiple edits to the same object
+	// Otherwise just passing the object would result in one of the updates being
+	// overwritten.
 	updateData: React.Dispatch<React.SetStateAction<T>>;
 };
 /**

--- a/src/Hedwig/ClientApp/src/components/Form_New/FormContext.ts
+++ b/src/Hedwig/ClientApp/src/components/Form_New/FormContext.ts
@@ -25,7 +25,7 @@ type FormContextType = {
 export type GenericFormContextType<T> = {
 	data: T;
 	dataDriller: ObjectDriller<T>;
-	updateData: (_: T) => void;
+	updateData: React.Dispatch<React.SetStateAction<T>>;
 };
 /**
  * Utility for casting the un-typed context to the generic with type parameter,

--- a/src/Hedwig/ClientApp/src/components/Form_New/index.ts
+++ b/src/Hedwig/ClientApp/src/components/Form_New/index.ts
@@ -1,0 +1,4 @@
+export { default as Form } from './Form';
+export { default as FormField } from './FormField';
+export * from './FormFieldSet';
+export { default as FormSubmitButton } from './FormSubmitButton';

--- a/src/Hedwig/ClientApp/src/components/Select/Select.tsx
+++ b/src/Hedwig/ClientApp/src/components/Select/Select.tsx
@@ -22,7 +22,7 @@ export type SelectProps = {
 	unselectedText?: string;
 	disabled?: boolean;
 	onChange: React.ChangeEventHandler<HTMLSelectElement>;
-} & Omit<HTMLAttributes<HTMLSelectElement>, 'defaultValue'> &
+} & Omit<HTMLAttributes<HTMLSelectElement>, 'defaultValue' | 'onChange'> &
 	FormFieldStatusProps;
 
 /**

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome/UpdateForm/FamilyDeterminationFormForCard.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome/UpdateForm/FamilyDeterminationFormForCard.tsx
@@ -11,7 +11,7 @@ type FamilyDeterminationFormForCardProps = {
 	formData: Enrollment;
 	onSubmit: (_: Enrollment) => void;
 	onCancel?: () => void;
-}
+};
 /**
  * The single-determination form to be embedded in Cards in the UpdateForm.
  *

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/ReportSubmitForm.tsx
@@ -193,7 +193,7 @@ export default function ReportSubmitForm({
 	const [timeSplitUtilizations, updateTimeSplitUtilizations] = useState(
 		report.timeSplitUtilizations && report.timeSplitUtilizations.length
 			? report.timeSplitUtilizations
-			: splitTimeFundingSpaces.map(fundingSpace =>
+			: splitTimeFundingSpaces.map((fundingSpace) =>
 					getSplitUtilization(
 						fundingSpace.timeSplit,
 						0,
@@ -242,7 +242,7 @@ export default function ReportSubmitForm({
 							? existingUtilizationForSpace.fullTimeWeeksUsed
 							: existingUtilizationForSpace.partTimeWeeksUsed
 					}`}
-					onChange={e => {
+					onChange={(e) => {
 						const input = e.target.value;
 						const lesserWeeksUsed = parseInt(input.replace(/[^0-9.]/g, ''), 10) || 0;
 

--- a/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/UtilizationTable.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Reports/ReportDetail/UtilizationTable.tsx
@@ -57,7 +57,7 @@ export default function UtilizationTable({
 }: // Pass in the state variable from reportSubmitForm that contains the utilization values for this report (either default values or user-defined)
 UtilizationTableProps): React.ReactElement<UtilizationTableProps> {
 	// Not functional component because ts had a problem with the empty fragments
-	const site = idx(report, _ => _.organization.sites[0]);
+	const site = idx(report, (_) => _.organization.sites[0]);
 	// TODO: if the space lives on the organization but the rates live on the site,
 	// we need to reconsider how we handle multi site org rate calculation
 	if (!site) {
@@ -72,11 +72,7 @@ UtilizationTableProps): React.ReactElement<UtilizationTableProps> {
 	const periodStart = idx(report, (_) => _.reportingPeriod.periodStart);
 	const periodEnd = idx(report, (_) => _.reportingPeriod.periodEnd);
 	const weeksInPeriod =
-		periodStart && periodEnd
-			? moment(periodEnd)
-					.add(1, 'day')
-					.diff(periodStart, 'weeks')
-			: 0;
+		periodStart && periodEnd ? moment(periodEnd).add(1, 'day').diff(periodStart, 'weeks') : 0;
 
 	const enrollments = (idx(report, (_) => _.enrollments) || []) as Enrollment[];
 
@@ -87,9 +83,9 @@ UtilizationTableProps): React.ReactElement<UtilizationTableProps> {
 	// Rows are sorted by fundingspace age, then time
 	const cdcFundingSpaces = (fundingSpaces as DeepNonUndefineableArray<FundingSpace>)
 		.sort(fundingSpaceSorter)
-		.filter(fundingSpace => fundingSpace.source === FundingSource.CDC);
+		.filter((fundingSpace) => fundingSpace.source === FundingSource.CDC);
 
-	let rows: UtilizationTableRow[] = cdcFundingSpaces.map(space => {
+	let rows: UtilizationTableRow[] = cdcFundingSpaces.map((space) => {
 		const capacity = space.capacity;
 		const ageGroup = space.ageGroup;
 		const fundingTime = space.time;
@@ -111,7 +107,7 @@ UtilizationTableProps): React.ReactElement<UtilizationTableProps> {
 
 		let fullWeeks: number | undefined, partWeeks: number | undefined;
 		if (fundingTime === FundingTime.Split) {
-			const thisUtilization = (timeSplitUtilizations || []).find(u => u.reportId === report.id);
+			const thisUtilization = (timeSplitUtilizations || []).find((u) => u.reportId === report.id);
 			fullWeeks = 0;
 			partWeeks = 0;
 			if (thisUtilization) {
@@ -144,7 +140,7 @@ UtilizationTableProps): React.ReactElement<UtilizationTableProps> {
 			ptRate,
 			total,
 			balance,
-			showFundingTime: cdcFundingSpaces.filter(fs => fs.ageGroup === ageGroup).length > 1,
+			showFundingTime: cdcFundingSpaces.filter((fs) => fs.ageGroup === ageGroup).length > 1,
 			weeksSplit: {
 				partWeeks: partWeeks,
 				fullWeeks: fullWeeks,

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/EnrollmentEndDate.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/EnrollmentEndDate.tsx
@@ -1,0 +1,93 @@
+import React, { useContext } from 'react';
+import FormContext, { useGenericContext } from '../../../components/Form_New/FormContext';
+import { Enrollment } from '../../../generated';
+import produce from 'immer';
+import set from 'lodash/set';
+import { DateInput } from '../../../components';
+import { ApiError } from '../../../hooks/useApi';
+import ReportingPeriodContext from '../../../contexts/ReportingPeriod/ReportingPeriodContext';
+import { REQUIRED_FOR_WITHDRAWAL } from '../../../utils/validations/messageStrings';
+import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
+import moment from 'moment';
+import { lastNReportingPeriods } from '../../../utils/models';
+import { ErrorAlertState } from '../../../hooks/useCatchallErrorAlert';
+
+type EnrollmentEndDateFieldProps = {
+	attemptedSave: boolean;
+	errorAlertState?: ErrorAlertState;
+	error: ApiError | null;
+};
+/**
+ * This component is used in Withdrawal to update the exit field on enrollment,
+ * and certificateEndDate in C4K Certificates (if they exist).
+ */
+export const EnrollmentEndDateField: React.FC<EnrollmentEndDateFieldProps> = ({
+	attemptedSave,
+	errorAlertState,
+	error,
+}) => {
+	const { dataDriller, updateData } = useGenericContext<Enrollment>(FormContext);
+	const { cdcReportingPeriods } = useContext(ReportingPeriodContext);
+
+	const currentEndDate = dataDriller.at('exit').value;
+	const reportingPeriodOptions = lastNReportingPeriods(
+		cdcReportingPeriods,
+		currentEndDate || moment().toDate(),
+		5
+	);
+
+	return (
+		<DateInput
+			id="enrollment-end-date"
+			label="Enrollment end date"
+			onChange={(e) => {
+				const target = e.target as HTMLInputElement;
+				const endDate = new Date(parseInt(target.value, 10));
+				// Update the enrollment exit field with the end date
+				updateData((enrollment) =>
+					produce<Enrollment>(enrollment, (draft) =>
+						set(draft, dataDriller.at('exit').path, endDate)
+					)
+				);
+				// Update the current c4kCertificate end date with the end date
+				updateData((enrollment) =>
+					produce<Enrollment>(enrollment, (draft) =>
+						set(
+							draft,
+							dataDriller
+								.at('child')
+								.at('c4KCertificates')
+								.find((cert) => !cert.endDate)
+								.at('endDate').path,
+							endDate
+						)
+					)
+				);
+			}}
+			status={
+				attemptedSave && !currentEndDate
+					? {
+							id: 'exit',
+							type: 'error',
+							message: REQUIRED_FOR_WITHDRAWAL,
+					  }
+					: reportingPeriodOptions.length === 0
+					? {
+							id: 'exit',
+							type: 'error',
+							message:
+								'ECE Reporter only contains data for fiscal year 2020 and later. Please do not add children who withdrew prior to July 2019.',
+					  }
+					: displayValidationStatus([
+							{
+								type: 'error',
+								response: error,
+								field: 'exit',
+								useValidationErrorMessage: true,
+								errorAlertState,
+							},
+					  ])
+			}
+		/>
+	);
+};

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/EnrollmentEndDate.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/EnrollmentEndDate.tsx
@@ -6,11 +6,14 @@ import set from 'lodash/set';
 import { DateInput } from '../../../components';
 import { ApiError } from '../../../hooks/useApi';
 import ReportingPeriodContext from '../../../contexts/ReportingPeriod/ReportingPeriodContext';
-import { REQUIRED_FOR_WITHDRAWAL } from '../../../utils/validations/messageStrings';
+import {
+	REQUIRED_FOR_WITHDRAWAL,
+	REPORTING_PERIODS_ONLY_EXIST_FOR_FY2020_AND_BEYOND,
+} from '../../../utils/validations/messageStrings';
 import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
 import moment from 'moment';
 import { lastNReportingPeriods } from '../../../utils/models';
-import { ErrorAlertState } from '../../../hooks/useCatchallErrorAlert';
+import { ErrorAlertState } from '../../../hooks/useCatchAllErrorAlert';
 
 type EnrollmentEndDateFieldProps = {
 	attemptedSave: boolean;
@@ -75,8 +78,7 @@ export const EnrollmentEndDateField: React.FC<EnrollmentEndDateFieldProps> = ({
 					? {
 							id: 'exit',
 							type: 'error',
-							message:
-								'ECE Reporter only contains data for fiscal year 2020 and later. Please do not add children who withdrew prior to July 2019.',
+							message: REPORTING_PERIODS_ONLY_EXIST_FOR_FY2020_AND_BEYOND,
 					  }
 					: displayValidationStatus([
 							{

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/ExitReason.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/ExitReason.tsx
@@ -3,10 +3,23 @@ import { Enrollment } from '../../../generated';
 import { ApiError } from '../../../hooks/useApi';
 import { REQUIRED_FOR_WITHDRAWAL } from '../../../utils/validations/messageStrings';
 import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
-import { enrollmentExitReasons } from '../../../utils/models';
 import { FormField } from '../../../components/Form_New';
 import { SelectProps, Select } from '../../../components/Select/Select';
-import { ErrorAlertState } from '../../../hooks/useCatchallErrorAlert';
+import { ErrorAlertState } from '../../../hooks/useCatchAllErrorAlert';
+
+/**
+ * String values for default enrollment exit reasons
+ */
+const enrollmentExitReasons = {
+	AgedOut: 'Aged out',
+	StoppedAttending: 'Stopped attending',
+	DifferentProgram: 'Chose to attend a different program',
+	MovedInCT: 'Moved within Connecticut',
+	MovedOutCT: 'Moved to another state',
+	LackOfPayment: 'Withdrew due to lack of payment',
+	AskedToLeave: 'Child was asked to leave',
+	Unknown: 'Unknown',
+};
 
 type ExitReasonFieldProps = {
 	errorAlertState?: ErrorAlertState;

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/ExitReason.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/ExitReason.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Enrollment } from '../../../generated';
+import { ApiError } from '../../../hooks/useApi';
+import { REQUIRED_FOR_WITHDRAWAL } from '../../../utils/validations/messageStrings';
+import { displayValidationStatus } from '../../../utils/validations/displayValidationStatus';
+import { enrollmentExitReasons } from '../../../utils/models';
+import { FormField } from '../../../components/Form_New';
+import { SelectProps, Select } from '../../../components/Select/Select';
+import { ErrorAlertState } from '../../../hooks/useCatchallErrorAlert';
+
+type ExitReasonFieldProps = {
+	errorAlertState?: ErrorAlertState;
+	error: ApiError | null;
+};
+/**
+ * This component is used in Withdrawal to update the exit reason field on
+ * enrollment.
+ */
+export const ExitReasonField: React.FC<ExitReasonFieldProps> = ({ errorAlertState, error }) => {
+	return (
+		<FormField<Enrollment, SelectProps, string | null>
+			getValue={(data) => data.at('exitReason')}
+			parseOnChangeEvent={(e) => e.target.value}
+			inputComponent={Select}
+			id="exit-reason"
+			label="Reason"
+			options={Object.entries(enrollmentExitReasons).map(([key, reason]) => ({
+				value: key,
+				text: reason,
+			}))}
+			status={(_) =>
+				displayValidationStatus([
+					{
+						type: 'error',
+						response: error,
+						field: 'exitReason',
+						message: REQUIRED_FOR_WITHDRAWAL,
+						errorAlertState,
+					},
+				])
+			}
+		/>
+	);
+};

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/LastReportingPeriod.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Fields/LastReportingPeriod.tsx
@@ -10,15 +10,15 @@ import { displayValidationStatus } from '../../../utils/validations/displayValid
 import moment from 'moment';
 import { lastNReportingPeriods, reportingPeriodFormatter } from '../../../utils/models';
 import { Select } from '../../../components/Select/Select';
-import { ErrorAlertState } from '../../../hooks/useCatchallErrorAlert';
+import { ErrorAlertState } from '../../../hooks/useCatchAllErrorAlert';
 
 type LastReportingFieldProps = {
 	errorAlertState?: ErrorAlertState;
 	error: ApiError | null;
 };
 /**
- * This component is used in Withdrawal to update the exit field on enrollment,
- * and certificateEndDate in C4K Certificates (if they exist).
+ * This component is used in Withdrawal to update the last reporting period
+ * on the current cdc funding in an enrollment.
  */
 export const LastReportingPeriodField: React.FC<LastReportingFieldProps> = ({
 	errorAlertState,
@@ -52,7 +52,7 @@ export const LastReportingPeriodField: React.FC<LastReportingFieldProps> = ({
 			}))}
 			onChange={(event) => {
 				const newReportingPeriodId = parseInt(event.target.value);
-				// Update the current c4kCertificate end date with the end date
+				// Update the last reporting period id on the current cdc funding
 				updateData((enrollment) =>
 					produce<Enrollment>(enrollment, (draft) =>
 						set(

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
@@ -1,42 +1,31 @@
-import React, { useContext, useReducer, useState, useEffect } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { History } from 'history';
 import UserContext from '../../contexts/User/UserContext';
 import {
 	Enrollment,
-	Funding,
 	ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest,
 	ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest,
-	C4KCertificate,
 } from '../../generated';
 import { nameFormatter, splitCamelCase, childWithdrawnAlert } from '../../utils/stringFormatters';
 import {
-	enrollmentExitReasons,
 	getCurrentCdcFunding,
-	getCurrentC4kCertificate,
-	lastNReportingPeriods,
 	reportingPeriodFormatter,
-	validatePermissions,
 	getIdForUser,
 	prettyFundingSpaceTime,
 } from '../../utils/models';
 import useApi, { ApiError } from '../../hooks/useApi';
-import { FormReducer, formReducer, updateData } from '../../utils/forms/form';
-import { DeepNonUndefineable, DeepNonUndefineableArray } from '../../utils/types';
-import ReportingPeriodContext from '../../contexts/ReportingPeriod/ReportingPeriodContext';
-import {
-	useFocusFirstError,
-	hasValidationErrors,
-	isBlockingValidationError,
-} from '../../utils/validations';
+import { useFocusFirstError, hasValidationErrors } from '../../utils/validations';
 import AlertContext from '../../contexts/Alert/AlertContext';
 import { missingInformationForWithdrawalAlert } from '../../utils/stringFormatters/alertTextMakers';
-import moment from 'moment';
 import CommonContainer from '../CommonContainer';
-import { InlineIcon, DateInput, ChoiceList, Button } from '../../components';
+import { InlineIcon, Button } from '../../components';
 import dateFormatter from '../../utils/dateFormatter';
 import { getFundingTag } from '../../utils/fundingType';
-import { REQUIRED_FOR_WITHDRAWAL } from '../../utils/validations/messageStrings';
-import { displayValidationStatus } from '../../utils/validations/displayValidationStatus';
+import { Form, FormSubmitButton } from '../../components/Form_New';
+import { EnrollmentEndDateField } from './Fields/EnrollmentEndDate';
+import { ExitReasonField } from './Fields/ExitReason';
+import { LastReportingPeriodField } from './Fields/LastReportingPeriod';
+import useCatchallErrorAlert from '../../hooks/useCatchallErrorAlert';
 
 type WithdrawalProps = {
 	history: History;
@@ -56,163 +45,103 @@ export default function Withdrawal({
 }: WithdrawalProps) {
 	const { user } = useContext(UserContext);
 	const { setAlerts } = useContext(AlertContext);
-	const { cdcReportingPeriods: reportingPeriods } = useContext(ReportingPeriodContext);
+	const [error, setError] = useState<ApiError | null>(null);
 
-	// Set request params as  a state var so that we only attempt to run queries once we have them
-	const [requestParams, setRequestParams] = useState<
-		ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest
-	>();
-	useEffect(() => {
-		if (!enrollmentId || !user || !siteId) {
-			return;
-		}
-		if (!validatePermissions(user, 'site', siteId)) {
-			throw new Error('User is not authorized');
-		}
-		setRequestParams({
-			// These are used in get and put
-			id: enrollmentId,
-			orgId: getIdForUser(user, 'org'),
-			siteId: siteId,
-		});
-	}, [enrollmentId, user, siteId, setRequestParams]);
+	// Store an enrollment that receives user mutations.
+	// This should be updated when the user clicks Save,
+	// applying the mutations to this local copy.
+	// We then send the mutatedEnrollment to the API.
+	const [mutatedEnrollment, setMutatedEnrollment] = useState<Enrollment | null>(null);
 
-	const { error: getRequestError, data: getRequestData } = useApi<Enrollment>(
+	// These are used in get and put
+	const commonParams:
+		| ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest
+		| ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest = {
+		id: enrollmentId,
+		orgId: getIdForUser(user, 'org'),
+		siteId: siteId,
+	};
+
+	const { error: errorOnGet, data: enrollment } = useApi<Enrollment>(
 		(api) =>
 			api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet({
-				...requestParams,
+				...commonParams,
 				include: ['child', 'family', 'determinations', 'fundings', 'sites'],
-			} as ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGetRequest),
-		{ skip: !requestParams }
+			}),
+		{ skip: !user }
 	);
-
-	const [enrollment, updateEnrollment] = useReducer<FormReducer<DeepNonUndefineable<Enrollment>>>(
-		formReducer,
-		getRequestData
-	);
-	const updateFormData = updateData<DeepNonUndefineable<Enrollment>>(updateEnrollment);
-
 	useEffect(() => {
-		// When get data has changed, update the enrollment to not be empty
-		updateEnrollment(getRequestData);
-	}, [getRequestData]);
-
-	const { exit: enrollmentEndDate, exitReason, site } = enrollment || {};
-
-	// set up supporting data contexts
-	const [reportingPeriodOptions, setReportingPeriodOptions] = useState(reportingPeriods);
-	useEffect(() => {
-		if (reportingPeriods) {
-			setReportingPeriodOptions(
-				lastNReportingPeriods(reportingPeriods, enrollmentEndDate || moment().toDate(), 5)
-			);
+		if (errorOnGet) {
+			setError(errorOnGet);
 		}
-	}, [reportingPeriods, enrollmentEndDate, setReportingPeriodOptions]);
+		if (enrollment) {
+			setMutatedEnrollment(enrollment);
+		}
+	}, [errorOnGet, enrollment]);
 
-	// set up form state
-	const [error, setError] = useState<ApiError | null>(getRequestError);
-	const [attemptedSave, setAttemptedSave] = useState(false); // Only matters once for sake of not showing client errors on first load, before user has a chance to do anything
-	const [attemptingSave, setAttemptingSave] = useState(false); // Matters when deciding to run "mutate" effect
-	useFocusFirstError([error]);
+	const { fundings, site } = mutatedEnrollment || {};
+	const cdcFunding = getCurrentCdcFunding(fundings || []);
 
-	// set up convenience derived variables
-	const isMissingInformation = hasValidationErrors(enrollment);
+	// Tracks whether to show client errors. On first load, we don't show errors,
+	// because the user hasn't had chance to do anything
+	const [attemptedSave, setAttemptedSave] = useState(false);
+	// Determines when to run "mutate" effect
+	const [attemptingSave, setAttemptingSave] = useState(false);
+
+	const isMissingInformation = hasValidationErrors(mutatedEnrollment);
 	// If the enrollment is missing information, navigate to that enrollment so user can fix it
 	useEffect(() => {
 		if (isMissingInformation) {
 			setAlerts([missingInformationForWithdrawalAlert]);
-			history.push(`/roster/sites/${siteId}/enrollments/${enrollment.id}`);
+			history.push(`/roster/sites/${siteId}/enrollments/${enrollmentId}`);
 		}
-	}, [enrollment, isMissingInformation, history, setAlerts, siteId]);
-
-	const fundings =
-		enrollment && enrollment.fundings
-			? enrollment.fundings
-			: ([] as DeepNonUndefineableArray<Funding>);
-	const cdcFunding = getCurrentCdcFunding(fundings);
-	const c4KFunding = getCurrentC4kCertificate(enrollment);
-
-	const setLastReportingPeriod = (lastReportingPeriodId: number) => {
-		let updatedFundings: Funding[] = fundings;
-		if (cdcFunding) {
-			updatedFundings = [
-				...updatedFundings.filter((f) => f.id !== cdcFunding.id),
-				{
-					...cdcFunding,
-					lastReportingPeriodId: lastReportingPeriodId,
-				},
-			];
-			updateEnrollment({
-				...enrollment,
-				fundings: updatedFundings as DeepNonUndefineableArray<Funding>,
-			});
-		}
-		if (c4KFunding) {
-			let c4KCertificates: C4KCertificate[] = enrollment.child
-				? enrollment.child.c4KCertificates || []
-				: [];
-			c4KCertificates = [
-				...c4KCertificates.filter((cert) => cert.id !== c4KFunding.id),
-				{
-					...c4KFunding,
-					endDate: enrollmentEndDate,
-				},
-			];
-			updateEnrollment({
-				...enrollment,
-				child: {
-					...enrollment.child,
-					c4KCertificates: c4KCertificates as DeepNonUndefineable<C4KCertificate[]>,
-				},
-			});
-		}
-	};
+	}, [isMissingInformation, siteId, enrollmentId, history, setAlerts]);
 
 	// set up PUT request to be triggered on save attempt
-	const { error: putRequestError, data: putRequestData } = useApi<Enrollment>(
+	const { error: errorOnSave, data: returnedEnrollment } = useApi<Enrollment>(
 		(api) =>
 			api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut({
-				...requestParams,
-				enrollment,
-			} as ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest),
+				...commonParams,
+				enrollment: mutatedEnrollment || undefined,
+			}),
 		{
-			skip: !attemptingSave || !requestParams || !enrollmentEndDate,
+			skip: !attemptingSave,
 			callback: () => setAttemptingSave(false),
 		}
 	);
+	const errorAlertState = useCatchallErrorAlert(error);
+	useFocusFirstError([error]);
 
 	useEffect(() => {
 		// If the withdraw request went through, then return to the roster
-		if (putRequestData && !putRequestError) {
-			setAlerts([childWithdrawnAlert(nameFormatter(enrollment.child), site.name || '')]);
+		if (returnedEnrollment && !errorOnSave && site) {
+			setAlerts([childWithdrawnAlert(nameFormatter(returnedEnrollment.child), site.name || '')]);
 			history.push(`/roster`);
+		} else {
+			// Otherwise handle the error
+			setError(errorOnSave);
 		}
+	}, [returnedEnrollment, errorOnSave, history, setAlerts, setError, site]);
 
-		// Otherwise handle the error
-		setError(putRequestError);
-		if (putRequestError) {
-			if (!isBlockingValidationError(putRequestError)) {
-				throw new Error(putRequestError.title || 'Unknown api error');
-			}
-		}
-	}, [putRequestData, putRequestError, history, setAlerts, setError, enrollment, site]);
+	if (!mutatedEnrollment || !site) {
+		return <div className="Withdrawal"></div>;
+	}
 
-	// save function
-	const save = () => {
+	const onFormSubmit = (userModifiedEnrollment: Enrollment) => {
+		const { exit: enrollmentEndDate } = userModifiedEnrollment;
 		if (!attemptedSave) {
-			// Only need to mess with this the first time
+			// Only need to update this the first time the user tries to save
 			setAttemptedSave(true);
 		}
 		if (enrollmentEndDate) {
-			// The enrollment end date is verified on the client side because it's how we know we're attempting a withdrawal
-			// If we set the attempting save variable without an end date, then it won't get unset, because the request won't hit the server, and the callback won't be called
+			// The enrollment end date is verified on the client side because it's how we
+			// know we're attempting a withdrawal. If we set the attempting save variable
+			// without an end date, then it won't get unset, because the request won't hit
+			// the server, and the callback won't be called
 			setAttemptingSave(true);
+			setMutatedEnrollment(userModifiedEnrollment);
 		}
 	};
-
-	if (!enrollment || !site) {
-		return <div className="Withdrawal"></div>;
-	}
 
 	return (
 		<CommonContainer
@@ -223,12 +152,12 @@ export default function Withdrawal({
 			}}
 		>
 			<div className="grid-container">
-				<h1>Withdraw {nameFormatter(enrollment.child)}</h1>
+				<h1>Withdraw {nameFormatter(mutatedEnrollment.child)}</h1>
 				<div className="grid-row grid-gap oec-enrollment-details-section__content margin-top-1">
 					<div className="mobile-lg:grid-col-6">
 						<p>{site.name}</p>
-						<p>Age: {splitCamelCase(enrollment.ageGroup, '/')}</p>
-						<p>Enrollment date: {dateFormatter(enrollment.entry)}</p>
+						<p>Age: {splitCamelCase(mutatedEnrollment.ageGroup, '/')}</p>
+						<p>Enrollment date: {dateFormatter(mutatedEnrollment.entry)}</p>
 					</div>
 					{cdcFunding && (
 						<div className="mobile-lg:grid-col-6">
@@ -248,105 +177,40 @@ export default function Withdrawal({
 					)}
 				</div>
 
-				<div className="use-form mobile-lg:grid-col-12">
-					<DateInput
-						label="Enrollment end date"
-						id="enrollment-end-date"
-						name="exit"
-						onChange_Old={updateFormData((newDate) => newDate.toDate())}
-						defaultValue={enrollmentEndDate ? moment(enrollmentEndDate).toDate() : undefined}
-						status={
-							attemptedSave && !enrollmentEndDate
-								? {
-										id: 'exit',
-										type: 'error',
-										message: REQUIRED_FOR_WITHDRAWAL,
-								  }
-								: reportingPeriodOptions.length === 0
-								? {
-										id: 'exit',
-										type: 'error',
-										message:
-											'ECE Reporter only contains data for fiscal year 2020 and later. Please do not add children who withdrew prior to July 2019.',
-								  }
-								: displayValidationStatus([
-										{
-											type: 'error',
-											response: error,
-											field: 'exit',
-											useValidationErrorMessage: true,
-										},
-								  ])
-						}
-					/>
-					<ChoiceList
-						type="select"
-						label="Reason"
-						id="exit-reason"
-						options={Object.entries(enrollmentExitReasons).map(([key, reason]) => ({
-							value: key,
-							text: reason,
-						}))}
-						defaultValue={exitReason ? [exitReason] : undefined}
-						otherInputLabel="Other"
-						name="exitReason"
-						onChange={updateFormData()}
-						status={displayValidationStatus([
-							{
-								type: 'error',
-								response: error,
-								field: 'exitReason',
-								message: REQUIRED_FOR_WITHDRAWAL,
-							},
-						])}
-					/>
-					{cdcFunding && (
-						<ChoiceList
-							type="select"
-							label="Last reporting period"
-							id="last-reporting-period"
-							options={reportingPeriodOptions.map((period) => ({
-								value: '' + period.id,
-								text: reportingPeriodFormatter(period, { extended: true }),
-							}))}
-							onChange={(event) => {
-								const newReportingPeriodId = parseInt(event.target.value);
-								setLastReportingPeriod(newReportingPeriodId);
-							}}
-							status={displayValidationStatus([
-								{
-									type: 'error',
-									response: error,
-									field: 'fundings',
-									message: REQUIRED_FOR_WITHDRAWAL,
-								},
-								{
-									type: 'error',
-									response: error,
-									field: 'fundings.lastReportingPeriod',
-									useValidationErrorMessage: true,
-								},
-							])}
-						/>
-					)}
-				</div>
-
-				<div className="grid-row margin-y-6">
-					<div className="mobile-lg:grid-col-auto">
-						<Button
-							text="Cancel"
-							href={`/roster/sites/${siteId}/enrollments/${enrollment.id}/`}
-							appearance="outline"
-						/>
+				<Form<Enrollment>
+					data={mutatedEnrollment}
+					onSubmit={onFormSubmit}
+					className=""
+					noValidate
+					autoComplete="off"
+				>
+					<div className="grid-row grid-gap">
+						<div className="mobile-lg:grid-col-12">
+							<EnrollmentEndDateField
+								attemptedSave={attemptedSave}
+								errorAlertState={errorAlertState}
+								error={error}
+							/>
+							<ExitReasonField errorAlertState={errorAlertState} error={error} />
+							{cdcFunding && (
+								<LastReportingPeriodField errorAlertState={errorAlertState} error={error} />
+							)}
+						</div>
 					</div>
-					<div className="mobile-lg:grid-col-auto padding-left-2">
-						<Button
-							text={attemptingSave ? 'Withdrawing...' : 'Confirm and withdraw'}
-							onClick={save}
-							disabled={isMissingInformation || attemptingSave}
-						/>
+					<div className="grid-row">
+						<div className="grid-col-auto">
+							<Button
+								text="Cancel"
+								href={`/roster/sites/${siteId}/enrollments/${enrollment.id}/`}
+								appearance="outline"
+							/>
+							<FormSubmitButton
+								text={attemptingSave ? 'Withdrawing...' : 'Confirm and withdraw'}
+								disabled={isMissingInformation || attemptingSave}
+							/>
+						</div>
 					</div>
-				</div>
+				</Form>
 			</div>
 		</CommonContainer>
 	);

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/__snapshots__/Withdrawal.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/__snapshots__/Withdrawal.test.tsx.snap
@@ -57,1403 +57,1406 @@ exports[`Withdrawal matches snapshot 1`] = `
         </p>
       </div>
     </div>
-    <div
-      class="use-form mobile-lg:grid-col-12"
+    <form
+      autocomplete="off"
+      class=""
+      novalidate=""
     >
-      <fieldset
-        aria-describedby="enrollment-end-date-hint"
-        aria-required="true"
-        class="grid-gap grid-row usa-fieldset oec-date-input oec-date-input-single"
-        id="enrollment-end-date"
+      <div
+        class="usa-form"
       >
-        <legend
-          id="fieldset-legend-enrollment-end-date"
-        >
-          <span
-            class="usa-label"
-          >
-            Enrollment end date
-          </span>
-        </legend>
-        <span
-          class="usa-hint text-italic"
-        >
-          For example: 04/28/1986
-        </span>
         <div
-          class="grid-gap grid-row"
+          class="grid-row grid-gap"
         >
-          <input
-            aria-hidden="true"
-            disabled=""
-            hidden=""
-            id="enrollment-end-date-internal"
-            value=""
-          />
           <div
-            class="grid-row flex-row flex-align-end grid-gap position-relative"
+            class="mobile-lg:grid-col-12"
           >
-            <div
-              class="oec-date-input__text usa-form-group"
+            <fieldset
+              aria-describedby="enrollment-end-date-hint"
+              aria-required="true"
+              class="grid-gap grid-row usa-fieldset oec-date-input oec-date-input-single"
+              id="enrollment-end-date"
             >
-              <label
-                class="usa-label usa-sr-only"
-                for="enrollment-end-date-input"
+              <legend
+                id="fieldset-legend-enrollment-end-date"
               >
-                Enrollment end date 
-              </label>
-              <input
-                aria-required="true"
-                class="usa-input"
-                id="enrollment-end-date-input"
-                name="exit"
-                type="text"
-                value=""
-              />
-            </div>
-            <div
-              class="oec-calendar-dropdown oec-date-input__calendar-dropdown"
-            >
-              <button
-                class="usa-button oec-calendar-toggle oec-calendar-dropdown__toggle"
-                title="open calendar"
-                type="button"
-              >
-                <svg
-                  class="oec-calendar-toggle__icon"
+                <span
+                  class="usa-label"
                 >
-                  calendar.svg
-                </svg>
-              </button>
+                  Enrollment end date
+                </span>
+              </legend>
+              <span
+                class="usa-hint text-italic"
+              >
+                For example: 04/28/1986
+              </span>
               <div
-                class="oec-calendar-dropdown__calendar position-absolute z-top"
-                hidden=""
+                class="grid-gap grid-row"
               >
+                <input
+                  aria-hidden="true"
+                  disabled=""
+                  hidden=""
+                  id="enrollment-end-date-internal"
+                  value=""
+                />
                 <div
-                  class="DayPicker DayPicker_1 DayPicker__horizontal DayPicker__horizontal_2 DayPicker__hidden DayPicker__hidden_3 DayPicker__withBorder DayPicker__withBorder_4"
-                  style="width: 319px;"
+                  class="grid-row flex-row flex-align-end grid-gap position-relative"
                 >
-                  <div>
+                  <div
+                    class="oec-date-input__text usa-form-group"
+                  >
+                    <label
+                      class="usa-label usa-sr-only"
+                      for="enrollment-end-date-input"
+                    >
+                      Enrollment end date 
+                    </label>
+                    <input
+                      aria-required="true"
+                      class="usa-input"
+                      id="enrollment-end-date-input"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="oec-calendar-dropdown oec-date-input__calendar-dropdown"
+                  >
+                    <button
+                      class="usa-button oec-calendar-toggle oec-calendar-dropdown__toggle"
+                      title="open calendar"
+                      type="button"
+                    >
+                      <svg
+                        class="oec-calendar-toggle__icon"
+                      >
+                        calendar.svg
+                      </svg>
+                    </button>
                     <div
-                      class=""
-                      style="width: 318px;"
+                      class="oec-calendar-dropdown__calendar position-absolute z-top"
+                      hidden=""
                     >
                       <div
-                        aria-hidden="true"
-                        class="DayPicker_weekHeaders DayPicker_weekHeaders_1 DayPicker_weekHeaders__horizontal DayPicker_weekHeaders__horizontal_2"
-                        role="presentation"
+                        class="DayPicker DayPicker_1 DayPicker__horizontal DayPicker__horizontal_2 DayPicker__hidden DayPicker__hidden_3 DayPicker__withBorder DayPicker__withBorder_4"
+                        style="width: 319px;"
                       >
-                        <div
-                          class="DayPicker_weekHeader DayPicker_weekHeader_1"
-                          style="left: 0px; padding: 0px 13px;"
-                        >
-                          <ul
-                            class="DayPicker_weekHeader_ul DayPicker_weekHeader_ul_1"
-                          >
-                            <li
-                              class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
-                              style="width: 39px;"
-                            >
-                              <small>
-                                Su
-                              </small>
-                            </li>
-                            <li
-                              class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
-                              style="width: 39px;"
-                            >
-                              <small>
-                                Mo
-                              </small>
-                            </li>
-                            <li
-                              class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
-                              style="width: 39px;"
-                            >
-                              <small>
-                                Tu
-                              </small>
-                            </li>
-                            <li
-                              class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
-                              style="width: 39px;"
-                            >
-                              <small>
-                                We
-                              </small>
-                            </li>
-                            <li
-                              class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
-                              style="width: 39px;"
-                            >
-                              <small>
-                                Th
-                              </small>
-                            </li>
-                            <li
-                              class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
-                              style="width: 39px;"
-                            >
-                              <small>
-                                Fr
-                              </small>
-                            </li>
-                            <li
-                              class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
-                              style="width: 39px;"
-                            >
-                              <small>
-                                Sa
-                              </small>
-                            </li>
-                          </ul>
-                        </div>
-                      </div>
-                      <div
-                        aria-label="Calendar"
-                        aria-roledescription="datepicker"
-                        class="DayPicker_focusRegion DayPicker_focusRegion_1"
-                        role="application"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="DayPickerNavigation DayPickerNavigation_1 DayPickerNavigation__horizontal DayPickerNavigation__horizontal_2"
-                        >
-                          <div
-                            aria-label="Move backward to switch to the previous month."
-                            class="DayPickerNavigation_button DayPickerNavigation_button_1 DayPickerNavigation_button__default DayPickerNavigation_button__default_2 DayPickerNavigation_button__horizontal DayPickerNavigation_button__horizontal_3 DayPickerNavigation_button__horizontalDefault DayPickerNavigation_button__horizontalDefault_4 DayPickerNavigation_leftButton__horizontalDefault DayPickerNavigation_leftButton__horizontalDefault_5"
-                            role="button"
-                            tabindex="0"
-                          >
-                            <svg
-                              class="DayPickerNavigation_svg__horizontal DayPickerNavigation_svg__horizontal_1"
-                              focusable="false"
-                              viewBox="0 0 1000 1000"
-                            >
-                              <path
-                                d="M336 275L126 485h806c13 0 23 10 23 23s-10 23-23 23H126l210 210c11 11 11 21 0 32-5 5-10 7-16 7s-11-2-16-7L55 524c-11-11-11-21 0-32l249-249c21-22 53 10 32 32z"
-                              />
-                            </svg>
-                          </div>
-                          <div
-                            aria-label="Move forward to switch to the next month."
-                            class="DayPickerNavigation_button DayPickerNavigation_button_1 DayPickerNavigation_button__default DayPickerNavigation_button__default_2 DayPickerNavigation_button__horizontal DayPickerNavigation_button__horizontal_3 DayPickerNavigation_button__horizontalDefault DayPickerNavigation_button__horizontalDefault_4 DayPickerNavigation_rightButton__horizontalDefault DayPickerNavigation_rightButton__horizontalDefault_5"
-                            role="button"
-                            tabindex="0"
-                          >
-                            <svg
-                              class="DayPickerNavigation_svg__horizontal DayPickerNavigation_svg__horizontal_1"
-                              focusable="false"
-                              viewBox="0 0 1000 1000"
-                            >
-                              <path
-                                d="M694 242l249 250c12 11 12 21 1 32L694 773c-5 5-10 7-16 7s-11-2-16-7c-11-11-11-21 0-32l210-210H68c-13 0-23-10-23-23s10-23 23-23h806L662 275c-21-22 11-54 32-33z"
-                              />
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          class="DayPicker_transitionContainer DayPicker_transitionContainer_1"
-                          style="width: 318px; height: 0px;"
-                        >
-                          <div
-                            class="CalendarMonthGrid CalendarMonthGrid_1 CalendarMonthGrid__horizontal CalendarMonthGrid__horizontal_2"
-                            style="transform: translateX(0px); width: 900px;"
-                          >
-                            <div
-                              class="CalendarMonthGrid_month__horizontal CalendarMonthGrid_month__horizontal_1 CalendarMonthGrid_month__hideForAnimation CalendarMonthGrid_month__hideForAnimation_2 CalendarMonthGrid_month__hidden CalendarMonthGrid_month__hidden_3"
-                            >
-                              <div
-                                class="CalendarMonth CalendarMonth_1"
-                                data-visible="false"
-                                style="padding: 0px 13px;"
-                              >
-                                <div
-                                  class="CalendarMonth_caption CalendarMonth_caption_1"
-                                >
-                                  <strong>
-                                    August 2019
-                                  </strong>
-                                </div>
-                                <table
-                                  class="CalendarMonth_table CalendarMonth_table_1"
-                                  role="presentation"
-                                >
-                                  <tbody>
-                                    <tr>
-                                      <td />
-                                      <td />
-                                      <td />
-                                      <td />
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, August 1, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        1
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, August 2, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        2
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, August 3, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        3
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, August 4, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        4
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, August 5, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        5
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, August 6, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        6
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, August 7, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        7
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, August 8, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        8
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, August 9, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        9
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, August 10, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        10
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, August 11, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        11
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, August 12, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        12
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, August 13, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        13
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, August 14, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        14
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, August 15, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        15
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, August 16, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        16
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, August 17, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        17
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, August 18, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        18
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, August 19, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        19
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, August 20, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        20
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, August 21, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        21
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, August 22, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        22
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, August 23, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        23
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, August 24, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        24
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, August 25, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        25
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, August 26, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        26
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, August 27, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        27
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, August 28, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        28
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, August 29, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        29
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, August 30, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        30
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, August 31, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        31
-                                      </td>
-                                    </tr>
-                                  </tbody>
-                                </table>
-                              </div>
-                            </div>
-                            <div
-                              class="CalendarMonthGrid_month__horizontal CalendarMonthGrid_month__horizontal_1"
-                            >
-                              <div
-                                class="CalendarMonth CalendarMonth_1"
-                                data-visible="true"
-                                style="padding: 0px 13px;"
-                              >
-                                <div
-                                  class="CalendarMonth_caption CalendarMonth_caption_1"
-                                >
-                                  <strong>
-                                    September 2019
-                                  </strong>
-                                </div>
-                                <table
-                                  class="CalendarMonth_table CalendarMonth_table_1"
-                                  role="presentation"
-                                >
-                                  <tbody>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, September 1, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        1
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, September 2, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        2
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, September 3, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        3
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, September 4, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        4
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, September 5, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        5
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, September 6, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        6
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, September 7, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        7
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, September 8, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        8
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, September 9, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        9
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, September 10, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        10
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, September 11, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        11
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, September 12, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        12
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, September 13, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        13
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, September 14, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        14
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, September 15, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        15
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, September 16, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        16
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, September 17, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        17
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, September 18, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        18
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, September 19, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        19
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, September 20, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        20
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, September 21, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        21
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, September 22, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        22
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, September 23, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        23
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, September 24, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        24
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, September 25, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        25
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, September 26, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        26
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, September 27, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        27
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, September 28, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        28
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, September 29, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        29
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, September 30, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__today CalendarDay__today_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        30
-                                      </td>
-                                      <td />
-                                      <td />
-                                      <td />
-                                      <td />
-                                      <td />
-                                    </tr>
-                                  </tbody>
-                                </table>
-                              </div>
-                            </div>
-                            <div
-                              class="CalendarMonthGrid_month__horizontal CalendarMonthGrid_month__horizontal_1 CalendarMonthGrid_month__hidden CalendarMonthGrid_month__hidden_2"
-                            >
-                              <div
-                                class="CalendarMonth CalendarMonth_1"
-                                data-visible="false"
-                                style="padding: 0px 13px;"
-                              >
-                                <div
-                                  class="CalendarMonth_caption CalendarMonth_caption_1"
-                                >
-                                  <strong>
-                                    October 2019
-                                  </strong>
-                                </div>
-                                <table
-                                  class="CalendarMonth_table CalendarMonth_table_1"
-                                  role="presentation"
-                                >
-                                  <tbody>
-                                    <tr>
-                                      <td />
-                                      <td />
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, October 1, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        1
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, October 2, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        2
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, October 3, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        3
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, October 4, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        4
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, October 5, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        5
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, October 6, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        6
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, October 7, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        7
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, October 8, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        8
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, October 9, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        9
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, October 10, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        10
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, October 11, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        11
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, October 12, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        12
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, October 13, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        13
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, October 14, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        14
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, October 15, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        15
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, October 16, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        16
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, October 17, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        17
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, October 18, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        18
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, October 19, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        19
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, October 20, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        20
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, October 21, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        21
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, October 22, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        22
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, October 23, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        23
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, October 24, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        24
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Friday, October 25, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        25
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Saturday, October 26, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        26
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Sunday, October 27, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        27
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Monday, October 28, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        28
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Tuesday, October 29, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        29
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Wednesday, October 30, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        30
-                                      </td>
-                                      <td
-                                        aria-disabled="false"
-                                        aria-label="Thursday, October 31, 2019"
-                                        class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
-                                        role="button"
-                                        style="width: 39px; height: 38px;"
-                                        tabindex="-1"
-                                      >
-                                        31
-                                      </td>
-                                      <td />
-                                      <td />
-                                    </tr>
-                                  </tbody>
-                                </table>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
                         <div>
-                          <button
-                            aria-label="Open the keyboard shortcuts panel."
-                            class="DayPickerKeyboardShortcuts_buttonReset DayPickerKeyboardShortcuts_buttonReset_1 DayPickerKeyboardShortcuts_show DayPickerKeyboardShortcuts_show_2 DayPickerKeyboardShortcuts_show__bottomRight DayPickerKeyboardShortcuts_show__bottomRight_3"
-                            type="button"
+                          <div
+                            class=""
+                            style="width: 318px;"
                           >
-                            <span
-                              class="DayPickerKeyboardShortcuts_showSpan DayPickerKeyboardShortcuts_showSpan_1 DayPickerKeyboardShortcuts_showSpan__bottomRight DayPickerKeyboardShortcuts_showSpan__bottomRight_2"
+                            <div
+                              aria-hidden="true"
+                              class="DayPicker_weekHeaders DayPicker_weekHeaders_1 DayPicker_weekHeaders__horizontal DayPicker_weekHeaders__horizontal_2"
+                              role="presentation"
                             >
-                              ?
-                            </span>
-                          </button>
+                              <div
+                                class="DayPicker_weekHeader DayPicker_weekHeader_1"
+                                style="left: 0px; padding: 0px 13px;"
+                              >
+                                <ul
+                                  class="DayPicker_weekHeader_ul DayPicker_weekHeader_ul_1"
+                                >
+                                  <li
+                                    class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
+                                    style="width: 39px;"
+                                  >
+                                    <small>
+                                      Su
+                                    </small>
+                                  </li>
+                                  <li
+                                    class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
+                                    style="width: 39px;"
+                                  >
+                                    <small>
+                                      Mo
+                                    </small>
+                                  </li>
+                                  <li
+                                    class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
+                                    style="width: 39px;"
+                                  >
+                                    <small>
+                                      Tu
+                                    </small>
+                                  </li>
+                                  <li
+                                    class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
+                                    style="width: 39px;"
+                                  >
+                                    <small>
+                                      We
+                                    </small>
+                                  </li>
+                                  <li
+                                    class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
+                                    style="width: 39px;"
+                                  >
+                                    <small>
+                                      Th
+                                    </small>
+                                  </li>
+                                  <li
+                                    class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
+                                    style="width: 39px;"
+                                  >
+                                    <small>
+                                      Fr
+                                    </small>
+                                  </li>
+                                  <li
+                                    class="DayPicker_weekHeader_li DayPicker_weekHeader_li_1"
+                                    style="width: 39px;"
+                                  >
+                                    <small>
+                                      Sa
+                                    </small>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                            <div
+                              aria-label="Calendar"
+                              aria-roledescription="datepicker"
+                              class="DayPicker_focusRegion DayPicker_focusRegion_1"
+                              role="application"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="DayPickerNavigation DayPickerNavigation_1 DayPickerNavigation__horizontal DayPickerNavigation__horizontal_2"
+                              >
+                                <div
+                                  aria-label="Move backward to switch to the previous month."
+                                  class="DayPickerNavigation_button DayPickerNavigation_button_1 DayPickerNavigation_button__default DayPickerNavigation_button__default_2 DayPickerNavigation_button__horizontal DayPickerNavigation_button__horizontal_3 DayPickerNavigation_button__horizontalDefault DayPickerNavigation_button__horizontalDefault_4 DayPickerNavigation_leftButton__horizontalDefault DayPickerNavigation_leftButton__horizontalDefault_5"
+                                  role="button"
+                                  tabindex="0"
+                                >
+                                  <svg
+                                    class="DayPickerNavigation_svg__horizontal DayPickerNavigation_svg__horizontal_1"
+                                    focusable="false"
+                                    viewBox="0 0 1000 1000"
+                                  >
+                                    <path
+                                      d="M336 275L126 485h806c13 0 23 10 23 23s-10 23-23 23H126l210 210c11 11 11 21 0 32-5 5-10 7-16 7s-11-2-16-7L55 524c-11-11-11-21 0-32l249-249c21-22 53 10 32 32z"
+                                    />
+                                  </svg>
+                                </div>
+                                <div
+                                  aria-label="Move forward to switch to the next month."
+                                  class="DayPickerNavigation_button DayPickerNavigation_button_1 DayPickerNavigation_button__default DayPickerNavigation_button__default_2 DayPickerNavigation_button__horizontal DayPickerNavigation_button__horizontal_3 DayPickerNavigation_button__horizontalDefault DayPickerNavigation_button__horizontalDefault_4 DayPickerNavigation_rightButton__horizontalDefault DayPickerNavigation_rightButton__horizontalDefault_5"
+                                  role="button"
+                                  tabindex="0"
+                                >
+                                  <svg
+                                    class="DayPickerNavigation_svg__horizontal DayPickerNavigation_svg__horizontal_1"
+                                    focusable="false"
+                                    viewBox="0 0 1000 1000"
+                                  >
+                                    <path
+                                      d="M694 242l249 250c12 11 12 21 1 32L694 773c-5 5-10 7-16 7s-11-2-16-7c-11-11-11-21 0-32l210-210H68c-13 0-23-10-23-23s10-23 23-23h806L662 275c-21-22 11-54 32-33z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                              <div
+                                class="DayPicker_transitionContainer DayPicker_transitionContainer_1"
+                                style="width: 318px; height: 0px;"
+                              >
+                                <div
+                                  class="CalendarMonthGrid CalendarMonthGrid_1 CalendarMonthGrid__horizontal CalendarMonthGrid__horizontal_2"
+                                  style="transform: translateX(0px); width: 900px;"
+                                >
+                                  <div
+                                    class="CalendarMonthGrid_month__horizontal CalendarMonthGrid_month__horizontal_1 CalendarMonthGrid_month__hideForAnimation CalendarMonthGrid_month__hideForAnimation_2 CalendarMonthGrid_month__hidden CalendarMonthGrid_month__hidden_3"
+                                  >
+                                    <div
+                                      class="CalendarMonth CalendarMonth_1"
+                                      data-visible="false"
+                                      style="padding: 0px 13px;"
+                                    >
+                                      <div
+                                        class="CalendarMonth_caption CalendarMonth_caption_1"
+                                      >
+                                        <strong>
+                                          August 2019
+                                        </strong>
+                                      </div>
+                                      <table
+                                        class="CalendarMonth_table CalendarMonth_table_1"
+                                        role="presentation"
+                                      >
+                                        <tbody>
+                                          <tr>
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, August 1, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              1
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, August 2, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              2
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, August 3, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              3
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, August 4, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              4
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, August 5, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              5
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, August 6, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              6
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, August 7, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              7
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, August 8, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              8
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, August 9, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              9
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, August 10, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              10
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, August 11, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              11
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, August 12, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              12
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, August 13, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              13
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, August 14, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              14
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, August 15, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              15
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, August 16, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              16
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, August 17, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              17
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, August 18, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              18
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, August 19, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              19
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, August 20, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              20
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, August 21, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              21
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, August 22, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              22
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, August 23, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              23
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, August 24, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              24
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, August 25, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              25
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, August 26, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              26
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, August 27, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              27
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, August 28, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              28
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, August 29, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              29
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, August 30, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              30
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, August 31, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              31
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="CalendarMonthGrid_month__horizontal CalendarMonthGrid_month__horizontal_1"
+                                  >
+                                    <div
+                                      class="CalendarMonth CalendarMonth_1"
+                                      data-visible="true"
+                                      style="padding: 0px 13px;"
+                                    >
+                                      <div
+                                        class="CalendarMonth_caption CalendarMonth_caption_1"
+                                      >
+                                        <strong>
+                                          September 2019
+                                        </strong>
+                                      </div>
+                                      <table
+                                        class="CalendarMonth_table CalendarMonth_table_1"
+                                        role="presentation"
+                                      >
+                                        <tbody>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, September 1, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              1
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, September 2, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              2
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, September 3, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              3
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, September 4, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              4
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, September 5, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              5
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, September 6, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              6
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, September 7, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              7
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, September 8, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              8
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, September 9, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              9
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, September 10, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              10
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, September 11, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              11
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, September 12, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              12
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, September 13, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              13
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, September 14, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              14
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, September 15, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              15
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, September 16, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              16
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, September 17, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              17
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, September 18, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              18
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, September 19, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              19
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, September 20, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              20
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, September 21, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              21
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, September 22, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              22
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, September 23, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              23
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, September 24, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              24
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, September 25, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              25
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, September 26, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              26
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, September 27, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              27
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, September 28, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              28
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, September 29, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              29
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, September 30, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__today CalendarDay__today_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              30
+                                            </td>
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td />
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="CalendarMonthGrid_month__horizontal CalendarMonthGrid_month__horizontal_1 CalendarMonthGrid_month__hidden CalendarMonthGrid_month__hidden_2"
+                                  >
+                                    <div
+                                      class="CalendarMonth CalendarMonth_1"
+                                      data-visible="false"
+                                      style="padding: 0px 13px;"
+                                    >
+                                      <div
+                                        class="CalendarMonth_caption CalendarMonth_caption_1"
+                                      >
+                                        <strong>
+                                          October 2019
+                                        </strong>
+                                      </div>
+                                      <table
+                                        class="CalendarMonth_table CalendarMonth_table_1"
+                                        role="presentation"
+                                      >
+                                        <tbody>
+                                          <tr>
+                                            <td />
+                                            <td />
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, October 1, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              1
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, October 2, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              2
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, October 3, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              3
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, October 4, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              4
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, October 5, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              5
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, October 6, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              6
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, October 7, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              7
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, October 8, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              8
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, October 9, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              9
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, October 10, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              10
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, October 11, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              11
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, October 12, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              12
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, October 13, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              13
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, October 14, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              14
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, October 15, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              15
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, October 16, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              16
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, October 17, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              17
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, October 18, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              18
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, October 19, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              19
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, October 20, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              20
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, October 21, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              21
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, October 22, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              22
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, October 23, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              23
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, October 24, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              24
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Friday, October 25, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              25
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Saturday, October 26, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__lastDayOfWeek CalendarDay__lastDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              26
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Sunday, October 27, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              27
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Monday, October 28, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              28
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Tuesday, October 29, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              29
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Wednesday, October 30, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              30
+                                            </td>
+                                            <td
+                                              aria-disabled="false"
+                                              aria-label="Thursday, October 31, 2019"
+                                              class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2"
+                                              role="button"
+                                              style="width: 39px; height: 38px;"
+                                              tabindex="-1"
+                                            >
+                                              31
+                                            </td>
+                                            <td />
+                                            <td />
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <button
+                                  aria-label="Open the keyboard shortcuts panel."
+                                  class="DayPickerKeyboardShortcuts_buttonReset DayPickerKeyboardShortcuts_buttonReset_1 DayPickerKeyboardShortcuts_show DayPickerKeyboardShortcuts_show_2 DayPickerKeyboardShortcuts_show__bottomRight DayPickerKeyboardShortcuts_show__bottomRight_3"
+                                  type="button"
+                                >
+                                  <span
+                                    class="DayPickerKeyboardShortcuts_showSpan DayPickerKeyboardShortcuts_showSpan_1 DayPickerKeyboardShortcuts_showSpan__bottomRight DayPickerKeyboardShortcuts_showSpan__bottomRight_2"
+                                  >
+                                    ?
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
+            </fieldset>
+            <div
+              class="usa-form-group"
+            >
+              <div
+                class=""
+              />
+              <label
+                class="usa-label"
+                for="exit-reason"
+              >
+                Reason
+              </label>
+              <select
+                aria-required="true"
+                class="usa-select"
+                id="exit-reason"
+                name=""
+              >
+                <option
+                  value="AgedOut"
+                >
+                  Aged out
+                </option>
+                <option
+                  value="StoppedAttending"
+                >
+                  Stopped attending
+                </option>
+                <option
+                  value="DifferentProgram"
+                >
+                  Chose to attend a different program
+                </option>
+                <option
+                  value="MovedInCT"
+                >
+                  Moved within Connecticut
+                </option>
+                <option
+                  value="MovedOutCT"
+                >
+                  Moved to another state
+                </option>
+                <option
+                  value="LackOfPayment"
+                >
+                  Withdrew due to lack of payment
+                </option>
+                <option
+                  value="AskedToLeave"
+                >
+                  Child was asked to leave
+                </option>
+                <option
+                  value="Unknown"
+                >
+                  Unknown
+                </option>
+                <option
+                  value=""
+                >
+                  - Select -
+                </option>
+              </select>
+            </div>
+            <div
+              class="usa-form-group"
+            >
+              <div
+                class=""
+              />
+              <label
+                class="usa-label"
+                for="last-reporting-period"
+              >
+                Last reporting period
+              </label>
+              <select
+                aria-required="true"
+                class="usa-select"
+                id="last-reporting-period"
+                name=""
+              >
+                <option
+                  value="3"
+                >
+                  May 2019 (5/1–5/31)
+                </option>
+                <option
+                  value="2"
+                >
+                  April 2019 (4/1–4/30)
+                </option>
+                <option
+                  value="1"
+                >
+                  March 2019 (3/1–3/31)
+                </option>
+                <option
+                  value=""
+                >
+                  - Select -
+                </option>
+              </select>
             </div>
           </div>
         </div>
-      </fieldset>
-      <div
-        class="usa-form-group "
-      >
         <div
-          class=""
-        />
-        <label
-          class="usa-label"
-          for="exit-reason"
+          class="grid-row"
         >
-          Reason
-        </label>
-        <select
-          aria-required="true"
-          class="usa-select"
-          id="exit-reason"
-          name="exitReason"
-        >
-          <option
-            value=""
+          <div
+            class="grid-col-auto"
           >
-            - Select -
-          </option>
-          <option
-            value="AgedOut"
-          >
-            Aged out
-          </option>
-          <option
-            value="StoppedAttending"
-          >
-            Stopped attending
-          </option>
-          <option
-            value="DifferentProgram"
-          >
-            Chose to attend a different program
-          </option>
-          <option
-            value="MovedInCT"
-          >
-            Moved within Connecticut
-          </option>
-          <option
-            value="MovedOutCT"
-          >
-            Moved to another state
-          </option>
-          <option
-            value="LackOfPayment"
-          >
-            Withdrew due to lack of payment
-          </option>
-          <option
-            value="AskedToLeave"
-          >
-            Child was asked to leave
-          </option>
-          <option
-            value="Unknown"
-          >
-            Unknown
-          </option>
-          <option
-            value="other"
-          >
-            Other
-          </option>
-        </select>
+            <a
+              class="usa-button usa-button--outline"
+              href="/roster/sites/1/enrollments/1/"
+            >
+              Cancel
+            </a>
+            <input
+              class="usa-button"
+              type="submit"
+              value="Confirm and withdraw"
+            />
+          </div>
+        </div>
       </div>
-      <div
-        class="usa-form-group "
-      >
-        <div
-          class=""
-        />
-        <label
-          class="usa-label"
-          for="last-reporting-period"
-        >
-          Last reporting period
-        </label>
-        <select
-          aria-required="true"
-          class="usa-select"
-          id="last-reporting-period"
-          name=""
-        >
-          <option
-            value=""
-          >
-            - Select -
-          </option>
-          <option
-            value="3"
-          >
-            May 2019 (5/1–5/31)
-          </option>
-          <option
-            value="2"
-          >
-            April 2019 (4/1–4/30)
-          </option>
-          <option
-            value="1"
-          >
-            March 2019 (3/1–3/31)
-          </option>
-        </select>
-      </div>
-    </div>
-    <div
-      class="grid-row margin-y-6"
-    >
-      <div
-        class="mobile-lg:grid-col-auto"
-      >
-        <a
-          class="usa-button usa-button--outline"
-          href="/roster/sites/1/enrollments/1/"
-        >
-          Cancel
-        </a>
-      </div>
-      <div
-        class="mobile-lg:grid-col-auto padding-left-2"
-      >
-        <button
-          class="usa-button"
-          type="button"
-        >
-          Confirm and withdraw
-        </button>
-      </div>
-    </div>
+    </form>
   </div>
 </DocumentFragment>
 `;

--- a/src/Hedwig/ClientApp/src/utils/models/enrollment/enrollment.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/enrollment/enrollment.ts
@@ -91,17 +91,3 @@ export function isFunded(
 
 	return fundings.length > 0;
 }
-
-/**
- * String values for default enrollment exit reasons
- */
-export const enrollmentExitReasons = {
-	AgedOut: 'Aged out',
-	StoppedAttending: 'Stopped attending',
-	DifferentProgram: 'Chose to attend a different program',
-	MovedInCT: 'Moved within Connecticut',
-	MovedOutCT: 'Moved to another state',
-	LackOfPayment: 'Withdrew due to lack of payment',
-	AskedToLeave: 'Child was asked to leave',
-	Unknown: 'Unknown',
-};

--- a/src/Hedwig/ClientApp/src/utils/models/funding.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/funding.ts
@@ -81,11 +81,11 @@ function isCurrentToRangeCDC(funding: Funding, range: DateRange): boolean {
  * @param fundings
  */
 export function getCurrentCdcFunding(
-	fundings: DeepNonUndefineable<Funding[]> | null
+	fundings: Funding[] | null
 ): DeepNonUndefineable<Funding> | undefined {
-	return (fundings || []).find<DeepNonUndefineable<Funding>>(
+	return (fundings || []).find(
 		(funding) => funding.source === FundingSource.CDC && !funding.lastReportingPeriod
-	);
+	) as DeepNonUndefineable<Funding>;
 }
 
 export function createFunding({

--- a/src/Hedwig/ClientApp/src/utils/models/fundingSpace.ts
+++ b/src/Hedwig/ClientApp/src/utils/models/fundingSpace.ts
@@ -24,7 +24,13 @@ import moment from 'moment';
  * - funding.time = split, funding.timeSplit = {fullTimeWeeks = 10, partTimeWeeks = 42}, include weeks = true: "Part time (42 weeks) / full time (10 weeks)"
  * @param fundingSpace
  */
-export function prettyFundingSpaceTime(fundingSpace: FundingSpace, includeWeeks: boolean = false) {
+export function prettyFundingSpaceTime(
+	fundingSpace: FundingSpace | undefined,
+	includeWeeks: boolean = false
+) {
+	if (!fundingSpace) {
+		return '';
+	}
 	const FULL_YEAR_WEEKS = 52;
 	if (fundingSpace.time !== FundingTime.Split) {
 		return `${prettyFundingTime(fundingSpace.time, { capitalize: true })}${formattedWeeks(

--- a/src/Hedwig/ClientApp/src/utils/stringFormatters/splitCamelCase.ts
+++ b/src/Hedwig/ClientApp/src/utils/stringFormatters/splitCamelCase.ts
@@ -1,4 +1,4 @@
-export const splitCamelCase = (input: string, delimiter = ' ') => {
+export const splitCamelCase = (input: string | undefined, delimiter = ' ') => {
 	if (!input || input.length === 0) {
 		return '';
 	}

--- a/src/Hedwig/ClientApp/src/utils/utilizationTable.tsx
+++ b/src/Hedwig/ClientApp/src/utils/utilizationTable.tsx
@@ -11,7 +11,7 @@ export function calculateRate(
 	time: FundingTime
 ) {
 	const rate = CdcRates.find(
-		r =>
+		(r) =>
 			r.accredited === accredited &&
 			r.titleI === titleI &&
 			r.region === region &&
@@ -23,14 +23,14 @@ export function calculateRate(
 }
 
 export function countFundedEnrollments(enrollments: Enrollment[], fundingSpaceId: number) {
-	return enrollments.filter(enrollment => {
+	return enrollments.filter((enrollment) => {
 		if (!enrollment.fundings) return false;
 		return isFundedForFundingSpace(enrollment, fundingSpaceId);
 	}).length;
 }
 
 export function productOfUnknowns(nums: (number | undefined)[]) {
-	return nums.map(n => n || 0).reduce((a, c) => a * c);
+	return nums.map((n) => n || 0).reduce((a, c) => a * c);
 }
 
 export function getValueBeforeDecimalPoint(number: number) {

--- a/src/Hedwig/ClientApp/src/utils/validations/messageStrings.ts
+++ b/src/Hedwig/ClientApp/src/utils/validations/messageStrings.ts
@@ -8,3 +8,5 @@ export const INCOME_REQUIRED_FOR_FUNDING_ALERT_TEXT =
 	'Income information is required enroll a child in a funded space. You will not be able to assign this child to a funding space without this information.';
 export const INFORMATION_REQUIRED_IF_INCOME_DISCLOSED =
 	'This information is required if family income is disclosed';
+export const REPORTING_PERIODS_ONLY_EXIST_FOR_FY2020_AND_BEYOND =
+	'ECE Reporter only contains data for fiscal year 2020 and later. Please do not add children who withdrew prior to July 2019.';


### PR DESCRIPTION
Should close #1133 

Updates Withdrawal to use our new form component. It takes inspiration of a `mutatedEnrollment` state variable a la `ChildInfo/NewForm`.

Also adds logic to prevent the last reporting period dropdown from showing a reporting period before the first reporting period.

Includes a few updates to form to allow for function style state update and updates to utils to support removing DeepNonUndefinable.