### PR TITLE
947: Update sidenav to function more like tabnav

### DIFF
--- a/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
@@ -7100,87 +7100,77 @@ exports[`Storyshots SideNav Default 1`] = `
     }
   }
 >
-  <nav
-    className="oec-sidenav"
+  <div
+    className="oec-sidenav grid-row grid-gap"
   >
     <div
-      className="tablet:grid-col-4"
+      className="mobile-lg:grid-col-4"
     >
-      <ul>
-        <li
-          className="oec-sidenav__item active"
-        >
-          <a
-            href="/"
-            onClick={[Function]}
+      <nav>
+        <ul>
+          <li
+            className="oec-sidenav__item"
           >
-            <div
-              className="oec-sidenav-item__title"
+            <a
+              onClick={[Function]}
             >
-              Item title is a link
-            </div>
-            <div
-              className="oec-sidenav-item__desc"
-            >
-              This is the first item
-            </div>
-          </a>
-        </li>
-        <li
-          className="oec-sidenav__item"
-        >
-          <a
-            href="/"
-            onClick={[Function]}
-          >
-            <div
-              className="oec-sidenav-item__title"
-            >
-              Item title is also a link
-            </div>
-            <div
-              className="oec-sidenav-item__desc"
-            >
-              This is the second item, which has a longer description
-            </div>
-          </a>
-        </li>
-        <li
-          className="oec-sidenav__item"
-        >
-          <a
-            href="/"
-            onClick={[Function]}
-          >
-            <div
-              className="oec-sidenav-item__title"
-            >
-              Look an icon
-              <span
-                className="oec-inline-icon oec-inline-icon--complete"
-              >
-                <svg>
-                  success.svg
-                </svg>
-                <span
-                  className="usa-sr-only"
+              <div>
+                <p
+                  className="oec-sidenav-item__title"
                 >
-                  (
-                  complete
-                  )
-                </span>
-              </span>
-            </div>
-            <div
-              className="oec-sidenav-item__desc"
+                  The default active item
+                   
+                </p>
+                <p
+                  className="oec-sidenav-item__desc"
+                >
+                  This is the first item
+                </p>
+              </div>
+            </a>
+          </li>
+          <li
+            className="oec-sidenav__item"
+          >
+            <a
+              onClick={[Function]}
             >
-              This is the third item
-            </div>
-          </a>
-        </li>
-      </ul>
+              <div>
+                <p
+                  className="oec-sidenav-item__title"
+                >
+                  The other item
+                   
+                  <span
+                    className="oec-inline-icon oec-inline-icon--complete"
+                  >
+                    <svg>
+                      success.svg
+                    </svg>
+                    <span
+                      className="usa-sr-only"
+                    >
+                      (
+                      complete
+                      )
+                    </span>
+                  </span>
+                </p>
+                <p
+                  className="oec-sidenav-item__desc"
+                >
+                  This is the third item
+                </p>
+              </div>
+            </a>
+          </li>
+        </ul>
+      </nav>
     </div>
-  </nav>
+    <div
+      className="margin-top-2 mobile-lg:grid-col-8"
+    />
+  </div>
 </div>
 `;
 

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNav.stories.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNav.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { SideNav } from '..';
+import { SideNav, Button } from '..';
 import { action } from '@storybook/addon-actions';
 import { SideNavItemProps } from './SideNavItem';
 
@@ -9,29 +9,22 @@ const onClick = action('onChange');
 const exampleItems: SideNavItemProps[] = [
 	{
 		titleLink: {
-			text: 'Item title is a link',
+			text: 'The default active item',
 			link: '/',
 		},
 		onClick,
 		description: 'This is the first item',
-		active: true,
+		content: <div>Some content for the first item</div>
 	},
 	{
 		titleLink: {
-			text: 'Item title is also a link',
-			link: '/',
-		},
-		onClick,
-		description: 'This is the second item, which has a longer description',
-	},
-	{
-		titleLink: {
-			text: 'Look an icon',
+			text: 'The other item',
 			link: '/',
 		},
 		onClick,
 		icon: 'complete',
 		description: 'This is the third item',
+		content: <div><Button text="A Button" /></div>
 	},
 ];
 

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNav.stories.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNav.stories.tsx
@@ -14,7 +14,7 @@ const exampleItems: SideNavItemProps[] = [
 		},
 		onClick,
 		description: 'This is the first item',
