### PR TITLE
Remove 'include' parameter parsing from Controllers and remove 'include' parameter handing in Repositories

### DIFF
--- a/src/Hedwig/ClientApp/src/components/Header/Header.test.tsx
+++ b/src/Hedwig/ClientApp/src/components/Header/Header.test.tsx
@@ -6,7 +6,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 
 const headerProps: HeaderProps = {
-	title: 'Header test',
+	primaryTitle: 'Header test',
 	navItems: [
 		{ type: 'primary', title: 'Active section', path: '/first' },
 		{ type: 'primary', title: 'Another section', path: '/another' },

--- a/src/Hedwig/Controllers/EnrollmentsController.cs
+++ b/src/Hedwig/Controllers/EnrollmentsController.cs
@@ -45,7 +45,6 @@ namespace Hedwig.Controllers
 		public async Task<ActionResult<List<Enrollment>>> Get(
 			int orgId,
 			[FromQuery(Name = "siteIds[]")] int[] siteIds,
-			[FromQuery(Name = "include[]")] string[] include,
 			[FromQuery(Name = "startDate")] DateTime? from = null,
 			[FromQuery(Name = "endDate")] DateTime? to = null,
 			[FromQuery(Name = "asOf")] DateTime? asOf = null,
@@ -66,14 +65,14 @@ namespace Hedwig.Controllers
 
 				foreach (var siteId in siteIds)
 				{
-					var siteEnrollments = await _enrollments.GetEnrollmentsForSiteAsync(siteId, from, to, include, skip, take);
+					var siteEnrollments = await _enrollments.GetEnrollmentsForSiteAsync(siteId, from, to, skip, take);
 					enrollments.AddRange(siteEnrollments);
 				}
 			}
 			else
 			// If no sites are specified, get all enrollments for the organization
 			{
-				enrollments = await _enrollments.GetEnrollmentsForOrganizationAsync(orgId, from, to, include, asOf, skip, take);
+				enrollments = await _enrollments.GetEnrollmentsForOrganizationAsync(orgId, from, to, asOf, skip, take);
 			}
 
 			return enrollments;
@@ -88,14 +87,13 @@ namespace Hedwig.Controllers
 		public async Task<ActionResult<List<Enrollment>>> Get(
 			int orgId,
 			int siteId,
-			[FromQuery(Name = "include[]")] string[] include,
 			[FromQuery(Name = "startDate")] DateTime? from = null,
 			[FromQuery(Name = "endDate")] DateTime? to = null,
 			[FromQuery(Name = "skip")] int skip = 0,
 			[FromQuery(Name = "take")] int? take = null
 		)
 		{
-			var enrollments = await _enrollments.GetEnrollmentsForSiteAsync(siteId, from, to, include, skip, take);
+			var enrollments = await _enrollments.GetEnrollmentsForSiteAsync(siteId, from, to, skip, take);
 			return enrollments;
 		}
 
@@ -108,12 +106,11 @@ namespace Hedwig.Controllers
 		public async Task<ActionResult<Enrollment>> Get(
 			int id,
 			int orgId,
-			int siteId,
-			[FromQuery(Name = "include[]")] string[] include
+			int siteId
 		)
 		{
 
-			var enrollment = await _enrollments.GetEnrollmentForSiteAsync(id, siteId, include);
+			var enrollment = await _enrollments.GetEnrollmentForSiteAsync(id, siteId);
 			if (enrollment == null) return NotFound();
 
 			return enrollment;

--- a/src/Hedwig/Controllers/OrganizationsController.cs
+++ b/src/Hedwig/Controllers/OrganizationsController.cs
@@ -20,9 +20,9 @@ namespace Hedwig.Controllers
 		[HttpGet("{id}")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
-		public ActionResult<Organization> Get(int id, [FromQuery(Name = "include[]")] string[] include)
+		public ActionResult<Organization> Get(int id)
 		{
-			var organization = _organizations.GetOrganizationById(id, include);
+			var organization = _organizations.GetOrganizationById(id);
 
 			if (organization == null) return NotFound();
 

--- a/src/Hedwig/Controllers/ReportingPeriodsController.cs
+++ b/src/Hedwig/Controllers/ReportingPeriodsController.cs
@@ -17,7 +17,7 @@ namespace Hedwig.Controllers
 			_periods = periods;
 		}
 
-		// GET api/ReportingPeriod/CDC
+		// GET api/ReportingPeriods/CDC
 		[HttpGet("{source}")]
 		public ActionResult<List<ReportingPeriod>> Get(
 			FundingSource source

--- a/src/Hedwig/Controllers/ReportsController.cs
+++ b/src/Hedwig/Controllers/ReportsController.cs
@@ -54,11 +54,10 @@ namespace Hedwig.Controllers
 		[DTOProjectionFilter(typeof(CdcReportDTO), Order = 2)]
 		public async Task<ActionResult<CdcReport>> Get(
 			int id,
-			int orgId,
-			[FromQuery(Name = "include[]")] string[] include
+			int orgId
 		)
 		{
-			var report = await _reports.GetReportForOrganizationAsync(id, orgId, include);
+			var report = await _reports.GetReportForOrganizationAsync(id, orgId);
 			if (report == null) return NotFound();
 
 			return Ok(report);

--- a/src/Hedwig/Controllers/SitesController.cs
+++ b/src/Hedwig/Controllers/SitesController.cs
@@ -40,11 +40,10 @@ namespace Hedwig.Controllers
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public async Task<ActionResult<Site>> Get(
 			int id,
-			int orgId,
-			[FromQuery(Name = "include[]")] string[] include
+			int orgId
 		)
 		{
-			var site = await _sites.GetSiteForOrganizationAsync(id, orgId, include);
+			var site = await _sites.GetSiteForOrganizationAsync(id, orgId);
 			if (site == null) return NotFound();
 			return Ok(site);
 		}

--- a/src/Hedwig/Repositories/ChildRepository.cs
+++ b/src/Hedwig/Repositories/ChildRepository.cs
@@ -14,42 +14,27 @@ namespace Hedwig.Repositories
 		public ChildRepository(HedwigContext context) : base(context) { }
 
 		public async Task<List<Child>> GetChildrenForOrganizationAsync(
-			int organizationId,
-			string[] include = null
+			int organizationId
 		)
 		{
 			var children = _context.Children
 				.Where(c => c.OrganizationId == organizationId);
 
-			include = include ?? new string[] { };
-			if (include.Contains(INCLUDE_FAMILY))
-			{
-				children = children.Include(c => c.Family);
+			children = children.Include(c => c.Family);
+      children = ((IIncludableQueryable<Child, Family>)children).ThenInclude(f => f.Determinations);
 
-				if (include.Contains(INCLUDE_DETERMINATIONS))
-				{
-					children = ((IIncludableQueryable<Child, Family>)children).ThenInclude(f => f.Determinations);
-				}
-			}
 			return await children.ToListAsync();
 		}
 
-		public Task<Child> GetChildForOrganizationAsync(Guid id, int organizationId, string[] include = null)
+		public Task<Child> GetChildForOrganizationAsync(Guid id, int organizationId)
 		{
 			var child = _context.Children
 				.Where(c => c.Id == id
 					&& c.OrganizationId == organizationId
 				);
-			include = include ?? new string[] { };
-			if (include.Contains(INCLUDE_FAMILY))
-			{
-				child = child.Include(c => c.Family);
 
-				if (include.Contains(INCLUDE_DETERMINATIONS))
-				{
-					child = ((IIncludableQueryable<Child, Family>)child).ThenInclude(f => f.Determinations);
-				}
-			}
+			child = child.Include(c => c.Family);
+			child = ((IIncludableQueryable<Child, Family>)child).ThenInclude(f => f.Determinations);
 
 			return child.FirstOrDefaultAsync();
 		}
@@ -63,10 +48,9 @@ namespace Hedwig.Repositories
 	public interface IChildRepository
 	{
 		Task<List<Child>> GetChildrenForOrganizationAsync(
-			int organizationId,
-			string[] include = null
+			int organizationId
 		);
-		Task<Child> GetChildForOrganizationAsync(Guid id, int organizationId, string[] include);
+		Task<Child> GetChildForOrganizationAsync(Guid id, int organizationId);
 		Child GetChildById(Guid id);
 	}
 }

--- a/src/Hedwig/Repositories/EnrollmentRepository.cs
+++ b/src/Hedwig/Repositories/EnrollmentRepository.cs
@@ -35,7 +35,6 @@ namespace Hedwig.Repositories
 			int siteId,
 			DateTime? from = null,
 			DateTime? to = null,
-			string[] include = null,
 			int skip = 0,
 			int? take = null
 		)
@@ -44,7 +43,8 @@ namespace Hedwig.Repositories
 				.FilterByDates(from, to)
 				.Where(e => e.SiteId == siteId);
 
-			enrollments = enrollments.ProcessInclude(include);
+			enrollments = enrollments.IncludeFundings();
+			enrollments = enrollments.IncludeSitesAndChild();
 
 			enrollments = enrollments.Skip(skip);
 			if (take.HasValue)
@@ -54,19 +54,20 @@ namespace Hedwig.Repositories
 			return enrollments.OrderBy(e => e.Id).ToListAsync();
 		}
 
-		public Task<Enrollment> GetEnrollmentForSiteAsync(int id, int siteId, string[] include)
+		public Task<Enrollment> GetEnrollmentForSiteAsync(int id, int siteId)
 		{
 			var enrollmentQuery = _context.Enrollments
 				.Where(e => e.SiteId == siteId && e.Id == id);
 
 			enrollmentQuery = enrollmentQuery.Include(e => e.Author);
-			enrollmentQuery = enrollmentQuery.ProcessInclude(include);
+			enrollmentQuery = enrollmentQuery.IncludeFundings();
+			enrollmentQuery = enrollmentQuery.IncludeSitesAndChild();
+			enrollmentQuery = enrollmentQuery.IncludeFamilyAndDeterminations();
 
 			var enrollment = enrollmentQuery.FirstOrDefault();
 
 			// handle special include of un-mapped properties
-			if (enrollment != null
-			&& include.Contains(HedwigRepository.INCLUDE_PAST_ENROLLMENTS))
+			if (enrollment != null)
 			{
 				var pastEnrollments = _context.Enrollments.Where(
 					e => e.ChildId == enrollment.ChildId
@@ -94,7 +95,6 @@ namespace Hedwig.Repositories
 			int orgId,
 			DateTime? from = null,
 			DateTime? to = null,
-			string[] include = null,
 			DateTime? asOf = null,
 			int skip = 0,
 			int? take = null
@@ -105,7 +105,7 @@ namespace Hedwig.Repositories
 				.FilterByDates(from, to)
 				.Where(e => e.Site.OrganizationId == orgId);
 
-			enrollments = enrollments.ProcessInclude(include);
+			enrollments = enrollments.IncludeFundings();
 
 			enrollments = enrollments.Skip(skip);
 			if (take.HasValue)
@@ -125,9 +125,9 @@ namespace Hedwig.Repositories
 	{
 		void UpdateEnrollment(Enrollment enrollment, EnrollmentDTO enrollmentDTO);
 		void AddEnrollment(Enrollment enrollment);
-		Task<List<Enrollment>> GetEnrollmentsForSiteAsync(int siteId, DateTime? from = null, DateTime? to = null, string[] include = null, int skip = 0, int? take = null);
-		Task<Enrollment> GetEnrollmentForSiteAsync(int id, int siteId, string[] include = null);
-		Task<List<Enrollment>> GetEnrollmentsForOrganizationAsync(int orgId, DateTime? from = null, DateTime? to = null, string[] include = null, DateTime? asOf = null, int skip = 0, int? take = null);
+		Task<List<Enrollment>> GetEnrollmentsForSiteAsync(int siteId, DateTime? from = null, DateTime? to = null, int skip = 0, int? take = null);
+		Task<Enrollment> GetEnrollmentForSiteAsync(int id, int siteId);
+		Task<List<Enrollment>> GetEnrollmentsForOrganizationAsync(int orgId, DateTime? from = null, DateTime? to = null, DateTime? asOf = null, int skip = 0, int? take = null);
 		Enrollment GetEnrollmentById(int id);
 
 		void DeleteEnrollment(Enrollment enrollment);
@@ -151,41 +151,36 @@ namespace Hedwig.Repositories
 			return query;
 		}
 
-		public static IQueryable<Enrollment> ProcessInclude(this IQueryable<Enrollment> query, string[] include = null)
+		public static IQueryable<Enrollment> IncludeFundings(this IQueryable<Enrollment> query)
 		{
-			include = include ?? new string[] { };
-			if (include.Contains(HedwigRepository.INCLUDE_SITES))
-			{
-				query = query.Include(e => e.Site);
-			}
+			query = query.Include(e => e.Fundings)
+					.ThenInclude(f => f.FundingSpace)
+						.ThenInclude(fs => fs.TimeSplit)
+				.Include(e => e.Fundings)
+					.ThenInclude(f => f.FirstReportingPeriod)
+				.Include(e => e.Fundings)
+					.ThenInclude(f => f.LastReportingPeriod)
+				.Include(e => e.Child)
+					.ThenInclude(c => c.C4KCertificates);
 
-			if (include.Contains(HedwigRepository.INCLUDE_FUNDINGS))
-			{
-				query = query.Include(e => e.Fundings)
-						.ThenInclude(f => f.FundingSpace)
-							.ThenInclude(fs => fs.TimeSplit)
-					.Include(e => e.Fundings)
-						.ThenInclude(f => f.FirstReportingPeriod)
-					.Include(e => e.Fundings)
-						.ThenInclude(f => f.LastReportingPeriod)
-					.Include(e => e.Child)
-						.ThenInclude(c => c.C4KCertificates);
-			}
+			return query;
+		}
 
-			if (include.Contains(HedwigRepository.INCLUDE_CHILD))
-			{
-				query = query.Include(e => e.Child);
+		public static IQueryable<Enrollment> IncludeSitesAndChild(this IQueryable<Enrollment> query)
+		{
+			query = query.Include(e => e.Site);
 
-				if (include.Contains(HedwigRepository.INCLUDE_FAMILY))
-				{
-					query = ((IIncludableQueryable<Enrollment, Child>)query).ThenInclude(c => c.Family);
+			query = query.Include(e => e.Child);
 
-					if (include.Contains(HedwigRepository.INCLUDE_DETERMINATIONS))
-					{
-						query = ((IIncludableQueryable<Enrollment, Family>)query).ThenInclude(f => f.Determinations);
-					}
-				}
-			}
+
+			return query;
+		}
+
+		public static IQueryable<Enrollment> IncludeFamilyAndDeterminations(this IQueryable<Enrollment> query)
+		{
+			query = ((IIncludableQueryable<Enrollment, Child>)query).ThenInclude(c => c.Family);
+
+			query = ((IIncludableQueryable<Enrollment, Family>)query).ThenInclude(f => f.Determinations);
 
 			return query;
 		}

--- a/src/Hedwig/Repositories/HedwigRepository.cs
+++ b/src/Hedwig/Repositories/HedwigRepository.cs
@@ -13,15 +13,6 @@ namespace Hedwig.Repositories
 {
 	public abstract class HedwigRepository
 	{
-		public const string INCLUDE_FAMILY = "family";
-		public const string INCLUDE_DETERMINATIONS = "determinations";
-		public const string INCLUDE_CHILD = "child";
-		public const string INCLUDE_FUNDINGS = "fundings";
-		public const string INCLUDE_ENROLLMENTS = "enrollments";
-		public const string INCLUDE_PAST_ENROLLMENTS = "past_enrollments";
-		public const string INCLUDE_SITES = "sites";
-		public const string INCLUDE_ORGANIZATIONS = "organizations";
-		public const string INCLUDE_FUNDING_SPACES = "funding_spaces";
 
 		protected readonly HedwigContext _context;
 

--- a/src/Hedwig/Repositories/OrganizationRepository.cs
+++ b/src/Hedwig/Repositories/OrganizationRepository.cs
@@ -12,26 +12,19 @@ namespace Hedwig.Repositories
 	{
 
 		public OrganizationRepository(HedwigContext context) : base(context) { }
-		public Organization GetOrganizationById(int id, string[] include = null)
+		public Organization GetOrganizationById(int id)
 		{
 			var organization = _context.Organizations
 				.Where(o => o.Id == id);
 
-			include = include ?? new string[] { };
-			if (include.Contains(INCLUDE_FUNDING_SPACES))
-			{
-				organization = organization.Include(o => o.FundingSpaces)
-					.ThenInclude(fs => fs.TimeSplit);
-			}
-			if (include.Contains(INCLUDE_SITES))
-			{
-				organization = organization.Include(o => o.Sites);
+			organization = organization.Include(o => o.FundingSpaces)
+				.ThenInclude(fs => fs.TimeSplit);
 
-				if (include.Contains(INCLUDE_ENROLLMENTS))
-				{
-					organization = ((IIncludableQueryable<Organization, Site>)organization).ThenInclude(s => s.Enrollments);
-				}
-			}
+			organization = organization.Include(o => o.Sites);
+
+			// This would have been returned if query parameter include[] included "enrollments"
+			// Please note that this returns an error.
+			//organization = ((IIncludableQueryable<Organization, Site>)organization).ThenInclude(s => s.Enrollments);
 
 			return organization.FirstOrDefault();
 		}
@@ -47,7 +40,7 @@ namespace Hedwig.Repositories
 
 	public interface IOrganizationRepository : IHedwigRepository
 	{
-		Organization GetOrganizationById(int id, string[] include = null);
+		Organization GetOrganizationById(int id);
 		List<Organization> GetOrganizationsWithFundingSpaces(FundingSource source);
 	}
 }

--- a/src/Hedwig/Repositories/ReportRepository.cs
+++ b/src/Hedwig/Repositories/ReportRepository.cs
@@ -29,70 +29,51 @@ namespace Hedwig.Repositories
 			.ToList();
 		}
 
-		public async Task<CdcReport> GetReportForOrganizationAsync(int id, int orgId, string[] include = null)
+		public async Task<CdcReport> GetReportForOrganizationAsync(int id, int orgId)
 		{
-			include = include ?? new string[] { };
-			var include_orgs = include.Contains(INCLUDE_ORGANIZATIONS);
-			var include_sites = include.Contains(INCLUDE_SITES);
-			var include_enrollments = include.Contains(INCLUDE_ENROLLMENTS);
-			var include_children = include.Contains(INCLUDE_CHILD);
-			var include_funding_spaces = include.Contains(INCLUDE_FUNDING_SPACES);
-
 			IQueryable<CdcReport> reportQuery = _context.Reports
 			.OfType<CdcReport>()
 			.Where(report => report.Id == id && report.OrganizationId == orgId)
 			.Include(report => report.ReportingPeriod)
 			.Include(report => report.TimeSplitUtilizations);
 
-			if (include.Contains(INCLUDE_ORGANIZATIONS))
-			{
-				reportQuery = reportQuery.Include(report => report.Organization);
-			}
+			reportQuery = reportQuery.Include(report => report.Organization);
 
-			if (include.Contains(INCLUDE_SITES))
-			{
-				reportQuery = reportQuery
-					.Include(report => report.Organization)
-					.ThenInclude(organization => organization.Sites);
-			}
+			reportQuery = reportQuery
+				.Include(report => report.Organization)
+				.ThenInclude(organization => organization.Sites);
 
-			if (include.Contains(INCLUDE_FUNDING_SPACES))
-			{
-				reportQuery = reportQuery
-					.Include(report => report.Organization)
-						.ThenInclude(organization => organization.FundingSpaces)
-							.ThenInclude(fundingSpace => fundingSpace.TimeSplit)
-					.Include(report => report.Organization)
-						.ThenInclude(organization => organization.FundingSpaces)
-							.ThenInclude(fundingSpace => fundingSpace.TimeSplitUtilizations)
-								.ThenInclude(timeSplitUtilization => timeSplitUtilization.ReportingPeriod)
-					.Include(report => report.Organization)
-						.ThenInclude(organization => organization.FundingSpaces)
-							.ThenInclude(fundingSpace => fundingSpace.TimeSplitUtilizations)
-								.ThenInclude(util => util.Report);
-			}
+			reportQuery = reportQuery
+				.Include(report => report.Organization)
+					.ThenInclude(organization => organization.FundingSpaces)
+						.ThenInclude(fundingSpace => fundingSpace.TimeSplit)
+				.Include(report => report.Organization)
+					.ThenInclude(organization => organization.FundingSpaces)
+						.ThenInclude(fundingSpace => fundingSpace.TimeSplitUtilizations)
+							.ThenInclude(timeSplitUtilization => timeSplitUtilization.ReportingPeriod)
+				.Include(report => report.Organization)
+					.ThenInclude(organization => organization.FundingSpaces)
+						.ThenInclude(fundingSpace => fundingSpace.TimeSplitUtilizations)
+							.ThenInclude(util => util.Report);
 
 			var reportResult = await reportQuery.FirstOrDefaultAsync();
 
-			// Optionally manually insert time-versioned enrollment records
-			if (reportResult != null && include.Contains(INCLUDE_ENROLLMENTS))
+			// Manually insert time-versioned enrollment records
+			if (reportResult != null)
 			{
 				var enrollments = GetEnrollmentsForReport(reportResult);
-				// Optionally manually insert time-versioned child records
-				if (include.Contains(INCLUDE_CHILD))
-				{
-					var childIds = enrollments.Select(enrollment => enrollment.ChildId);
-					var children = (reportResult.SubmittedAt.HasValue ? _context.Children.AsOf(reportResult.SubmittedAt.Value) : _context.Children)
+				// Manually insert time-versioned child records
+				var childIds = enrollments.Select(enrollment => enrollment.ChildId);
+				var children = (reportResult.SubmittedAt.HasValue ? _context.Children.AsOf(reportResult.SubmittedAt.Value) : _context.Children)
 					.Include(child => child.C4KCertificates)
 					.Where(child => childIds.Contains(child.Id))
 					.ToDictionary(child => child.Id);
 
-					// Add children to enrollments
-					enrollments.ForEach(enrollment =>
-					{
-						enrollment.Child = children[enrollment.ChildId];
-					});
-				}
+				// Add children to enrollments
+				enrollments.ForEach(enrollment =>
+				{
+					enrollment.Child = children[enrollment.ChildId];
+				});
 
 				// Add enrollments to report
 				reportResult.Enrollments = enrollments;
@@ -190,7 +171,7 @@ namespace Hedwig.Repositories
 	{
 		void UpdateReport(CdcReport report, CdcReportDTO reportDTO);
 		List<CdcReport> GetReportsForOrganization(int orgId);
-		Task<CdcReport> GetReportForOrganizationAsync(int id, int orgId, string[] include);
+		Task<CdcReport> GetReportForOrganizationAsync(int id, int orgId);
 		List<Enrollment> GetEnrollmentsForReport(CdcReport report);
 		CdcReport GetMostRecentSubmittedCdcReportForOrganization(int orgId);
 		IEnumerable<CdcReport> GetReportsForOrganizationByFiscalYear(int orgId, DateTime periodDate);

--- a/src/Hedwig/Validations/Attributes/Reports/Cdc/FundingTimeUtilizationsWeeksUsedAreLessThanReportingPeriodWeeks.cs
+++ b/src/Hedwig/Validations/Attributes/Reports/Cdc/FundingTimeUtilizationsWeeksUsedAreLessThanReportingPeriodWeeks.cs
@@ -15,7 +15,7 @@ namespace Hedwig.Validations.Attributes
 			var timeSplitUtilizations = value as ICollection<FundingTimeSplitUtilization> ?? new List<FundingTimeSplitUtilization> { };
 
 			var organizations = (IOrganizationRepository)validationContext.GetService(typeof(IOrganizationRepository));
-			var organization = organizations.GetOrganizationById(report.OrganizationId, new string[] { "funding_spaces" });
+			var organization = organizations.GetOrganizationById(report.OrganizationId);
 			var fundingSpaces = organization.FundingSpaces;
 
 			foreach (var timeSplitUtilization in timeSplitUtilizations)

--- a/src/Hedwig/Validations/Attributes/Reports/Cdc/FundingTimeUtilizationsWeeksUsedDoNotExceedTotalAvailableWeeks.cs
+++ b/src/Hedwig/Validations/Attributes/Reports/Cdc/FundingTimeUtilizationsWeeksUsedDoNotExceedTotalAvailableWeeks.cs
@@ -15,7 +15,7 @@ namespace Hedwig.Validations.Attributes
 			var timeSplitUtilizations = value as ICollection<FundingTimeSplitUtilization> ?? new List<FundingTimeSplitUtilization> { };
 
 			var organizations = (IOrganizationRepository)validationContext.GetService(typeof(IOrganizationRepository));
-			var organization = organizations.GetOrganizationById(report.OrganizationId, new string[] { "funding_spaces" });
+			var organization = organizations.GetOrganizationById(report.OrganizationId);
 			var fundingSpaces = organization.FundingSpaces;
 
 			var reports = (IReportRepository)validationContext.GetService(typeof(IReportRepository));

--- a/test/HedwigTests/Controllers/EnrollmentsControllerTests.cs
+++ b/test/HedwigTests/Controllers/EnrollmentsControllerTests.cs
@@ -23,10 +23,9 @@ namespace HedwigTests.Controllers
 			var controller = new EnrollmentsController(_enrollments.Object, _sites.Object, _mapper.Object);
 
 			var siteId = 1;
-			var include = new string[] { "foo" };
-			await controller.Get(1, siteId, include);
+			await controller.Get(1, siteId);
 
-			_enrollments.Verify(e => e.GetEnrollmentsForSiteAsync(siteId, null, null, include, 0, null), Times.Once());
+			_enrollments.Verify(e => e.GetEnrollmentsForSiteAsync(siteId, null, null, 0, null), Times.Once());
 		}
 
 		[Fact]
@@ -41,9 +40,9 @@ namespace HedwigTests.Controllers
 			var id = 1;
 			var siteId = 1;
 			var include = new string[] { "foo" };
-			await controller.Get(id, 1, siteId, include);
+			await controller.Get(id, 1, siteId);
 
-			_enrollments.Verify(e => e.GetEnrollmentForSiteAsync(id, siteId, include), Times.Once());
+			_enrollments.Verify(e => e.GetEnrollmentForSiteAsync(id, siteId), Times.Once());
 		}
 
 		[Theory]

--- a/test/HedwigTests/Controllers/OrganizationsControllerTests.cs
+++ b/test/HedwigTests/Controllers/OrganizationsControllerTests.cs
@@ -21,18 +21,17 @@ namespace HedwigTests.Controllers
 		)
 		{
 			var id = 1;
-			var include = new string[] { "foo" };
 
 			var returns = exists ? new Organization() : null;
 			var _organizations = new Mock<IOrganizationRepository>();
-			_organizations.Setup(o => o.GetOrganizationById(id, include))
+			_organizations.Setup(o => o.GetOrganizationById(id))
 			.Returns(returns);
 
 			var controller = new OrganizationsController(_organizations.Object);
 
-			var result = controller.Get(id, include);
+			var result = controller.Get(id);
 
-			_organizations.Verify(o => o.GetOrganizationById(id, include), Times.Once());
+			_organizations.Verify(o => o.GetOrganizationById(id), Times.Once());
 			Assert.IsType(resultType, result.Result);
 		}
 	}

--- a/test/HedwigTests/Controllers/ReportsControllerTests.cs
+++ b/test/HedwigTests/Controllers/ReportsControllerTests.cs
@@ -38,20 +38,19 @@ namespace HedwigTests.Controllers
 		{
 			var id = 1;
 			var orgId = 1;
-			var include = new string[] { "foo" };
 
 			var returns = exists ? new CdcReport() : null;
 			var _reports = new Mock<IReportRepository>();
-			_reports.Setup(r => r.GetReportForOrganizationAsync(id, orgId, include))
+			_reports.Setup(r => r.GetReportForOrganizationAsync(id, orgId))
 				.ReturnsAsync(returns);
 
 			var _mapper = new Mock<IMapper>();
 
 			var controller = new ReportsController(_reports.Object, _mapper.Object);
 
-			var result = await controller.Get(id, orgId, include);
+			var result = await controller.Get(id, orgId);
 
-			_reports.Verify(r => r.GetReportForOrganizationAsync(id, orgId, include), Times.Once());
+			_reports.Verify(r => r.GetReportForOrganizationAsync(id, orgId), Times.Once());
 			Assert.IsType(resultType, result.Result);
 		}
 

--- a/test/HedwigTests/Controllers/SitesControllerTests.cs
+++ b/test/HedwigTests/Controllers/SitesControllerTests.cs
@@ -35,18 +35,17 @@ namespace HedwigTests.Controllers
 		{
 			var id = 1;
 			var orgId = 1;
-			var include = new string[] { "foo" };
 
 			var returns = exists ? new Site() : null;
 			var _sites = new Mock<ISiteRepository>();
-			_sites.Setup(s => s.GetSiteForOrganizationAsync(id, orgId, include))
+			_sites.Setup(s => s.GetSiteForOrganizationAsync(id, orgId))
 				.ReturnsAsync(returns);
 
 			var controller = new SitesController(_sites.Object);
 
-			var result = await controller.Get(id, orgId, include);
+			var result = await controller.Get(id, orgId);
 
-			_sites.Verify(s => s.GetSiteForOrganizationAsync(id, orgId, include));
+			_sites.Verify(s => s.GetSiteForOrganizationAsync(id, orgId));
 			Assert.IsType(resultType, result.Result);
 
 		}

--- a/test/HedwigTests/Integrations/HedwigAPIRequests.cs
+++ b/test/HedwigTests/Integrations/HedwigAPIRequests.cs
@@ -13,20 +13,12 @@ namespace HedwigTests.Integrations
 			User user,
 			Organization organization,
 			Site[] sites,
-			string[] include = null,
 			DateTime? startDate = null,
 			DateTime? endDate = null
 		)
 		{
-			include = include ?? new string[] {
-				"child",
-				"fundings",
-				"sites"
-			};
-
 			var uri = $"api/organizations/{organization.Id}/Enrollments";
 
-			uri = AddQueryParams(uri, "include[]", s => s, include);
 			uri = AddQueryParams(uri, "siteIds[]", s => s.Id.ToString(), sites);
 
 			return MakeAuthenticatedRequest(HttpMethod.Get, user, uri);
@@ -37,39 +29,21 @@ namespace HedwigTests.Integrations
 			Enrollment enrollment,
 			Organization organization,
 			Site site,
-			string[] include = null,
 			DateTime? startDate = null,
 			DateTime? endDate = null
 		)
 		{
-			include = include ?? new string[] {
-				"child",
-				"family",
-				"determinations",
-				"fundings",
-				"sites",
-				"past_enrollments"
-			};
-
 			var uri = $"api/organizations/{organization.Id}/sites/{site.Id}/Enrollments/{enrollment.Id}";
-			uri = AddQueryParams(uri, "include[]", s => s, include);
 
 			return MakeAuthenticatedRequest(HttpMethod.Get, user, uri);
 		}
 
 		public static HttpRequestMessage Organizations(
 			User user,
-			Organization organization,
-			string[] include = null
+			Organization organization
 		)
 		{
-			include = include ?? new string[] {
-				"sites",
-				"funding_spaces"
-			};
-
 			var uri = $"api/organizations/{organization.Id}";
-			uri = AddQueryParams(uri, "include[]", s => s, include);
 
 			return MakeAuthenticatedRequest(HttpMethod.Get, user, uri);
 		}
@@ -86,20 +60,10 @@ namespace HedwigTests.Integrations
 		public static HttpRequestMessage OrganizationReport(
 			User user,
 			Organization organization,
-			Report report,
-			string[] include = null
+			Report report
 		)
 		{
-			include = include ?? new string[] {
-				"organizations",
-				"enrollments",
-				"sites",
-				"funding_spaces",
-				"child"
-			};
-
 			var uri = $"api/organizations/{organization.Id}/Reports/{report.Id}";
-			uri = AddQueryParams(uri, "include[]", s => s, include);
 
 			return MakeAuthenticatedRequest(HttpMethod.Get, user, uri);
 		}

--- a/test/HedwigTests/Integrations/OrganizationsConrollerIntegrationTests.cs
+++ b/test/HedwigTests/Integrations/OrganizationsConrollerIntegrationTests.cs
@@ -20,10 +20,8 @@ namespace HedwigTests.Integrations
 		}
 
 		[Theory]
-		[InlineData(new string[] { }, false)]
-		[InlineData(new string[] { "sites", "funding_spaces" }, true)]
+		[InlineData(true)]
 		public async Task OrganizationControllerOrganizationsGet_ReturnsCorrectResponseShape(
-			string[] include,
 			bool isInclude
 		)
 		{
@@ -47,8 +45,7 @@ namespace HedwigTests.Integrations
 
 			var request = HedwigAPIRequests.Organizations(
 				user,
-				organization,
-				include
+				organization
 			);
 
 			var response = await client.SendAsync(request);

--- a/test/HedwigTests/Repositories/ChildRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/ChildRepositoryTests.cs
@@ -12,13 +12,9 @@ namespace HedwigTests.Repositories
 	public class ChildRepositoryTests
 	{
 		[Theory]
-		[InlineData(new string[] { }, false, false)]
-		[InlineData(new string[] { "family" }, true, false)]
-		[InlineData(new string[] { "determinations" }, false, false)]
-		[InlineData(new string[] { "family", "determinations" }, true, true)]
+		[InlineData(true, true)]
 
 		public async Task GetChildrenForOrganization(
-			string[] include,
 			bool includeFamily,
 			bool includeDeterminations
 		)
@@ -36,7 +32,7 @@ namespace HedwigTests.Repositories
 			using (var context = new TestHedwigContextProvider().Context)
 			{
 				var childRepo = new ChildRepository(context);
-				var res = await childRepo.GetChildrenForOrganizationAsync(organizationId, include);
+				var res = await childRepo.GetChildrenForOrganizationAsync(organizationId);
 
 				Assert.Equal(ids.OrderBy(id => id), res.Select(c => c.Id).OrderBy(id => id));
 				Assert.Equal(includeFamily, res.TrueForAll(c => c.Family != null));
@@ -45,12 +41,8 @@ namespace HedwigTests.Repositories
 		}
 
 		[Theory]
-		[InlineData(new string[] { }, false, false)]
-		[InlineData(new string[] { "family" }, true, false)]
-		[InlineData(new string[] { "determinations" }, false, false)]
-		[InlineData(new string[] { "family", "determinations" }, true, true)]
+		[InlineData(true, true)]
 		public async Task GetChildForOrganization(
-			string[] include,
 			bool includeFamily,
 			bool includeDeterminations
 		)
@@ -63,7 +55,7 @@ namespace HedwigTests.Repositories
 			using (var context = new TestHedwigContextProvider().Context)
 			{
 				var childRepo = new ChildRepository(context);
-				var res = await childRepo.GetChildForOrganizationAsync(child.Id, child.OrganizationId, include);
+				var res = await childRepo.GetChildForOrganizationAsync(child.Id, child.OrganizationId);
 
 				Assert.Equal(child.Id, res.Id);
 				Assert.Equal(includeFamily, res.Family != null);

--- a/test/HedwigTests/Repositories/EnrollmentRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/EnrollmentRepositoryTests.cs
@@ -220,19 +220,9 @@ namespace HedwigTests.Repositories
 		}
 
 		[Theory]
-		[InlineData(new string[] { }, false, false, false, false)]
-		[InlineData(new string[] { "fundings" }, true, true, false, false)]
-		[InlineData(new string[] { "child" }, false, true, false, false)]
-		[InlineData(new string[] { "family" }, false, false, false, false)]
-		[InlineData(new string[] { "determinations" }, false, false, false, false)]
-		[InlineData(new string[] { "child", "family" }, false, true, true, false)]
-		[InlineData(new string[] { "child", "determinations" }, false, true, false, false)]
-		[InlineData(new string[] { "child", "family", "determinations" }, false, true, true, true)]
-		[InlineData(new string[] { "child", "family", "determinations", "fundings" }, true, true, true, true)]
-		[InlineData(new string[] { "family", "determinations" }, false, false, false, false)]
-		[InlineData(new string[] { "family", "determinations", "fundings" }, true, true, false, false)]
+		[InlineData(true, true, true, true)]
+
 		public async Task GetEnrollmentsForSite_ReturnsEnrollmentsWithSiteId_IncludesEntities(
-			string[] include,
 			bool includeFundings,
 			bool includeChildren,
 			bool includeFamilies,
@@ -252,7 +242,7 @@ namespace HedwigTests.Repositories
 			using (var context = new TestHedwigContextProvider().Context)
 			{
 				var enrollmentRepo = new EnrollmentRepository(context);
-				var res = await enrollmentRepo.GetEnrollmentsForSiteAsync(siteId, include: include);
+				var res = await enrollmentRepo.GetEnrollmentsForSiteAsync(siteId);
 
 				Assert.Equal(ids.OrderBy(id => id), res.Select(e => e.Id).OrderBy(id => id));
 				Assert.Equal(includeFundings, res.TrueForAll(e => e.Fundings != null));
@@ -263,20 +253,9 @@ namespace HedwigTests.Repositories
 		}
 
 		[Theory]
-		[InlineData(new string[] { }, false, false, false, false, false)]
-		[InlineData(new string[] { "fundings" }, true, true, false, false, false)]
-		[InlineData(new string[] { "child" }, false, true, false, false, false)]
-		[InlineData(new string[] { "family" }, false, false, false, false, false)]
-		[InlineData(new string[] { "determinations" }, false, false, false, false, false)]
-		[InlineData(new string[] { "past_enrollments" }, false, false, false, false, true)]
-		[InlineData(new string[] { "child", "family" }, false, true, true, false, false)]
-		[InlineData(new string[] { "child", "determinations" }, false, true, false, false, false)]
-		[InlineData(new string[] { "child", "family", "determinations" }, false, true, true, true, false)]
-		[InlineData(new string[] { "child", "family", "determinations", "fundings" }, true, true, true, true, false)]
-		[InlineData(new string[] { "family", "determinations" }, false, false, false, false, false)]
-		[InlineData(new string[] { "family", "determinations", "fundings" }, true, true, false, false, false)]
+		[InlineData(true, true, true, true, true)]
+
 		public async Task GetEnrollmentForSite_ReturnsEnrollmentWithIdAndSiteId_IncludesEntities(
-			string[] include,
 			bool includeFundings,
 			bool includeChild,
 			bool includeFamily,
@@ -297,7 +276,7 @@ namespace HedwigTests.Repositories
 			using (var context = new TestHedwigContextProvider().Context)
 			{
 				var enrollmentRepo = new EnrollmentRepository(context);
-				var res = await enrollmentRepo.GetEnrollmentForSiteAsync(id, siteId, include);
+				var res = await enrollmentRepo.GetEnrollmentForSiteAsync(id, siteId);
 
 				Assert.Equal(id, res.Id);
 				Assert.Equal(includeFundings, res.Fundings != null);

--- a/test/HedwigTests/Repositories/ReportRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/ReportRepositoryTests.cs
@@ -14,12 +14,9 @@ namespace HedwigTests.Repositories
 	public class ReportRepositoryTests
 	{
 		[Theory]
-		[InlineData(false, new string[] { })]
-		[InlineData(false, new string[] { "organizations" })]
-		[InlineData(false, new string[] { "organizations", "sites", "funding_spaces" })]
-		[InlineData(false, new string[] { "organizations", "sites", "funding_spaces", "enrollments" })]
-		[InlineData(true, new string[] { "organizations", "sites", "funding_spaces", "enrollments" })]
-		public async Task Get_Report_For_Organization(bool submitted, string[] include)
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task Get_Report_For_Organization(bool submitted)
 		{
 			using (var context = new TestHedwigContextProvider().Context)
 			{
@@ -46,33 +43,29 @@ namespace HedwigTests.Repositories
 
 				// When the repository is queried
 				var repo = new ReportRepository(context);
-				var result = await repo.GetReportForOrganizationAsync(report.Id, organization.Id, include) as CdcReport;
+				var result = await repo.GetReportForOrganizationAsync(report.Id, organization.Id) as CdcReport;
 
 				// It returns the Report
 				Assert.Equal(result.Id, report.Id);
 
 				// It includes the Organization
-				Assert.Equal(include.Contains("organizations"), result.Organization != null);
+				Assert.True(result.Organization != null);
 
 				// It includes the Sites
-				Assert.Equal(include.Contains("sites"), result.Organization != null && result.Organization.Sites != null);
+				Assert.True(result.Organization != null && result.Organization.Sites != null);
 
 				// It includes the Enrollments (and Fundings too)
-				Assert.Equal(
-					include.Contains("enrollments"),
+				Assert.True(
 					result.Enrollments != null &&
-					 result.Enrollments.FirstOrDefault().Fundings != null
+					result.Enrollments.FirstOrDefault().Fundings != null
 				);
 
-				// When it includes enrollments
-				if (include.Contains("enrollments"))
-				{
-					var enrollmentResult = result.Enrollments.FirstOrDefault();
-					var fundingResult = enrollmentResult.Fundings.FirstOrDefault();
+				var enrollmentResult = result.Enrollments.FirstOrDefault();
+				var fundingResult = enrollmentResult.Fundings.FirstOrDefault();
 
-					// A submitted report should return the data as of when it was submitted
-					Assert.Equal(submitted ? Age.Preschool : Age.SchoolAge, enrollmentResult.AgeGroup);
-				}
+				// A submitted report should return the data as of when it was submitted
+				Assert.Equal(submitted ? Age.Preschool : Age.SchoolAge, enrollmentResult.AgeGroup);
+
 			}
 		}
 

--- a/test/HedwigTests/Repositories/SiteRepositoryTests.cs
+++ b/test/HedwigTests/Repositories/SiteRepositoryTests.cs
@@ -34,15 +34,8 @@ namespace HedwigTests.Repositories
 		}
 
 		[Theory]
-		[InlineData(new string[] { }, false, false, false)]
-		[InlineData(new string[] { "enrollments" }, true, false, false)]
-		[InlineData(new string[] { "fundings" }, false, false, false)]
-		[InlineData(new string[] { "child" }, false, false, false)]
-		[InlineData(new string[] { "enrollments", "fundings" }, true, true, false)]
-		[InlineData(new string[] { "enrollments", "child" }, true, false, true)]
-		[InlineData(new string[] { "enrollments", "fundings", "child" }, true, true, true)]
+		[InlineData(true, true, true)]
 		public async Task GetSiteForOrganization_ReturnsSiteWithIdAndOrganizationId_IncludesEntities(
-			string[] include,
 			bool includeEnrollments,
 			bool includeFundings,
 			bool includeChildren
@@ -61,7 +54,7 @@ namespace HedwigTests.Repositories
 			using (var context = new TestHedwigContextProvider().Context)
 			{
 				var siteRepo = new SiteRepository(context);
-				var res = await siteRepo.GetSiteForOrganizationAsync(id, orgId, include);
+				var res = await siteRepo.GetSiteForOrganizationAsync(id, orgId);
 
 				Assert.Equal(includeEnrollments, res.Enrollments != null);
 				Assert.Equal(includeFundings, res.Enrollments != null && res.Enrollments.All(e => e.Fundings != null));

--- a/test/HedwigTests/Validations/Attributes/Report/Cdc/FundingTimeUtilizationsWeeksUsedAreLessThanReportingPeriodWeeksTests.cs
+++ b/test/HedwigTests/Validations/Attributes/Report/Cdc/FundingTimeUtilizationsWeeksUsedAreLessThanReportingPeriodWeeksTests.cs
@@ -56,7 +56,7 @@ namespace HedwigTests.Validations.Attributes
 			});
 
 			var organizations = new Mock<IOrganizationRepository>();
-			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>(), It.IsAny<string[]>()))
+			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>()))
 			.Returns(organization);
 
 			var serviceProvider = new Mock<IServiceProvider>();
@@ -139,7 +139,7 @@ namespace HedwigTests.Validations.Attributes
 			});
 
 			var organizations = new Mock<IOrganizationRepository>();
-			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>(), It.IsAny<string[]>()))
+			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>()))
 			.Returns(organization);
 
 			var serviceProvider = new Mock<IServiceProvider>();

