### PR TITLE
Add history context for location fiber

### DIFF
--- a/src/Hedwig/ClientApp/src/containers/CommonContainer.tsx
+++ b/src/Hedwig/ClientApp/src/containers/CommonContainer.tsx
@@ -3,6 +3,8 @@ import cx from 'classnames';
 import AlertContext from '../contexts/Alert/AlertContext';
 import { Alert, AlertProps, TextWithIcon, ErrorBoundary, Button } from '../components';
 import { ReactComponent as ArrowRight } from '../assets/images/arrowRight.svg';
+import HistoryContext from '../contexts/History/HistoryContext';
+import { createPath } from 'history';
 
 export type CommonContainerPropsType = {
 	children: ReactElement<any> | null;
@@ -20,13 +22,15 @@ export default function CommonContainer({
 	const { getAlerts } = useContext(AlertContext);
 	const alerts = [...additionalAlerts, ...getAlerts()];
 
+	const { previousLocation } = useContext(HistoryContext);
+
 	return (
 		<ErrorBoundary>
-			<div className={cx({ 'grid-container': backHref || alerts.length })}>
-				{backHref && backText && (
+			<div className={cx({ 'grid-container': backText || alerts.length })}>
+				{backText && (
 					<Button
 						appearance="unstyled"
-						href={backHref}
+						href={backHref || createPath(previousLocation)}
 						className="text-bold text-underline"
 						text={<TextWithIcon text={backText} Icon={ArrowRight} direction="left" />}
 					/>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
@@ -86,7 +86,7 @@ export default function EnrollmentDetail({
 	const enrollmentHistoryProps = getEnrollmentTimelineProps(enrollment);
 
 	return (
-		<CommonContainer backHref="/roster" backText="Back to roster">
+		<CommonContainer backText="Back to roster">
 			<div className="grid-container">
 				<div className="grid-row flex-first-baseline flex-space-between">
 					<div>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
   >
     <a
       class="usa-button usa-button--unstyled text-bold text-underline"
-      href="/roster"
+      href="/"
     >
       <span
         class="oec-text-with-icon"

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Update/EnrollmentUpdate.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Update/EnrollmentUpdate.tsx
@@ -121,10 +121,7 @@ export default function EnrollmentUpdate({
 	};
 
 	return (
-		<CommonContainer
-			backText="Back to summary"
-			backHref={`/roster/sites/${siteId}/enrollments/${enrollment.id}/`}
-		>
+		<CommonContainer backText="Back to summary">
 			<div className="grid-container">
 				<h1>Update {section.name.toLowerCase()}</h1>
 				<p className="usa-intro">{nameFormatter(enrollment.child)}</p>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Update/__snapshots__/EnrollmentUpdate.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Update/__snapshots__/EnrollmentUpdate.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EnrollmentUpdate FamilyIncome matches snapshot 1`] = `
   >
     <a
       class="usa-button usa-button--unstyled text-bold text-underline"
-      href="/roster/sites/1/enrollments/1/"
+      href="/"
     >
       <span
         class="oec-text-with-icon"
@@ -2860,7 +2860,7 @@ exports[`EnrollmentUpdate enrollment and funding matches snapshot 1`] = `
   >
     <a
       class="usa-button usa-button--unstyled text-bold text-underline"
-      href="/roster/sites/1/enrollments/1/"
+      href="/"
     >
       <span
         class="oec-text-with-icon"
@@ -4401,7 +4401,7 @@ exports[`EnrollmentUpdate family info matches snapshot 1`] = `
   >
     <a
       class="usa-button usa-button--unstyled text-bold text-underline"
-      href="/roster/sites/1/enrollments/1/"
+      href="/"
     >
       <span
         class="oec-text-with-icon"

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/FirstName.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/FirstName.tsx
@@ -9,10 +9,7 @@ import { REQUIRED_FOR_ENROLLMENT } from '../../../../../utils/validations/messag
 /**
  * Component for entering the first name of a child in an enrollment.
  */
-export const FirstNameField: React.FC<ChildInfoFormFieldProps> = ({
-	error,
-	errorAlertState,
-}) => {
+export const FirstNameField: React.FC<ChildInfoFormFieldProps> = ({ error, errorAlertState }) => {
 	return (
 		<FormField<Enrollment, TextInputProps, string | null>
 			getValue={(data) => data.at('child').at('firstName')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/LastName.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/LastName.tsx
@@ -9,10 +9,7 @@ import { REQUIRED_FOR_ENROLLMENT } from '../../../../../utils/validations/messag
 /**
  * Component for entering the last name of a child in an enrollment.
  */
-export const LastNameField: React.FC<ChildInfoFormFieldProps> = ({
-	error,
-	errorAlertState,
-}) => {
+export const LastNameField: React.FC<ChildInfoFormFieldProps> = ({ error, errorAlertState }) => {
 	return (
 		<FormField<Enrollment, TextInputProps, string | null>
 			getValue={(data) => data.at('child').at('lastName')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/Funding/ContractSpace.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/Funding/ContractSpace.tsx
@@ -40,15 +40,15 @@ export const ContractSpaceField: React.FC<FundingFormFieldProps> = ({
 				text: prettyFundingSpaceTime(space, true),
 				value: `${space.id}`,
 			}))}
-			status={(_) => 
+			status={(_) =>
 				displayValidationStatus([
 					{
 						type: 'error',
 						response: error,
 						field: 'fundings.fundingSpaceId',
 						message: REQUIRED_FOR_OEC_REPORTING,
-						errorAlertState
-					}
+						errorAlertState,
+					},
 				])
 			}
 		/>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/Funding/FirstReportingPeriod.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/Funding/FirstReportingPeriod.tsx
@@ -17,7 +17,6 @@ type FirstReportingPeriodFieldProps = Pick<
 	FundingFormFieldProps,
 	Exclude<keyof FundingFormFieldProps, 'fundingSpaces'>
 >;
-	
 
 export const FirstReportingPeriodField: React.FC<FirstReportingPeriodFieldProps> = ({
 	fundingId,
@@ -30,11 +29,13 @@ export const FirstReportingPeriodField: React.FC<FirstReportingPeriodFieldProps>
 
 	// Get reports
 	const { user } = useContext(UserContext);
-	const { data: reports } = useApi((api) => api.apiOrganizationsOrgIdReportsGet({orgId: getIdForUser(user, 'org')}));
+	const { data: reports } = useApi((api) =>
+		api.apiOrganizationsOrgIdReportsGet({ orgId: getIdForUser(user, 'org') })
+	);
 	// Get most recently submitted report to use to bound valid reporting period options
 	const [mostRecentlySubmittedReport] = (reports || [])
 		.filter((report) => !!report.submittedAt)
-		.sort((a, b) => propertyDateSorter(a, b, (r => r.submittedAt), true));
+		.sort((a, b) => propertyDateSorter(a, b, (r) => r.submittedAt, true));
 
 	const startDate = dataDriller.at('entry').value || moment().toDate();
 	useEffect(() => {
@@ -45,7 +46,9 @@ export const FirstReportingPeriodField: React.FC<FirstReportingPeriodFieldProps>
 		// - are after the most recent reporting period for which there is a submitted report
 		// - are not more than 3 periods in the "future" -- TODO confirm this AC
 		//   (i.e. in May, we will show May, June, and July reporting periods but not August)
-		const validPeriodStartDate = mostRecentlySubmittedReport ? moment.max(moment(mostRecentlySubmittedReport.reportingPeriod.periodEnd), moment(startDate)) : moment(startDate);
+		const validPeriodStartDate = mostRecentlySubmittedReport
+			? moment.max(moment(mostRecentlySubmittedReport.reportingPeriod.periodEnd), moment(startDate))
+			: moment(startDate);
 		const startIdx = reportingPeriods.findIndex((period) =>
 			moment(period.period).isSame(moment(validPeriodStartDate), 'month')
 		);
@@ -79,8 +82,8 @@ export const FirstReportingPeriodField: React.FC<FirstReportingPeriodFieldProps>
 						response: error,
 						field: 'fundings.firstReportingPeriodId',
 						message: REQUIRED_FOR_OEC_REPORTING,
-						errorAlertState
-					}
+						errorAlertState,
+					},
 				])
 			}
 		/>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/Funding/index.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/Funding/index.tsx
@@ -97,8 +97,17 @@ export const FundingField: React.FC<FundingFormFieldProps> = ({
 							expansion:
 								source === FundingSource.CDC ? (
 									<>
-										<ContractSpaceField fundingId={fundingId} fundingSpaces={validFundingSpaces} error={error} errorAlertState={errorAlertState}/>
-										<FirstReportingPeriodField fundingId={fundingId} error={error} errorAlertState={errorAlertState}/>
+										<ContractSpaceField
+											fundingId={fundingId}
+											fundingSpaces={validFundingSpaces}
+											error={error}
+											errorAlertState={errorAlertState}
+										/>
+										<FirstReportingPeriodField
+											fundingId={fundingId}
+											error={error}
+											errorAlertState={errorAlertState}
+										/>
 									</>
 								) : undefined,
 						} as RadioOption)

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/common.ts
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/Fields/common.ts
@@ -9,7 +9,7 @@ export type EnrollmentFormFieldProps = {
 export type FundingFormFieldProps = {
 	fundingId: number;
 	fundingSpaces: FundingSpace[];
-	error: ApiError | null,
+	error: ApiError | null;
 	errorAlertState: ErrorAlertState;
 };
 

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/NewForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/NewForm.tsx
@@ -110,7 +110,12 @@ export const NewForm: React.FC<SectionProps> = ({
 			>
 				<EnrollmentStartDate initialLoad={false} />
 				<AgeGroupField initialLoad={false} />
-				<FundingField fundingId={0} fundingSpaces={fundingSpaces} error={saveError} errorAlertState={errorAlertState}/>
+				<FundingField
+					fundingId={0}
+					fundingSpaces={fundingSpaces}
+					error={saveError}
+					errorAlertState={errorAlertState}
+				/>
 
 				<WithNewC4kCertificate shouldCreate={certificateId === 0 && receivesC4K}>
 					{/* TODO: replace with solo checkbox when/if that exists-- just add flag on solo checkbox and go ditch all the margins */}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/EnrollmentFunding/FundingCard.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/EnrollmentFunding/FundingCard.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import { Funding } from '../../../../../../generated';
 import { Card, Button, CardProps, TextWithIcon } from '../../../../../../components';
-import {
-	prettyFundingSpaceTime,
-	reportingPeriodFormatter,
-} from '../../../../../../utils/models';
+import { prettyFundingSpaceTime, reportingPeriodFormatter } from '../../../../../../utils/models';
 import { CardExpansion } from '../../../../../../components/Card/CardExpansion';
 import { ExpandCard } from '../../../../../../components/Card/ExpandCard';
 import { getFundingTag } from '../../../../../../utils/fundingType';
 import { ReactComponent as Pencil } from '../../../../../../assets/images/pencil.svg';
 
-type FundingCardProps = Pick<CardProps,
+type FundingCardProps = Pick<
+	CardProps,
 	Exclude<keyof CardProps, 'appearance' | 'forceClose' | 'key'>
 > & {
 	funding: Funding;

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/EnrollmentFunding/FundingFormForCard.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/EnrollmentFunding/FundingFormForCard.tsx
@@ -12,7 +12,7 @@ type FundingFormForCardProps = {
 	formData: Enrollment;
 	onSubmit: (_: Enrollment) => void;
 	fundingSpaces: FundingSpace[];
-	error: ApiError | null,
+	error: ApiError | null;
 	errorAlertState: ErrorAlertState;
 };
 
@@ -27,11 +27,11 @@ export const FundingFormForCard: React.FC<FundingFormForCardProps> = ({
 	onSubmit,
 	fundingSpaces,
 	error,
-	errorAlertState
+	errorAlertState,
 }) => {
 	return (
 		<Form id={`edit-funding-${fundingId}`} data={formData} onSubmit={onSubmit} className="usa-form">
-			<FundingField 
+			<FundingField
 				fundingId={fundingId}
 				fundingSpaces={fundingSpaces}
 				error={error}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/EnrollmentFunding/index.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/EnrollmentFunding/index.tsx
@@ -19,7 +19,7 @@ export const EnrollmentFundingForm: React.FC<UpdateFormSectionProps> = ({
 	setMutatedEnrollment,
 	saveError,
 	setAttemptingSave,
-	forceCloseEditForms
+	forceCloseEditForms,
 }) => {
 	const { user } = useContext(UserContext);
 
@@ -87,7 +87,11 @@ export const EnrollmentFundingForm: React.FC<UpdateFormSectionProps> = ({
 						<>
 							<EnrollmentCard enrollment={pastEnrollment} isCurrent={false} />
 							{(pastEnrollment.fundings || []).map((pastFunding) => (
-								<FundingCard funding={pastFunding} isCurrent={false} forceClose={forceCloseEditForms} />
+								<FundingCard
+									funding={pastFunding}
+									isCurrent={false}
+									forceClose={forceCloseEditForms}
+								/>
 							))}
 						</>
 					))}
@@ -96,4 +100,3 @@ export const EnrollmentFundingForm: React.FC<UpdateFormSectionProps> = ({
 		</>
 	);
 };
-

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/common.ts
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/common.ts
@@ -8,4 +8,4 @@ export type UpdateFormSectionProps = {
 	setAttemptingSave: React.Dispatch<React.SetStateAction<boolean>>;
 	saveError: ApiError | null;
 	forceCloseEditForms: boolean;
-}
+};

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/index.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/UpdateForm/index.tsx
@@ -3,25 +3,24 @@ import { TabNav } from '../../../../../components/TabNav/TabNav';
 import { EnrollmentFundingForm } from './EnrollmentFunding';
 import { Care4KidsForm } from './Care4Kids';
 import { SectionProps } from '../../../enrollmentTypes';
-import { Enrollment, ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest } from '../../../../../generated';
+import {
+	Enrollment,
+	ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest,
+} from '../../../../../generated';
 import UserContext from '../../../../../contexts/User/UserContext';
 import { validatePermissions, getIdForUser } from '../../../../../utils/models';
 import useApi from '../../../../../hooks/useApi';
 
-export const UpdateForm: React.FC<SectionProps> = ({
-	enrollment,
-	siteId
-}) => {
-	if(!enrollment) {
+export const UpdateForm: React.FC<SectionProps> = ({ enrollment, siteId }) => {
+	if (!enrollment) {
 		throw new Error('Section rendered without enrollment');
 	}
 
 	const { user } = useContext(UserContext);
 	const [forceCloseEditForms, setForceCloseEditForms] = useState(false);
 
-	const [mutatedEnrollment, setMutatedEnrollment] = useState<Enrollment>(enrollment)
+	const [mutatedEnrollment, setMutatedEnrollment] = useState<Enrollment>(enrollment);
 	const [attemptingSave, setAttemptingSave] = useState(false);
-
 
 	const renameToAvoidCodeDupeError: ApiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPutRequest = {
 		id: enrollment.id,
@@ -37,7 +36,7 @@ export const UpdateForm: React.FC<SectionProps> = ({
 			callback: () => {
 				setAttemptingSave(false);
 			},
-		},
+		}
 	);
 
 	// Handle successful API request
@@ -50,7 +49,7 @@ export const UpdateForm: React.FC<SectionProps> = ({
 		}
 
 		// If the request successed, process the response
-		if(returnedEnrollment) {
+		if (returnedEnrollment) {
 			setMutatedEnrollment(returnedEnrollment);
 			setForceCloseEditForms(true);
 		}
@@ -62,7 +61,7 @@ export const UpdateForm: React.FC<SectionProps> = ({
 		setAttemptingSave,
 		saveError,
 		forceCloseEditForms,
-	}
+	};
 	return (
 		<TabNav
 			items={[

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/index.ts
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/EnrollmentFunding_NEW/index.ts
@@ -1,6 +1,6 @@
 import { Section } from '../../enrollmentTypes';
 import { NewForm } from './NewForm';
-import { UpdateForm } from './UpdateForm'
+import { UpdateForm } from './UpdateForm';
 import EnrollmentFunding from '../EnrollmentFunding';
 
 export default {

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome/UpdateForm/FamilyDeterminationCard.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome/UpdateForm/FamilyDeterminationCard.tsx
@@ -33,7 +33,7 @@ export const FamilyDeterminationCard = ({
 			showTag={isCurrent ? isNew : undefined}
 			forceClose={forceClose}
 			key={determination.id}
-		>		
+		>
 			<div className="display-flex flex-justify">
 				<div className="flex-1">
 					<p>Household size</p>
@@ -57,10 +57,10 @@ export const FamilyDeterminationCard = ({
 							: InlineIcon({ icon: 'incomplete' })}
 					</p>
 				</div>
-			<ExpandCard>
-				<Button text={<TextWithIcon text="Edit" Icon={Pencil} />} appearance="unstyled" />
-			</ExpandCard>
-		</div>
+				<ExpandCard>
+					<Button text={<TextWithIcon text="Edit" Icon={Pencil} />} appearance="unstyled" />
+				</ExpandCard>
+			</div>
 			<CardExpansion>{expansion}</CardExpansion>
 		</Card>
 	);

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/Withdrawal.tsx
@@ -170,10 +170,7 @@ export default function Withdrawal({
 	};
 
 	return (
-		<CommonContainer
-			backHref={`/roster/sites/${siteId}/enrollments/${enrollmentId}`}
-			backText="Back"
-		>
+		<CommonContainer backText="Back">
 			<div className="grid-container">
 				<h1>Withdraw {nameFormatter(mutatedEnrollment.child)}</h1>
 				<div className="grid-row grid-gap oec-enrollment-details-section__content margin-top-1">

--- a/src/Hedwig/ClientApp/src/containers/Withdrawal/__snapshots__/Withdrawal.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Withdrawal/__snapshots__/Withdrawal.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Withdrawal matches snapshot 1`] = `
   >
     <a
       class="usa-button usa-button--unstyled text-bold text-underline"
-      href="/roster/sites/1/enrollments/1"
+      href="/"
     >
       <span
         class="oec-text-with-icon"

--- a/src/Hedwig/ClientApp/src/contexts/History/HistoryContext.tsx
+++ b/src/Hedwig/ClientApp/src/contexts/History/HistoryContext.tsx
@@ -1,0 +1,51 @@
+import React, { createContext, useState, useEffect } from 'react';
+import { History, Location, createLocation } from 'history';
+import { useLocation } from 'react-router';
+
+export type HistoryContextType = {
+	previousLocation: Location<History.PoorMansUnknown>;
+};
+
+const HistoryContext = createContext<HistoryContextType>({
+	previousLocation: createLocation('/'),
+});
+
+const { Provider, Consumer } = HistoryContext;
+
+type LocationFiber = {
+	current: Location<History.PoorMansUnknown>;
+	previous?: LocationFiber;
+};
+
+export const HistoryProvider: React.FC = ({ children }) => {
+	const location = useLocation();
+	const defaultLocation = createLocation('/');
+	const defaultFiber: LocationFiber = {
+		current: defaultLocation,
+	};
+	const [locationFiber, setLocationFiber] = useState<LocationFiber>(defaultFiber);
+
+	useEffect(() => {
+		// Create the next location fiber
+		// Set current to the incoming location
+		// Set previous to the heretofore current location
+		// Set previous.previous to undefined to allow GC
+		const nextLocationFiber: LocationFiber = {
+			current: location,
+			previous: {
+				...locationFiber,
+				previous: undefined,
+			},
+		};
+		setLocationFiber(nextLocationFiber);
+	}, [location]);
+
+	return (
+		<Provider value={{ previousLocation: locationFiber.previous?.current || defaultLocation }}>
+			{children}
+		</Provider>
+	);
+};
+
+export { Consumer as HistoryConsumer };
+export default HistoryContext;

--- a/src/Hedwig/ClientApp/src/index.tsx
+++ b/src/Hedwig/ClientApp/src/index.tsx
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/browser';
 import * as serviceWorker from './serviceWorker';
 
 import App from './containers/App/App';
+import { HistoryProvider } from './contexts/History/HistoryContext';
 import { AuthenticationProvider } from './contexts/Authentication/AuthenticationContext';
 import { UserProvider } from './contexts/User/UserContext';
 import { ReportingPeriodProvider } from './contexts/ReportingPeriod/ReportingPeriodContext';
@@ -25,24 +26,26 @@ const productionPreRender = async () => {
 const render = (Component: React.FC) => {
 	return ReactDOM.render(
 		<BrowserRouter>
-			<AuthenticationProvider
-				clientId="hedwig"
-				localStorageAccessTokenKey="hedwig-key"
-				localStorageIdTokenKey="hedwig-id"
-				defaultOpenIdConnectUrl={process.env.REACT_APP_DEFAULT_WINGED_KEYS_URL}
-				// NOTE: "offline_access" is required in scope string to retrieve refresh tokens
-				scope="openid profile hedwig_backend offline_access"
-				extras={{
-					// NOTE: Required for refresh tokens
-					access_type: 'offline',
-				}}
-			>
-				<UserProvider>
-					<ReportingPeriodProvider>
-						<Component />
-					</ReportingPeriodProvider>
-				</UserProvider>
-			</AuthenticationProvider>
+			<HistoryProvider>
+				<AuthenticationProvider
+					clientId="hedwig"
+					localStorageAccessTokenKey="hedwig-key"
+					localStorageIdTokenKey="hedwig-id"
+					defaultOpenIdConnectUrl={process.env.REACT_APP_DEFAULT_WINGED_KEYS_URL}
+					// NOTE: "offline_access" is required in scope string to retrieve refresh tokens
+					scope="openid profile hedwig_backend offline_access"
+					extras={{
+						// NOTE: Required for refresh tokens
+						access_type: 'offline',
+					}}
+				>
+					<UserProvider>
+						<ReportingPeriodProvider>
+							<Component />
+						</ReportingPeriodProvider>
+					</UserProvider>
+				</AuthenticationProvider>
+			</HistoryProvider>
 		</BrowserRouter>,
 		document.getElementById('root')
 	);


### PR DESCRIPTION
Should close #1066 

GOING THROUGH ALL THAT REACT INTERNAL CODE HAS PAID OFF BECAUSE IT SHOWED LIGHT ON THE FIBER DATA STRUCTURE (basically just a linked list) AND ITS VALUE WITHIN THE REACT LIFECYCLE