### PR TITLE
Remove default EC2 security group deletion hack

### DIFF
--- a/src/Hedwig/.ebextensions/https-instance.config
+++ b/src/Hedwig/.ebextensions/https-instance.config
@@ -1,7 +1,4 @@
 Resources:
-  # Forcibly remove the default Elastic Beanstalk EC2 security group
-  # https://github.com/aws/elastic-beanstalk-roadmap/issues/44 
-  AWSEBSecurityGroup: { "CmpFn::Remove" : {} }
   AWSEBAutoScalingGroup:
     Metadata:
       AWS::CloudFormation::Authentication:


### PR DESCRIPTION
This hack has since been [moved to Terraform](https://github.com/skylight-hq/ctoec-devops/pull/150), so at least it lives in one place and not three.

---------------------------------------------------------------------------------------------------------------------------

### Associated PRs
- https://github.com/skylight-hq/ctoec-devops/pull/150
- https://github.com/ctoec/winged-keys/pull/63
- https://github.com/ctoec/data-collection/pull/755