-		content: <div>Some content for the first item</div>
+		content: <div>Some content for the first item</div>,
 	},
 	{
 		titleLink: {
@@ -24,7 +24,11 @@ const exampleItems: SideNavItemProps[] = [
 		onClick,
 		icon: 'complete',
 		description: 'This is the third item',
-		content: <div><Button text="A Button" /></div>
+		content: (
+			<div>
+				<Button text="A Button" />
+			</div>
+		),
 	},
 ];
 

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
@@ -7,21 +7,17 @@ export type SideNavProps = {
 	noActiveItemContent?: JSX.Element;
 };
 
-export const SideNav = ({ 
-	items,
-	externalActiveItemIndex,
-	noActiveItemContent
-}: SideNavProps) => {
+export const SideNav = ({ items, externalActiveItemIndex, noActiveItemContent }: SideNavProps) => {
 	const [activeItemIndex, setActiveItemIndex] = useState(externalActiveItemIndex);
 
 	useEffect(() => {
 		setActiveItemIndex(
 			externalActiveItemIndex != undefined && !isNaN(externalActiveItemIndex)
-			? externalActiveItemIndex
-			: undefined
+				? externalActiveItemIndex
+				: undefined
 		);
-	}, [externalActiveItemIndex])
-	
+	}, [externalActiveItemIndex]);
+
 	return (
 		<div className="oec-sidenav grid-row grid-gap">
 			<div className="mobile-lg:grid-col-4">
@@ -29,25 +25,26 @@ export const SideNav = ({
 					<ul>
 						{items.map((item, idx) => {
 							const _onClick = () => {
-								console.log("setting tab nav to ", idx);
+								console.log('setting tab nav to ', idx);
 								setActiveItemIndex(idx);
 								item.onClick && item.onClick();
-							}
-							return <SideNavItem 
-								{...item} 
-								key={idx} 
-								onClick={_onClick} 
-								active={idx === activeItemIndex}
-							/>
+							};
+							return (
+								<SideNavItem
+									{...item}
+									key={idx}
+									onClick={_onClick}
+									active={idx === activeItemIndex}
+								/>
+							);
 						})}
 					</ul>
 				</nav>
 			</div>
 			<div className="margin-top-2 mobile-lg:grid-col-8">
-				{activeItemIndex !== undefined && activeItemIndex < items.length 
+				{activeItemIndex !== undefined && activeItemIndex < items.length
 					? items[activeItemIndex].content
-					: noActiveItemContent
-				}
+					: noActiveItemContent}
 			</div>
 		</div>
 	);

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
@@ -1,20 +1,54 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { SideNavItem, SideNavItemProps } from './SideNavItem';
 
 export type SideNavProps = {
 	items: SideNavItemProps[];
+	externalActiveItemIndex?: number;
+	noActiveItemContent?: JSX.Element;
 };
 
-export const SideNav = ({ items }: SideNavProps) => {
+export const SideNav = ({ 
+	items,
+	externalActiveItemIndex,
+	noActiveItemContent
+}: SideNavProps) => {
+	const [activeItemIndex, setActiveItemIndex] = useState(externalActiveItemIndex);
+
+	useEffect(() => {
+		setActiveItemIndex(
+			externalActiveItemIndex != undefined && !isNaN(externalActiveItemIndex)
+			? externalActiveItemIndex
+			: undefined
+		);
+	}, [externalActiveItemIndex])
+	
 	return (
-		<nav className="oec-sidenav">
-			<div className="tablet:grid-col-4">
-				<ul>
-					{items.map((item) => (
-						<SideNavItem {...item} />
-					))}
-				</ul>
+		<div className="oec-sidenav grid-row grid-gap">
+			<div className="mobile-lg:grid-col-4">
+				<nav>
+					<ul>
+						{items.map((item, idx) => {
+							const _onClick = () => {
+								console.log("setting tab nav to ", idx);
+								setActiveItemIndex(idx);
+								item.onClick && item.onClick();
+							}
+							return <SideNavItem 
+								{...item} 
+								key={idx} 
+								onClick={_onClick} 
+								active={idx === activeItemIndex}
+							/>
+						})}
+					</ul>
+				</nav>
 			</div>
-		</nav>
+			<div className="margin-top-2 mobile-lg:grid-col-8">
+				{activeItemIndex !== undefined && activeItemIndex < items.length 
+					? items[activeItemIndex].content
+					: noActiveItemContent
+				}
+			</div>
+		</div>
 	);
 };

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
 import { InlineIcon, Icon } from '..';
-import { TextWithIcon } from '../TextWithIcon/TextWithIcon';
 
 type SideNavItemTitle = {
 	text: string;
@@ -32,7 +31,9 @@ export const SideNavItem = ({
 		<li className={cx('oec-sidenav__item', { active })}>
 			<a onClick={onClick}>
 				<div>
-					<p className="oec-sidenav-item__title">{titleLink.text} {icon && <InlineIcon icon={icon} /> }</p>
+					<p className="oec-sidenav-item__title">
+						{titleLink.text} {icon && <InlineIcon icon={icon} />}
+					</p>
 					<p className="oec-sidenav-item__desc">{description}</p>
 				</div>
 			</a>

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { InlineIcon, Icon } from '..';
+import { TextWithIcon } from '../TextWithIcon/TextWithIcon';
 
 type SideNavItemTitle = {
 	text: string;
@@ -10,9 +11,14 @@ type SideNavItemTitle = {
 export type SideNavItemProps = {
 	titleLink: SideNavItemTitle;
 	description: string;
-	active?: boolean;
 	icon?: Icon;
 	onClick?: () => any;
+	content: JSX.Element;
+};
+
+type InternalSideNavItemProps = SideNavItemProps & {
+	active: boolean;
+	onClick: () => any;
 };
 
 export const SideNavItem = ({
@@ -21,15 +27,14 @@ export const SideNavItem = ({
 	active,
 	onClick,
 	icon,
-}: SideNavItemProps) => {
+}: InternalSideNavItemProps) => {
 	return (
 		<li className={cx('oec-sidenav__item', { active })}>
-			<a href={titleLink.link} onClick={onClick}>
-				<div className="oec-sidenav-item__title">
-					{titleLink.text}
-					{icon && <InlineIcon icon={icon} />}
+			<a onClick={onClick}>
+				<div>
+					<p className="oec-sidenav-item__title">{titleLink.text} {icon && <InlineIcon icon={icon} /> }</p>
+					<p className="oec-sidenav-item__desc">{description}</p>
 				</div>
-				<div className="oec-sidenav-item__desc">{description}</div>
 			</a>
 		</li>
 	);

--- a/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
+++ b/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
@@ -1,7 +1,10 @@
 .oec-sidenav {
+
 	ul {
 		list-style-type: none;
+		padding: 0;
 	}
+
 
 	.oec-sidenav__item {
 		width: 100%;
@@ -35,6 +38,7 @@
 		.oec-sidenav-item__title {
 			padding-bottom: 0.5rem;
 			font-weight: bold;
+			margin: 0;
 		}
 
 		.oec-inline-icon {
@@ -44,6 +48,7 @@
 		.oec-sidenav-item__desc {
 			color: color($theme-color-base);
 			line-height: 1.25em;
+			margin: 0;
 		}
 	}
 }

--- a/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
+++ b/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
@@ -1,10 +1,8 @@
 .oec-sidenav {
-
 	ul {
 		list-style-type: none;
 		padding: 0;
 	}
-
 
 	.oec-sidenav__item {
 		width: 100%;


### PR DESCRIPTION
this was motivated by how the sidenav is used in the specs for batchedit, specifically:
- need to control cycle logic beyond just via clicks (i.e. completing the last enrollment in sidenav list will cycle back to first enrollment that still has missing info, or if no enrollment with missing info then no item selected)
- need to display content when no item is selected 

it does this by exposing the active item index. Not sure how we feel about exposing the index to the user to control selection (vs some other more logical means) BUT since it is a *list* i figured some sort of ordering was reasonable to assume & leverage.
