### PR TITLE
947 batch edit

### DIFF
--- a/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
@@ -7111,8 +7111,10 @@ exports[`Storyshots SideNav Default 1`] = `
           <li
             className="oec-sidenav__item"
           >
-            <a
+            <button
+              className="usa-button usa-button--unstyled"
               onClick={[Function]}
+              type="button"
             >
               <div>
                 <p
@@ -7127,13 +7129,15 @@ exports[`Storyshots SideNav Default 1`] = `
                   This is the first item
                 </p>
               </div>
-            </a>
+            </button>
           </li>
           <li
             className="oec-sidenav__item"
           >
-            <a
+            <button
+              className="usa-button usa-button--unstyled"
               onClick={[Function]}
+              type="button"
             >
               <div>
                 <p
@@ -7162,7 +7166,7 @@ exports[`Storyshots SideNav Default 1`] = `
                   This is the third item
                 </p>
               </div>
-            </a>
+            </button>
           </li>
         </ul>
       </nav>

--- a/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/Hedwig/ClientApp/src/__snapshots__/storyshots.test.ts.snap
@@ -7101,7 +7101,7 @@ exports[`Storyshots SideNav Default 1`] = `
   }
 >
   <div
-    className="oec-sidenav grid-row grid-gap"
+    className="oec-sidenav grid-row"
   >
     <div
       className="mobile-lg:grid-col-4"