--- a/test/HedwigTests/Validations/Attributes/Report/Cdc/FundingTimeUtilizationsWeeksUsedDoNotExceedTotalAvailableWeeksTests.cs
+++ b/test/HedwigTests/Validations/Attributes/Report/Cdc/FundingTimeUtilizationsWeeksUsedDoNotExceedTotalAvailableWeeksTests.cs
@@ -59,7 +59,7 @@ namespace HedwigTests.Validations.Attributes
 				report
 			});
 			var organizations = new Mock<IOrganizationRepository>();
-			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>(), It.IsAny<string[]>()))
+			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>()))
 			.Returns(organization);
 
 			var serviceProvider = new Mock<IServiceProvider>();
@@ -147,7 +147,7 @@ namespace HedwigTests.Validations.Attributes
 				report
 			});
 			var organizations = new Mock<IOrganizationRepository>();
-			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>(), It.IsAny<string[]>()))
+			organizations.Setup(o => o.GetOrganizationById(It.IsAny<int>()))
 			.Returns(organization);
 
 			var serviceProvider = new Mock<IServiceProvider>();


### PR DESCRIPTION
Addresses #1138. Process followed:
- Exercised the application and found the "coverage" of include= parameters for api endpoints. 
- Adjusted Repository methods to include the  maximum "includes" for each endpoint
- Removed 'include' parameter parsing from Controllers
- Removed 'include' parameter handing in Repositories

For the most part, this has resulted in every 'include' possibility being returned for every API endpoint, with a few exceptions, such as:
- Enrollments not included in GetOrganizationById
- Sites, Child, Family, and Determinations not included in GetEnrollmentsForOrganizationAsync
- Family and Determinations not included in GetEnrollmentsForSiteAsync
- Child not included in GetSiteForOrganizationAsync