### PR TITLE
Match updated secrets location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           name: Download and Parse AWS Secrets
           command: |
             cd src/Hedwig
-            aws secretsmanager get-secret-value --secret-id /ece/<< parameters.env >>/hedwig > secrets.json
+            aws secretsmanager get-secret-value --secret-id /ece/<< parameters.env >>/hedwig/admin > secrets.json
             jq '.SecretString | fromjson' secrets.json > tmp.json && mv tmp.json secrets.json
             jq '.ConnectionStrings={ HEDWIG: ."ConnectionStrings.HEDWIG" }' secrets.json > tmp.json && mv tmp.json secrets.json
             jq 'del(.["ConnectionStrings.HEDWIG"])' secrets.json > tmp.json && mv tmp.json secrets.json


### PR DESCRIPTION
PR to update the path where Hedwig secrets are stored in CircleCI, so that deploys can continue without issue.  Said path was unfortunately necessarily updated in https://github.com/skylight-hq/ctoec-devops/pull/96.