@@ -7168,7 +7168,7 @@ exports[`Storyshots SideNav Default 1`] = `
       </nav>
     </div>
     <div
-      className="margin-top-2 mobile-lg:grid-col-8"
+      className="mobile-lg:grid-col-8 oec-sidenav__content"
     />
   </div>
 </div>

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNav.stories.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNav.stories.tsx
@@ -8,19 +8,13 @@ import { SideNavItemProps } from './SideNavItem';
 const onClick = action('onChange');
 const exampleItems: SideNavItemProps[] = [
 	{
-		titleLink: {
-			text: 'The default active item',
-			link: '/',
-		},
+		title: 'The default active item',
 		onClick,
 		description: 'This is the first item',
 		content: <div>Some content for the first item</div>,
 	},
 	{
-		titleLink: {
-			text: 'The other item',
-			link: '/',
-		},
+		title: 'The other item',
 		onClick,
 		icon: 'complete',
 		description: 'This is the third item',

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNav.tsx
@@ -19,13 +19,12 @@ export const SideNav = ({ items, externalActiveItemIndex, noActiveItemContent }:
 	}, [externalActiveItemIndex]);
 
 	return (
-		<div className="oec-sidenav grid-row grid-gap">
+		<div className="oec-sidenav grid-row">
 			<div className="mobile-lg:grid-col-4">
 				<nav>
 					<ul>
 						{items.map((item, idx) => {
 							const _onClick = () => {
-								console.log('setting tab nav to ', idx);
 								setActiveItemIndex(idx);
 								item.onClick && item.onClick();
 							};
@@ -41,8 +40,8 @@ export const SideNav = ({ items, externalActiveItemIndex, noActiveItemContent }:
 					</ul>
 				</nav>
 			</div>
-			<div className="margin-top-2 mobile-lg:grid-col-8">
-				{activeItemIndex !== undefined && activeItemIndex < items.length
+			<div className="mobile-lg:grid-col-8 oec-sidenav__content">
+				{activeItemIndex !== undefined && activeItemIndex < items.length 
 					? items[activeItemIndex].content
 					: noActiveItemContent}
 			</div>

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
-import { InlineIcon, Icon } from '..';
+import { InlineIcon, Icon, Button } from '..';
 
 export type SideNavItemProps = {
 	title: string;
@@ -24,12 +24,13 @@ export const SideNavItem = ({
 }: InternalSideNavItemProps) => {
 	return (
 		<li className={cx('oec-sidenav__item', { active })}>
-			<a onClick={onClick}>
+			<Button onClick={onClick} appearance="unstyled" text={
 				<div>
 					<p className="oec-sidenav-item__title">{title} {icon && <InlineIcon icon={icon} /> }</p>
 					<p className="oec-sidenav-item__desc">{description}</p>
 				</div>
-			</a>
+			}>
+			</Button>
 		</li>
 	);
 };

--- a/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
+++ b/src/Hedwig/ClientApp/src/components/SideNav/SideNavItem.tsx
@@ -2,13 +2,8 @@ import React from 'react';
 import cx from 'classnames';
 import { InlineIcon, Icon } from '..';
 
-type SideNavItemTitle = {
-	text: string;
-	link: string;
-};
-
 export type SideNavItemProps = {
-	titleLink: SideNavItemTitle;
+	title: string;
 	description: string;
 	icon?: Icon;
 	onClick?: () => any;
@@ -21,7 +16,7 @@ type InternalSideNavItemProps = SideNavItemProps & {
 };
 
 export const SideNavItem = ({
-	titleLink,
+	title,
 	description,
 	active,
 	onClick,
@@ -31,9 +26,7 @@ export const SideNavItem = ({
 		<li className={cx('oec-sidenav__item', { active })}>
 			<a onClick={onClick}>
 				<div>
-					<p className="oec-sidenav-item__title">
-						{titleLink.text} {icon && <InlineIcon icon={icon} />}
-					</p>
+					<p className="oec-sidenav-item__title">{title} {icon && <InlineIcon icon={icon} /> }</p>
 					<p className="oec-sidenav-item__desc">{description}</p>
 				</div>
 			</a>

--- a/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
+++ b/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
@@ -34,7 +34,7 @@
 			border-left: 0.5rem solid $theme-color-primary;
 		}
 
-		a {
+		button {
 			color: inherit;
 			padding: 1rem;
 			text-decoration: none;

--- a/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
+++ b/src/Hedwig/ClientApp/src/components/SideNav/_index.scss
@@ -4,16 +4,30 @@
 		padding: 0;
 	}
 
+	.oec-sidenav__content {
+		padding: 1rem 0rem 1rem 0rem;
+		margin-top: 1rem;
+		border: 1px solid color($theme-color-base-light);
+		border-width: 1px 1px 1px 1px;
+
+		div {
+			&second-child {
+				border-top: 1px solid color($theme-color-base-light);
+
+			}
+		}
+	}
+
 	.oec-sidenav__item {
 		width: 100%;
 		border: 1px solid color($theme-color-base-light);
-		border-width: 0px 1px 1px 1px;
+		border-width: 0px 0px 1px 1px;
 		padding: 0;
 		display: block;
 
 		&:first-child {
-			border-width: 1px;
 			// First child should have top border
+			border-width: 1px 0px 1px 1px;
 		}
 
 		&.active {

--- a/src/Hedwig/ClientApp/src/components/StepList/Step.tsx
+++ b/src/Hedwig/ClientApp/src/components/StepList/Step.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { InlineIcon } from '..';
+import cx from 'classnames';
 
 export type ExternalStepStatus = 'incomplete' | 'complete' | 'attentionNeeded' | 'exempt';
 
@@ -14,6 +15,7 @@ export type InternalStepProps<T> = {
 	Summary: React.FC<T>;
 	Form: React.FC<T>;
 	props: T;
+	type?: 'normal' | 'embedded';
 };
 
 const labelForStatus = (status: ExternalStepStatus) => {
@@ -36,9 +38,14 @@ export default function Step<T>({
 	Summary,
 	Form,
 	props,
+	type = 'normal'
 }: InternalStepProps<T>) {
 	return (
-		<li className={`oec-step-list__step oec-step-list__step--${status}`}>
+		<li className={cx(
+			'oec-step-list__step',
+			`oec-step-list__step--${status}`,
+			{'embedded': type === 'embedded' }
+		)}>
 			<div className="oec-step-list__step__content">
 				<h2 className="oec-step-list__step__title">{name}</h2>
 

--- a/src/Hedwig/ClientApp/src/components/StepList/StepList.tsx
+++ b/src/Hedwig/ClientApp/src/components/StepList/StepList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { default as Step, ExternalStepStatus, InternalStepProps, InternalStepStatus } from './Step';
+import cx from 'classnames';
 
 // The statuses 'active' and 'notStarted' can only be assigned by StepList itself
 export type StepStatus = ExternalStepStatus;
@@ -17,6 +18,7 @@ export type StepListProps<T> = {
 	steps: StepProps<T>[];
 	props: T;
 	activeStep: string;
+	type?: 'normal' | 'embedded';
 };
 
 const mapStepsToInternalProps = function <T>(steps: StepProps<T>[], activeStep: string, props: T) {
@@ -39,12 +41,15 @@ const mapStepsToInternalProps = function <T>(steps: StepProps<T>[], activeStep: 
 	});
 };
 
-export default function StepList<T>({ steps, props, activeStep }: StepListProps<T>) {
+export default function StepList<T>({ steps, props, activeStep, type = 'normal' }: StepListProps<T>) {
 	const internalSteps = mapStepsToInternalProps(steps, activeStep, props);
 	return (
-		<ol className="oec-step-list">
+		<ol className={cx(
+			"oec-step-list",
+			{ "embedded": type === 'embedded' }
+		)}>
 			{internalSteps.map((step) => (
-				<Step {...step} />
+				<Step {...step} type={type}/>
 			))}
 		</ol>
 	);

--- a/src/Hedwig/ClientApp/src/components/StepList/_index.scss
+++ b/src/Hedwig/ClientApp/src/components/StepList/_index.scss
@@ -19,6 +19,22 @@ $future-step-color: color('base-dark') !default;
 	margin: 0;
 	padding: 0 $step-list-padding-h;
 	padding-left: $step-list-padding-left;
+	&.embedded {
+		padding-left: 0 !important;
+		li::before {
+			content: none !important;
+		}
+		&::after {
+			border-bottom: $step-border-width solid color('base-lighter');
+			bottom: 0;
+			content: '';
+			display: block;
+			height: 1px;
+			left: 0 !important;
+			position: absolute;
+			right: 0 !important;
+		}
+	}
 }
 
 .oec-step-list__step {
@@ -28,7 +44,7 @@ $future-step-color: color('base-dark') !default;
 	padding-bottom: $step-margin;
 	position: relative;
 
-	&::before {
+	&::before{
 		border: $step-list-number-border-size solid $future-step-color;
 		border-radius: 50%;
 		box-sizing: border-box;
@@ -98,7 +114,7 @@ $future-step-color: color('base-dark') !default;
 	color: color('ink');
 }
 
-.oec-step-list__step:not(.oec-step-list__step--notStarted):not(.oec-step-list__step--active) {
+.oec-step-list__step:not(.oec-step-list__step--notStarted):not(.oec-step-list__step--active){
 	.oec-step-list__step__title {
 		color: color('ink');
 	}

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/BatchEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/BatchEdit.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react';
+import moment from 'moment';
+import UserContext from '../../contexts/User/UserContext';
+import useApi from '../../hooks/useApi';
+import { Enrollment } from '../../generated';
+import { getIdForUser } from '../../utils/models';
+import CommonContainer from '../CommonContainer';
+
+type BatchEditProps = {};
+const BatchEdit: React.FC<BatchEditProps> = ({
+}) => {
+	// TODO get from QS param from roster
+	const startDate = moment();
+	const endDate = moment();
+
+	// Set up enrollments get.
+	const { user } = useContext(UserContext);
+	const params = {
+		orgId: getIdForUser(user, 'org'),
+		startDate: startDate.toDate(),
+		endDate: endDate.toDate(),
+	};
+
+	const { data: enrollments, loading, error } = useApi<Enrollment[]>(
+		(api) => api.apiOrganizationsOrgIdEnrollmentsGet(params)
+	)
+
+	const needInfoEnrollments = (enrollments || []).filter(e => e.validationErrors && e.validationErrors.length);
+	console.log("needInfoEnrollments", needInfoEnrollments);
+	return (
+		<CommonContainer>
+			<div className="grid-container">
+				<h1>Add needed information</h1>
+				<p className="usa-intro">{needInfoEnrollments.length} enrollments have missing or incomplete information</p> 
+				{needInfoEnrollments.forEach(e => {
+					return <p> BLAH {e.childId}</p>
+				})}
+			</div>
+		</CommonContainer>
+	)
+}
+
+export default BatchEdit;

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/BatchEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/BatchEdit.tsx
@@ -28,9 +28,13 @@ const BatchEdit: React.FC<BatchEditProps> = ({
 		endDate: endDate.toDate(),
 	};
 
-	const { data: enrollments, loading, error } = useApi<Enrollment[]>(
+	const { data: enrollments, loading } = useApi<Enrollment[]>(
 		(api) => api.apiOrganizationsOrgIdEnrollmentsGet(params)
 	)
+
+	if(loading) {
+		return <>Loading...</>
+	}
 
 	const needInfoEnrollments = (enrollments || []).filter(e => e.validationErrors && e.validationErrors.length);
 	return (
@@ -38,10 +42,7 @@ const BatchEdit: React.FC<BatchEditProps> = ({
 			<div className="grid-container">
 				<h1>Add needed information</h1>
 				<p className="usa-intro">{needInfoEnrollments.length} enrollments have missing or incomplete information</p> 
-				{needInfoEnrollments.length 
-					? <EnrollmentsEditList enrollments={needInfoEnrollments} />
-					: <p>all good</p>
-				}
+				<EnrollmentsEditList enrollments={needInfoEnrollments} />
 			</div>
 		</CommonContainer>
 	)

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/BatchEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/BatchEdit.tsx
@@ -5,9 +5,16 @@ import useApi from '../../hooks/useApi';
 import { Enrollment } from '../../generated';
 import { getIdForUser } from '../../utils/models';
 import CommonContainer from '../CommonContainer';
+import { EnrollmentsEditList } from './EnrollmentsEditList';
 
-type BatchEditProps = {};
+type BatchEditProps = {
+	history: History;
+	match: {
+		params: { activeEnrollmentId?: number; }
+	}
+};
 const BatchEdit: React.FC<BatchEditProps> = ({
+	match: {params: sectionId }
 }) => {
 	// TODO get from QS param from roster
 	const startDate = moment();
@@ -26,15 +33,15 @@ const BatchEdit: React.FC<BatchEditProps> = ({
 	)
 
 	const needInfoEnrollments = (enrollments || []).filter(e => e.validationErrors && e.validationErrors.length);
-	console.log("needInfoEnrollments", needInfoEnrollments);
 	return (
 		<CommonContainer>
 			<div className="grid-container">
 				<h1>Add needed information</h1>
 				<p className="usa-intro">{needInfoEnrollments.length} enrollments have missing or incomplete information</p> 
-				{needInfoEnrollments.forEach(e => {
-					return <p> BLAH {e.childId}</p>
-				})}
+				{needInfoEnrollments.length 
+					? <EnrollmentsEditList enrollments={needInfoEnrollments} />
+					: <p>all good</p>
+				}
 			</div>
 		</CommonContainer>
 	)

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/EnrollmentsEditList.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/EnrollmentsEditList.tsx
@@ -22,16 +22,12 @@ export const EnrollmentsEditList: React.FC<EnrollmentsEditListProps> = ({
 			: (editedEnrollments.length ? 0: undefined));
 
 	const moveNext = () => {
-		console.log("current enrollment idx", currentEnrollmentIdx);
 		if(currentEnrollmentIdx == undefined) return;
 
-		console.log('editedEnrollments.length', editedEnrollments.length);
 		if(currentEnrollmentIdx === editedEnrollments.length - 1) {
 			setCurrentEnrollmentIdx(undefined);
 			return;
 		}
-
-		console.log("next");
 
 		setCurrentEnrollmentIdx(currentEnrollmentIdx + 1);
 	}
@@ -46,10 +42,13 @@ export const EnrollmentsEditList: React.FC<EnrollmentsEditListProps> = ({
 					content: <SingleEnrollmentEdit enrollmentId={enrollment.id} siteId={enrollment.siteId} moveNextEnrollment={moveNext}/>
 				}))
 			}
+			// TODO: IMPLEMENT THIS!!!!
+			// noActiveItemContent={}
 		/>
 	);
 }
 
+// TODO: IMPLEMENT THIS!!!!!
 const getMissingInfoFields = (enrollment: Enrollment) => {
 	if(hasValidationErrors(enrollment)) return 'Birth certificate';
 	return '';

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/EnrollmentsEditList.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/EnrollmentsEditList.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Enrollment, SiteFromJSON } from '../../generated';
+import { SideNav } from '../../components';
+import { lastFirstNameFormatter, nameFormatter } from '../../utils/stringFormatters';
+import { hasValidationErrors } from '../../utils/validations';
+import { SingleEnrollmentEdit } from './SingleEnrollmentEdit';
+
+type EnrollmentsEditListProps = {
+	enrollments: Enrollment[];
+	activeEnrollmentId?: number;
+};
+
+export const EnrollmentsEditList: React.FC<EnrollmentsEditListProps> = ({
+	enrollments,
+	activeEnrollmentId
+}) => {
+	const [editedEnrollments, setEditedEnrollments] = useState(enrollments);
+
+	const [currentEnrollmentIdx, setCurrentEnrollmentIdx] = useState<number|undefined>(
+		activeEnrollmentId 
+			? editedEnrollments.findIndex((e) => e.id === activeEnrollmentId) 
+			: (editedEnrollments.length ? 0: undefined));
+
+	const moveNext = () => {
+		console.log("current enrollment idx", currentEnrollmentIdx);
+		if(currentEnrollmentIdx == undefined) return;
+
+		console.log('editedEnrollments.length', editedEnrollments.length);
+		if(currentEnrollmentIdx === editedEnrollments.length - 1) {
+			setCurrentEnrollmentIdx(undefined);
+			return;
+		}
+
+		console.log("next");
+
+		setCurrentEnrollmentIdx(currentEnrollmentIdx + 1);
+	}
+
+	return (
+		<SideNav
+			externalActiveItemIndex={currentEnrollmentIdx}
+			items={
+				editedEnrollments.map((enrollment, idx) => ({
+					title: lastFirstNameFormatter(enrollment.child),
+					description:	getMissingInfoFields(enrollment),
+					content: <SingleEnrollmentEdit enrollmentId={enrollment.id} siteId={enrollment.siteId} moveNextEnrollment={moveNext}/>
+				}))
+			}
+		/>
+	);
+}
+
+const getMissingInfoFields = (enrollment: Enrollment) => {
+	if(hasValidationErrors(enrollment)) return 'Birth certificate';
+	return '';
+}

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/SingleEnrollmentEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/SingleEnrollmentEdit.tsx
@@ -53,7 +53,6 @@ export const SingleEnrollmentEdit: React.FC<SingleEnrollmentEditProps> = ({
 		}
 	);
 
-
 	
 	// Create steps for step list, based on state of missing/needed information
 	// in the fetched enrollment
@@ -128,7 +127,6 @@ export const SingleEnrollmentEdit: React.FC<SingleEnrollmentEditProps> = ({
 		onSkip: moveNextStep,
 	};
 
-	console.log("steps", steps);
 	return (
 		<>
 			<div className="grid-row flex-first-baseline flex-space-between padding-x-2 padding-bottom-3">

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/SingleEnrollmentEdit.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/SingleEnrollmentEdit.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useContext, useEffect } from 'react';
+import { Enrollment } from '../../generated';
+import { hasValidationErrors } from '../../utils/validations';
+import { StepProps, Button } from '../../components';
+import { lastFirstNameFormatter } from '../../utils/stringFormatters';
+import dateFormatter from '../../utils/dateFormatter';
+import StepList from '../../components/StepList/StepList';
+import UserContext from '../../contexts/User/UserContext';
+import { getIdForUser, enrollmentWithDefaultFamily } from '../../utils/models';
+import useApi from '../../hooks/useApi';
+import ChildInfo from './_sections/ChildInfo';
+import { BatchEditStepProps } from './_sections/batchEditTypes';
+import FamilyInfo from './_sections/FamilyInfo';
+import { useHistory } from 'react-router';
+import HistoryContext from '../../contexts/History/HistoryContext';
+
+
+type SingleEnrollmentEditProps = {
+	enrollmentId: number,
+	siteId: number,
+	moveNextEnrollment: () => void;
+}
+
+export const SingleEnrollmentEdit: React.FC<SingleEnrollmentEditProps> = ({
+	enrollmentId,
+	siteId,
+	moveNextEnrollment,
+}) => {
+
+	const { user } = useContext(UserContext);
+	const orgId = getIdForUser(user, 'org');
+
+	const params = {
+		orgId,
+		siteId: siteId,
+		id: enrollmentId,
+	};
+	const history = useHistory();
+	const [mutatedEnrollment, setMutatedEnrollment] = useState<Enrollment>();
+
+	// populate mutatedEnrollment (better name: to-be-mutated-enrollment) with enrollment detail from API
+	const {data: enrollmentDetail } = useApi<Enrollment>(
+		(api) => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdGet(params),
+		{
+			successCallback: (returnedEnrollment) => {
+				setMutatedEnrollment(returnedEnrollment);
+			},
+			skip: !user,
+			deps: [enrollmentId],
+		}
+	);
+
+	console.log("mutated enrollment", mutatedEnrollment);
+	console.log("enrollment id", enrollmentId);
+
+	// Set up PUT request, to be triggered by steplist forms
+	const [attemptingSave, setAttemptingSave] = useState(false);
+	const { data: returnedEnrollment, loading: isSaving, error: errorOnSave } = useApi<Enrollment>(
+		(api) => api.apiOrganizationsOrgIdSitesSiteIdEnrollmentsIdPut({
+			...params,
+			enrollment: mutatedEnrollment
+		}),
+		{
+			skip: !user || !attemptingSave,
+			callback: () => setAttemptingSave(false),
+			successCallback: (returnedEnrollment) => {
+				setAttemptingSave(false);
+				setMutatedEnrollment(returnedEnrollment);
+				moveNextStep();
+			}
+		}
+	)
+	
+	// Create steps for step list, based on state of missing/needed information
+	// in the fetched enrollment
+	const steps: StepProps<BatchEditStepProps>[] = [];
+	if(hasValidationErrors(enrollmentDetail?.child), undefined, true /*skip subobj validation*/) {
+		steps.push(ChildInfo);
+	}
+	if(hasValidationErrors(enrollmentDetail?.child?.family, undefined, true)) {
+		steps.push(FamilyInfo);
+	}
+
+	// set up url path for initial step
+	const firstStep = steps.length ? steps[0].key : 'complete';
+	useEffect(() => {
+		let path = '';
+		const pathIdMatch = history.location.pathname.match(/(\d+)/);
+		if(!pathIdMatch || (pathIdMatch[0] !== `${enrollmentId}`)) {
+			path += `/batch-edit/${enrollmentId}`;
+		}
+
+		path += `#${firstStep}`
+		history.push(path);	
+	}, [enrollmentDetail]);
+
+	// set up function to advance to next step.
+	// If there is no next step for this enrollment,
+	// then invoke the moveNextEnrollment function
+	const locationHash = history.location.hash;
+	const activeStepId = locationHash ? locationHash.slice(1) : firstStep;
+	const moveNextStep = () => {
+		const currentIndex = steps.findIndex((step) => step.key === activeStepId);
+		if(currentIndex === steps.length - 1) {
+			moveNextEnrollment();
+			return;
+		}
+
+		history.push(`#${steps[currentIndex + 1].key}`);
+	}
+
+
+	if(!mutatedEnrollment) {
+		return <></>;
+	}
+
+	const stepProps: BatchEditStepProps = {
+		enrollment: mutatedEnrollment,
+		error: errorOnSave,
+		onSubmit: (userModifiedEnrollment) => { 
+			setMutatedEnrollment(userModifiedEnrollment)
+			setAttemptingSave(true);
+		},
+		onSkip: moveNextStep,
+	};
+
+	return (
+		<>
+			<div className="grid-row flex-first-baseline flex-space-between padding-x-2 padding-bottom-3">
+				<div>
+					<h2>{lastFirstNameFormatter(mutatedEnrollment.child)}</h2>
+					<Button appearance='unstyled' text="View full profile" href={`/roster/sites/${siteId}/enrollments/${enrollmentId}`} />
+				</div>
+				<span>
+					Date of Birth: {dateFormatter(mutatedEnrollment.child?.birthdate)}
+				</span>
+			</div>
+			<div className="padding-top-4 padding-x-2 border-top-1px border-base-light">
+				<StepList key={mutatedEnrollment.id} steps={steps} props ={stepProps} activeStep={activeStepId} type='embedded' />
+			</div>
+		</>
+	);
+}

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/ChildInfo/EditForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/ChildInfo/EditForm.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Form, FormSubmitButton } from "../../../../components/Form_New";
+import { Enrollment } from "../../../../generated";
+import { hasValidationErrors } from "../../../../utils/validations";
+import { DateOfBirthField, BirthCertificateFormFieldSet, RaceField, GenderField, EthnicityField } from "../../../Enrollment/_sections/ChildInfo/Fields";
+import useCatchAllErrorAlert from "../../../../hooks/useCatchAllErrorAlert";
+import { BatchEditStepProps } from "../batchEditTypes";
+import { Button } from "../../../../components";
+
+export const EditForm: React.FC<BatchEditStepProps> = ({
+	enrollment,
+	error,
+	onSubmit,
+	onSkip
+}) => {
+	if(!enrollment) {
+		throw new Error("Section rendered without enrollment");
+	}
+
+	useCatchAllErrorAlert(error);
+
+	return (
+		<Form<Enrollment>
+			className="usa-form"
+			data={enrollment}
+			onSubmit={onSubmit}
+			noValidate
+			autoComplete="off"
+		>
+			{hasValidationErrors(enrollment.child, ['birthdate']) &&
+				<>
+					<h3>Date of Birth</h3>
+					<DateOfBirthField errorDisplayGuard={true}/>
+				</>
+			}
+			{hasValidationErrors(enrollment.child, ['birthCertificateId', 'birthState', 'birthTown']) &&
+				<>
+					<h3>Birth Certificate</h3>
+					<BirthCertificateFormFieldSet errorDisplayGuard={true}/>
+				</>
+			}
+			{hasValidationErrors(enrollment.child, ['americanIndianOrAlaskaNative', 'asian', 'blackOrAfricanAmerican', 'nativeHawaiianOrPacificIslander', 'white']) &&
+				<>
+					<h3>Race</h3>
+					<RaceField errorDisplayGuard={true}/>
+				</>
+			}
+			{hasValidationErrors(enrollment.child, ['hispanicOrLatinxEthnicity']) &&
+				<>
+					<h3>Ethnicity</h3>
+					<EthnicityField errorDisplayGuard={true}/>
+				</>
+			}	
+			{hasValidationErrors(enrollment.child, ['gender']) &&
+				<>
+					<h3>Gender</h3>
+					<GenderField errorDisplayGuard={true} />
+				</>
+			}	
+			<FormSubmitButton text="Save and next"/>
+			<Button appearance="outline" text="Skip" onClick={onSkip} />
+		</Form>
+	)
+}

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/ChildInfo/index.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/ChildInfo/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { EditForm } from './EditForm';
+import { StepProps } from '../../../../components';
+import { BatchEditStepProps } from '../batchEditTypes';
+
+export default {
+	key: 'child-info',
+	name: "Child's information",
+	status: () => 'incomplete',
+	editPath: '',
+	Summary: () => <></>,
+	Form: EditForm
+} as StepProps<BatchEditStepProps>;

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyIncome/EditForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyIncome/EditForm.tsx
@@ -1,0 +1,66 @@
+import { Form, FormSubmitButton } from "../../../../components/Form_New";
+import { BatchEditStepProps } from "../batchEditTypes";
+import React from "react";
+import { Enrollment } from "../../../../generated";
+import { hasValidationErrors } from "../../../../utils/validations";
+import { IncomeDeterminationFieldSet } from "../../../Enrollment/_sections/FamilyIncome/Fields";
+import { Button } from "../../../../components";
+import useCatchAllErrorAlert from "../../../../hooks/useCatchAllErrorAlert";
+
+export const EditForm: React.FC<BatchEditStepProps> = ({
+	enrollment,
+	error,
+	onSubmit,
+	onSkip,
+}) => {
+	if (!enrollment) { 
+		throw new Error("Section rendered without enrollment");
+	}
+
+	useCatchAllErrorAlert(error);
+	const determinationsWithErrors = (enrollment.child?.family?.determinations || []).filter(
+		(det) => !!det.validationErrors && det.validationErrors.length
+	);
+
+	return (
+		<Form<Enrollment>
+			className="usa-form"
+			data={enrollment}
+			onSubmit={onSubmit}
+			noValidate
+			autoComplete="off"
+		>
+			{/* 
+				NOTE: This validation is not currently active; TODO: test when it is activated
+				When the enrollment has warning due to expired income determination
+				-- which is NOT a sub-object validation -- 
+				then display form fields to redetermine income (create new income determination)
+			 */}
+			{hasValidationErrors(enrollment.child?.family, ['determinations'], true) && 
+				<>
+					<h3>Redetermine family income</h3>
+					<IncomeDeterminationFieldSet type="redetermine" determinationId={0} errorDisplayGuard={true} />
+				</>
+			}
+
+			{/*
+				When the enrollment has warnings due to other income determination fields
+				-- which are sub-object validations --
+				then display form fields to edit those determinations with validation errors 
+			 */}
+			{determinationsWithErrors.length && 
+				<>
+					<h3>Family income determinations</h3>
+					{
+						determinationsWithErrors.map((det) => 
+							<IncomeDeterminationFieldSet type="edit" determinationId={det.id} errorDisplayGuard={true} />
+						)
+					}
+				</>
+			}
+
+			<FormSubmitButton text="Save and next" />
+			<Button appearance="outline" text="skip" onClick={onSkip} />
+		</Form>
+	)
+}

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyIncome/index.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyIncome/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { EditForm } from './EditForm';
+import { BatchEditStepProps } from '../batchEditTypes';
+import { StepProps } from '../../../../components';
+
+export default {
+	key: 'family-income',
+	name: 'Family income',
+	status: () => 'incomplete',
+	editPath: '',
+	Summary: () => <></>,
+	Form: EditForm,
+} as StepProps<BatchEditStepProps>;

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyInfo/EditForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyInfo/EditForm.tsx
@@ -5,6 +5,7 @@ import { Form, FormSubmitButton } from '../../../../components/Form_New';
 import { hasValidationErrors } from '../../../../utils/validations';
 import { AddressFieldset } from '../../../Enrollment/_sections/FamilyInfo/Fields';
 import { Button } from '../../../../components';
+import useCatchAllErrorAlert from '../../../../hooks/useCatchAllErrorAlert';
 
 export const EditForm: React.FC<BatchEditStepProps> = ({
 	enrollment,
@@ -16,8 +17,8 @@ export const EditForm: React.FC<BatchEditStepProps> = ({
 		throw new Error("Section rendered without enrollment");
 	}
 
-	console.log("enrollment", enrollment);
-
+	useCatchAllErrorAlert(error);
+	
 	// Family will always exist (because we create it if missing in SingleEnrollmentEdit)
 	const family = enrollment.child?.family;
 	return (

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyInfo/EditForm.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyInfo/EditForm.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { BatchEditStepProps } from '../batchEditTypes';
+import { Enrollment } from '../../../../generated';
+import { Form, FormSubmitButton } from '../../../../components/Form_New';
+import { hasValidationErrors } from '../../../../utils/validations';
+import { AddressFieldset } from '../../../Enrollment/_sections/FamilyInfo/Fields';
+import { Button } from '../../../../components';
+
+export const EditForm: React.FC<BatchEditStepProps> = ({
+	enrollment,
+	error,
+	onSubmit,
+	onSkip,
+}) => {
+	if (!enrollment) {
+		throw new Error("Section rendered without enrollment");
+	}
+
+	console.log("enrollment", enrollment);
+
+	// Family will always exist (because we create it if missing in SingleEnrollmentEdit)
+	const family = enrollment.child?.family;
+	return (
+		<Form<Enrollment>
+			className="usa-form"
+			data={enrollment}
+			onSubmit={onSubmit}
+			noValidate 
+			autoComplete="off"
+		> 
+			{hasValidationErrors(family, ['addressLine1', 'town', 'state', 'zip']) && 
+				<>
+					<h3>Address</h3>
+					<AddressFieldset errorDisplayGuard={true} />
+				</>
+			}
+
+			<FormSubmitButton text="Save and next" />
+			<Button appearance="outline" text="Skip" onClick={onSkip} />
+		</Form>
+	)
+}

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyInfo/index.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/FamilyInfo/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { EditForm } from './EditForm';
+import { StepProps } from '../../../../components';
+import { BatchEditStepProps } from '../batchEditTypes';
+
+export default {
+	key: 'family-info',
+	name: "Family information",
+	status: () => 'incomplete',
+	editPath: '',
+	Summary: () => <></>,
+	Form: EditForm
+} as StepProps<BatchEditStepProps>;

--- a/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/batchEditTypes.tsx
+++ b/src/Hedwig/ClientApp/src/containers/BatchEdit/_sections/batchEditTypes.tsx
@@ -1,0 +1,9 @@
+import { Enrollment } from "../../../generated";
+import { ApiError } from "../../../hooks/useApi";
+
+export type BatchEditStepProps = {
+	enrollment: Enrollment;
+	error: ApiError | null;
+	onSubmit: (_: Enrollment) => void;
+	onSkip: () => void;
+};

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/EnrollmentDetail.tsx
@@ -86,7 +86,7 @@ export default function EnrollmentDetail({
 	const enrollmentHistoryProps = getEnrollmentTimelineProps(enrollment);
 
 	return (
-		<CommonContainer backText="Back to roster">
+		<CommonContainer backText="Back to roster" backHref="/roster">
 			<div className="grid-container">
 				<div className="grid-row flex-first-baseline flex-space-between">
 					<div>

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/Detail/__snapshots__/EnrollmentDetail.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EnrollmentDetail matches snapshot 1`] = `
   >
     <a
       class="usa-button usa-button--unstyled text-bold text-underline"
-      href="/"
+      href="/roster"
     >
       <span
         class="oec-text-with-icon"

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthCertificateFieldSet.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthCertificateFieldSet.tsx
@@ -13,7 +13,7 @@ import { BirthStateField } from './BirthState';
  * Component that wraps BirthCertificateId, BirthTown, and BirthState in a fieldset.
  */
 export const BirthCertificateFormFieldSet: React.FC<ChildInfoFormFieldProps> = ({
-	initialLoad,
+	errorDisplayGuard: initialLoad,
 }) => {
 	return (
 		<FormFieldSet<Enrollment>
@@ -35,13 +35,13 @@ export const BirthCertificateFormFieldSet: React.FC<ChildInfoFormFieldProps> = (
 			}
 		>
 			<div className="mobile-lg:grid-col-12">
-				<BirthCertificateIdField initialLoad={initialLoad} />
+				<BirthCertificateIdField errorDisplayGuard={initialLoad} />
 			</div>
 			<div className="mobile-lg:grid-col-8 display-inline-block">
-				<BirthTownField initialLoad={initialLoad} />
+				<BirthTownField errorDisplayGuard={initialLoad} />
 			</div>
 			<div className="mobile-lg:grid-col-4 display-inline-block">
-				<BirthStateField initialLoad={initialLoad} />
+				<BirthStateField errorDisplayGuard={initialLoad} />
 			</div>
 		</FormFieldSet>
 	);

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthCertificateId.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthCertificateId.tsx
@@ -9,7 +9,7 @@ import { displayValidationStatus } from '../../../../../utils/validations/displa
 /**
  * Component for entering a birth certificate id of a child in an enrollment.
  */
-export const BirthCertificateIdField: React.FC<ChildInfoFormFieldProps> = ({ initialLoad }) => {
+export const BirthCertificateIdField: React.FC<ChildInfoFormFieldProps> = ({ errorDisplayGuard: initialLoad }) => {
 	return (
 		<FormField<Enrollment, TextInputProps, string | null>
 			getValue={(data) => data.at('child').at('birthCertificateId')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthState.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthState.tsx
@@ -9,7 +9,7 @@ import { displayValidationStatus } from '../../../../../utils/validations/displa
 /**
  * Component for entering the birth state of a child in an enrollment.
  */
-export const BirthStateField: React.FC<ChildInfoFormFieldProps> = ({ initialLoad }) => {
+export const BirthStateField: React.FC<ChildInfoFormFieldProps> = ({ errorDisplayGuard: initialLoad }) => {
 	return (
 		<FormField<Enrollment, TextInputProps, string | null>
 			getValue={(data) => data.at('child').at('birthState')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthTown.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/BirthTown.tsx
@@ -9,7 +9,7 @@ import { displayValidationStatus } from '../../../../../utils/validations/displa
 /**
  * Component for entering the birth town of a child in an enrollment.
  */
-export const BirthTownField: React.FC<ChildInfoFormFieldProps> = ({ initialLoad }) => {
+export const BirthTownField: React.FC<ChildInfoFormFieldProps> = ({ errorDisplayGuard: initialLoad }) => {
 	return (
 		<FormField<Enrollment, TextInputProps, string | null>
 			getValue={(data) => data.at('child').at('birthTown')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/DateOfBirth.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/DateOfBirth.tsx
@@ -10,7 +10,7 @@ import { REQUIRED_FOR_OEC_REPORTING } from '../../../../../utils/validations/mes
 /**
  * Component for entering the birth date of a child in an enrollment.
  */
-export const DateOfBirthField: React.FC<ChildInfoFormFieldProps> = ({ initialLoad }) => {
+export const DateOfBirthField: React.FC<ChildInfoFormFieldProps> = ({ errorDisplayGuard: initialLoad }) => {
 	return (
 		<FormField<Enrollment, DateInputProps, Date | null>
 			getValue={(data) => data.at('child').at('birthdate')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/Ethnicity.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/Ethnicity.tsx
@@ -17,7 +17,7 @@ import RadioButton from '../../../../../components/RadioButton/RadioButton';
  * The internal controlling component, RadioButtonGroup, wraps the individual
  * RadioButtons in a fieldset.
  */
-export const EthnicityField: React.FC<ChildInfoFormFieldProps> = ({ initialLoad }) => {
+export const EthnicityField: React.FC<ChildInfoFormFieldProps> = ({ errorDisplayGuard: initialLoad }) => {
 	return (
 		<FormField<Enrollment, RadioButtonGroupProps, boolean | null>
 			getValue={(data) => data.at('child').at('hispanicOrLatinxEthnicity')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/Gender.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/Gender.tsx
@@ -11,7 +11,7 @@ import { SelectProps, Select } from '../../../../../components/Select/Select';
 /**
  * Component for entering the gender of a child in an enrollment.
  */
-export const GenderField: React.FC<ChildInfoFormFieldProps> = ({ initialLoad }) => {
+export const GenderField: React.FC<ChildInfoFormFieldProps> = ({ errorDisplayGuard: initialLoad }) => {
 	return (
 		<FormField<Enrollment, SelectProps, Gender>
 			getValue={(data) => data.at('child').at('gender')}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/Race.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/Race.tsx
@@ -15,7 +15,7 @@ import { FormFieldSetProps } from '../../../../../components/Form_New';
 /**
  * Component for entering the race of a child in an enrollment.
  */
-export const RaceField: React.FC<ChildInfoFormFieldProps> = ({ initialLoad }) => {
+export const RaceField: React.FC<ChildInfoFormFieldProps> = ({ errorDisplayGuard: initialLoad }) => {
 	return (
 		<CheckboxGroup<FormFieldSetProps<Enrollment>>
 			useFormFieldSet

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/common.ts
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/ChildInfo/Fields/common.ts
@@ -3,7 +3,7 @@ import { ValidationResponse } from '../../../../../utils/validations/displayVali
 
 // Common helper type for supplying additional props to field components
 export type ChildInfoFormFieldProps = {
-	initialLoad?: boolean;
+	errorDisplayGuard?: boolean;
 	error?: ValidationResponse | null;
 	errorAlertState?: ErrorAlertState;
 };

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome/Fields/IncomeDeterminationFieldSet.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyIncome/Fields/IncomeDeterminationFieldSet.tsx
@@ -8,15 +8,18 @@ import { FormFieldSet } from '../../../../../components/Form_New/FormFieldSet';
 import React from 'react';
 import { HouseholdSizeField, AnnualHouseholdIncomeField, DeterminationDateField } from '.';
 import { FormStatusFunc } from '../../../../../components/Form_New/FormStatusFunc';
+import { initialLoadErrorGuard } from '../../../../../utils/validations';
 
 type IncomeDeterminationFieldSetProps = {
 	type: 'new' | 'redetermine' | 'edit';
 	determinationId: number;
+	errorDisplayGuard?: boolean;
 };
 
 export const IncomeDeterminationFieldSet: React.FC<IncomeDeterminationFieldSetProps> = ({
 	type,
 	determinationId,
+	errorDisplayGuard = false,
 }) => {
 	let status, elementId, legend, showLegend;
 	switch (type) {
@@ -29,20 +32,23 @@ export const IncomeDeterminationFieldSet: React.FC<IncomeDeterminationFieldSetPr
 
 		case 'edit':
 			status = ((data) =>
-				displayValidationStatus([
-					{
-						type: 'warning',
-						response:
-							data
-								.at('child')
-								.at('family')
-								.at('determinations')
-								.find((det) => det.id === determinationId)
-								.at('validationErrors').value || null,
-						fields: ['numberOfPeople', 'income', 'determinationDate'],
-						message: REQUIRED_FOR_OEC_REPORTING,
-					},
-				])) as FormStatusFunc<Enrollment>;
+				initialLoadErrorGuard(
+					errorDisplayGuard,
+					displayValidationStatus([
+						{
+							type: 'warning',
+							response:
+								data
+									.at('child')
+									.at('family')
+									.at('determinations')
+									.find((det) => det.id === determinationId)
+									.at('validationErrors').value || null,
+							fields: ['numberOfPeople', 'income', 'determinationDate'],
+							message: REQUIRED_FOR_OEC_REPORTING,
+						},
+					]))
+				) as FormStatusFunc<Enrollment>;
 			elementId = `family-income-determination-edit-${determinationId}`;
 			legend = 'Edit family income';
 			showLegend = true;

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/AddressFieldset.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/AddressFieldset.tsx
@@ -11,7 +11,9 @@ import { State } from './State';
 import { Town } from './Town';
 import { FamilyInfoFormFieldProps } from './common';
 
-export const AddressFieldset: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
+export const AddressFieldset: React.FC<FamilyInfoFormFieldProps> = ({ 
+	errorDisplayGuard  = false
+}) => (
 	<FormFieldSet<Enrollment>
 		id="family-address"
 		legend="Address"
@@ -19,7 +21,7 @@ export const AddressFieldset: React.FC<FamilyInfoFormFieldProps> = ({ initialLoa
 		className="display-inline-block"
 		status={(enrollment) =>
 			initialLoadErrorGuard(
-				initialLoad || false,
+				errorDisplayGuard,
 				displayValidationStatus([
 					{
 						type: 'warning',
@@ -32,19 +34,19 @@ export const AddressFieldset: React.FC<FamilyInfoFormFieldProps> = ({ initialLoa
 		}
 	>
 		<div className="mobile-lg:grid-col-12">
-			<AddressLine1 />
+			<AddressLine1 errorDisplayGuard={errorDisplayGuard} />
 		</div>
 		<div className="mobile-lg:grid-col-12">
 			<AddressLine2 />
 		</div>
 		<div className="mobile-lg:grid-col-8 display-inline-block">
-			<Town />
+			<Town errorDisplayGuard={errorDisplayGuard} />
 		</div>
 		<div className="mobile-lg:grid-col-4 display-inline-block">
-			<State />
+			<State errorDisplayGuard={errorDisplayGuard} />
 		</div>
 		<div className="mobile-lg:grid-col-6">
-			<Zip />
+			<Zip errorDisplayGuard={errorDisplayGuard} />
 		</div>
 	</FormFieldSet>
 );

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/AddressLine1.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/AddressLine1.tsx
@@ -6,7 +6,9 @@ import { displayValidationStatus } from '../../../../../utils/validations/displa
 import FormField from '../../../../../components/Form_New/FormField';
 import { Enrollment } from '../../../../../generated';
 
-export const AddressLine1: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
+export const AddressLine1: React.FC<FamilyInfoFormFieldProps> = ({ 
+	errorDisplayGuard = false
+}) => (
 	<FormField<Enrollment, TextInputProps, string | null>
 		getValue={(data) => data.at('child').at('family').at('addressLine1')}
 		type="input"
@@ -16,7 +18,7 @@ export const AddressLine1: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }
 		parseOnChangeEvent={(e) => e.target.value}
 		status={(enrollment) =>
 			initialLoadErrorGuard(
-				initialLoad || false,
+				errorDisplayGuard,
 				displayValidationStatus([
 					{
 						type: 'warning',

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/FosterCheckbox.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/FosterCheckbox.tsx
@@ -5,7 +5,7 @@ import { FamilyInfoFormFieldProps } from './common';
 import { Checkbox, CheckboxProps } from '../../../../../components';
 import FormField from '../../../../../components/Form_New/FormField';
 
-export const FosterCheckbox: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
+export const FosterCheckbox: React.FC<FamilyInfoFormFieldProps> = () => (
 	<FormField<Enrollment, CheckboxProps, boolean | null>
 		getValue={(data) => data.at('child').at('foster')}
 		value={'foster'}

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/HomelessnessCheckbox.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/HomelessnessCheckbox.tsx
@@ -5,7 +5,7 @@ import { Enrollment } from '../../../../../generated';
 import FormField from '../../../../../components/Form_New/FormField';
 import { FamilyInfoFormFieldProps } from './common';
 
-export const HomelessnessCheckbox: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
+export const HomelessnessCheckbox: React.FC<FamilyInfoFormFieldProps> = () => (
 	<div className="margin-top-3">
 		<FormField<Enrollment, CheckboxProps, boolean | null>
 			id="homelessness"

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/State.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/State.tsx
@@ -8,7 +8,9 @@ import { Enrollment } from '../../../../../generated';
 
 const possibleStates = ['CT', 'MA', 'NY', 'RI'];
 
-export const State: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
+export const State: React.FC<FamilyInfoFormFieldProps> = ({
+	errorDisplayGuard = false
+}) => (
 	<FormField<Enrollment, SelectProps, string>
 		id="state"
 		label="State"
@@ -19,7 +21,7 @@ export const State: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
 		name="state"
 		status={(enrollment) =>
 			initialLoadErrorGuard(
-				initialLoad || false,
+				errorDisplayGuard,
 				displayValidationStatus([
 					{
 						type: 'warning',

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/Town.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/Town.tsx
@@ -6,7 +6,9 @@ import { displayValidationStatus } from '../../../../../utils/validations/displa
 import FormField from '../../../../../components/Form_New/FormField';
 import { Enrollment } from '../../../../../generated';
 
-export const Town: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
+export const Town: React.FC<FamilyInfoFormFieldProps> = ({
+	errorDisplayGuard = false
+}) => (
 	<FormField<Enrollment, TextInputProps, string | null>
 		getValue={(data) => data.at('child').at('family').at('town')}
 		type="input"
@@ -16,7 +18,7 @@ export const Town: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
 		parseOnChangeEvent={(e) => e.target.value}
 		status={(enrollment) =>
 			initialLoadErrorGuard(
-				initialLoad || false,
+				errorDisplayGuard,
 				displayValidationStatus([
 					{
 						type: 'warning',

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/Zip.tsx
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/Zip.tsx
@@ -6,7 +6,9 @@ import { displayValidationStatus } from '../../../../../utils/validations/displa
 import FormField from '../../../../../components/Form_New/FormField';
 import { Enrollment } from '../../../../../generated';
 
-export const Zip: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
+export const Zip: React.FC<FamilyInfoFormFieldProps> = ({
+	errorDisplayGuard = false
+}) => (
 	<FormField<Enrollment, TextInputProps, string | null>
 		getValue={(data) => data.at('child').at('family').at('zip')}
 		type="input"
@@ -16,7 +18,7 @@ export const Zip: React.FC<FamilyInfoFormFieldProps> = ({ initialLoad }) => (
 		parseOnChangeEvent={(e) => e.target.value}
 		status={(enrollment) =>
 			initialLoadErrorGuard(
-				initialLoad || false,
+				errorDisplayGuard,
 				displayValidationStatus([
 					{
 						type: 'warning',

--- a/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/common.ts
+++ b/src/Hedwig/ClientApp/src/containers/Enrollment/_sections/FamilyInfo/Fields/common.ts
@@ -3,7 +3,7 @@ import { ValidationResponse } from '../../../../../utils/validations/displayVali
 
 // Copied from child info-- probably can be consolidated?
 export type FamilyInfoFormFieldProps = {
-	initialLoad?: boolean;
+	errorDisplayGuard?: boolean;
 	error?: ValidationResponse | null;
 	errorAlertState?: ErrorAlertState;
 };

--- a/src/Hedwig/ClientApp/src/hooks/useApi/query.ts
+++ b/src/Hedwig/ClientApp/src/hooks/useApi/query.ts
@@ -90,7 +90,6 @@ export default function useApi<TData>(
 						if (noMoreResult) {
 							// Need to use function syntax for state updates so pending updates aren't overwritten
 							setState((s) => ({ ...s, loading: false }));
-							return;
 						}
 
 						// Need to use function syntax for state updates so pending updates aren't overwritten

--- a/src/Hedwig/ClientApp/src/routes.ts
+++ b/src/Hedwig/ClientApp/src/routes.ts
@@ -12,6 +12,7 @@ import ReportsSummary from './containers/Reports/ReportsSummary/ReportsSummary';
 import ReportDetail from './containers/Reports/ReportDetail/ReportDetail';
 import Withdrawal from './containers/Withdrawal/Withdrawal';
 import Home from './containers/Home/Home';
+import BatchEdit from './containers/BatchEdit/BatchEdit';
 
 export type RouteConfig = {
 	path: string;
@@ -59,6 +60,10 @@ export const routes: RouteConfig[] = [
 	{
 		path: '/roster/sites/:siteId/enrollments/:enrollmentId/withdraw',
 		component: Withdrawal,
+	},
+	{
+		path: '/batch-edit/:activeEnrollmentId?',
+		component: BatchEdit,
 	},
 	{
 		path: '/reports',

--- a/src/Hedwig/Models/Child/EnrollmentSummaryChildDTO.cs
+++ b/src/Hedwig/Models/Child/EnrollmentSummaryChildDTO.cs
@@ -12,6 +12,7 @@ namespace Hedwig.Models
 		public string MiddleName { get; set; }
 		public string LastName { get; set; }
 		public string Suffix { get; set; }
+		public int OrganizationId { get; set; }
 		public DateTime? Birthdate { get; set; }
 		public List<C4KCertificateDTO> C4KCertificates { get; set; }
 		public List<ValidationError> ValidationErrors { get; set; }


### PR DESCRIPTION
addresses #947
 Does not finish batch-edit, but b/c it is not navigate-able without manually typing in a url path, i think we should merge.

then we can parallelize on some of the work:
- styling the step-list to have a different version that can be embedded into other content (i started on this, it's prob WHACK as it involves multiple `!important`s ....)
- adding logic to extract & format the list of missing fields for side nav item description
- adding the final Enrollment/Funding batch edit form
- adding the content for when all enrollments have been updated (green check with link back to roster)
- updating roster legend to match specs & navigate to the batch-edit view
- add tests! 